### PR TITLE
Refatora páginas de gerenciamento

### DIFF
--- a/src/static/corpo-docente.html
+++ b/src/static/corpo-docente.html
@@ -103,9 +103,9 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="d-flex justify-content-between align-items-center mb-4">
-                    <h1>Gestão de Corpo Docente</h1>
+                    <h2 class="mb-0">Gestão de Corpo Docente</h2>
                     <button id="btnAdicionarNovo" class="btn btn-primary">
-                        <i class="bi bi-plus-circle me-2"></i>NOVO INSTRUTOR
+                        <i class="bi bi-plus-circle me-2"></i>ADICIONAR INSTRUTOR
                     </button>
                 </div>
 
@@ -114,12 +114,28 @@
                         <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
                     </div>
                     <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-4">
+                                <label for="filtroInstrutor" class="form-label">Buscar</label>
+                                <input type="text" class="form-control" id="filtroInstrutor" placeholder="Nome do instrutor...">
+                            </div>
+                        </div>
+                        <div class="row mt-3">
+                            <div class="col-12">
+                                <button type="button" class="btn btn-primary me-2" onclick="aplicarFiltros()">
+                                    <i class="bi bi-search me-1"></i>Filtrar
+                                </button>
+                                <button type="button" class="btn btn-outline-secondary" onclick="limparFiltros()">
+                                    <i class="bi bi-x-circle me-1"></i>Limpar
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
-                <div class="card">
+                <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0">Lista de Instrutores</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE INSTRUTORES</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">

--- a/src/static/gerenciar-turmas.html
+++ b/src/static/gerenciar-turmas.html
@@ -111,17 +111,41 @@
             
             <main class="col-lg-9 col-md-12">
                 <div class="d-flex justify-content-between align-items-center mb-4">
-                    <h1 class="mb-0">Gerenciar Turmas</h1>
+                    <h2 class="mb-0">Gerenciar Turmas</h2>
                     <button class="btn btn-primary" onclick="novaTurma()">
-                        <i class="bi bi-plus-circle me-2"></i>Adicionar Turma
+                        <i class="bi bi-plus-circle me-2"></i>ADICIONAR TURMA
                     </button>
+                </div>
+
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-4">
+                                <label for="filtroBusca" class="form-label">Buscar</label>
+                                <input type="text" class="form-control" id="filtroBusca" placeholder="Nome da turma...">
+                            </div>
+                        </div>
+                        <div class="row mt-3">
+                            <div class="col-12">
+                                <button type="button" class="btn btn-primary me-2" onclick="aplicarFiltros()">
+                                    <i class="bi bi-search me-1"></i>Filtrar
+                                </button>
+                                <button type="button" class="btn btn-outline-secondary" onclick="limparFiltros()">
+                                    <i class="bi bi-x-circle me-1"></i>Limpar
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 <div id="alertContainer"></div>
 
-                <div class="card">
+                <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0">Lista de Turmas</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE TURMAS</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">

--- a/src/static/laboratorios-turmas.html
+++ b/src/static/laboratorios-turmas.html
@@ -87,35 +87,49 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4">Gerenciamento de Laboratórios e Turmas</h2>
-                
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h2 class="mb-0">Gerenciamento de Laboratórios e Turmas</h2>
+                    <div>
+                        <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#laboratorioModal">
+                            <i class="bi bi-plus-circle me-2"></i>ADICIONAR LABORATÓRIO
+                        </button>
+                        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#turmaModal">
+                            <i class="bi bi-plus-circle me-2"></i>ADICIONAR TURMA
+                        </button>
+                    </div>
+                </div>
+
                 <div id="alertContainer"></div>
-                
+
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0">Cadastro de Laboratórios</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
                     </div>
                     <div class="card-body">
-                        <form id="laboratorioForm" class="row g-3 mb-4">
-                            <div class="col-md-8">
-                                <input type="hidden" id="laboratorioId">
-                                <label for="nomeLaboratorio" class="form-label">Nome do Laboratório</label>
-                                <input type="text" class="form-control" id="nomeLaboratorio" placeholder="Ex: Lab 01" required>
+                        <div class="row">
+                            <div class="col-md-4">
+                                <label for="filtroBusca" class="form-label">Buscar</label>
+                                <input type="text" class="form-control" id="filtroBusca" placeholder="Nome...">
                             </div>
-                            <div class="col-md-5">
-                                <label for="classeIconeLaboratorio" class="form-label">Classe do Ícone</label>
-                                <input type="text" class="form-control" id="classeIconeLaboratorio" placeholder="Ex: bi-robot">
-                                <small class="form-text text-muted">
-                                    Cole a classe do <a href="https://icons.getbootstrap.com/" target="_blank">Bootstrap Icons</a> aqui.
-                                </small>
-                            </div>
-                            <div class="col-md-4 d-flex align-items-end">
-                                <button type="submit" class="btn btn-primary w-100" id="btnSalvarLaboratorio">
-                                    <i class="bi bi-plus-circle me-2"></i>Adicionar
+                        </div>
+                        <div class="row mt-3">
+                            <div class="col-12">
+                                <button type="button" class="btn btn-primary me-2" onclick="aplicarFiltros()">
+                                    <i class="bi bi-search me-1"></i>Filtrar
+                                </button>
+                                <button type="button" class="btn btn-outline-secondary" onclick="limparFiltros()">
+                                    <i class="bi bi-x-circle me-1"></i>Limpar
                                 </button>
                             </div>
-                        </form>
-                        
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE LABORATÓRIOS</h5>
+                    </div>
+                    <div class="card-body">
                         <div class="table-responsive">
                             <table class="table table-striped table-hover">
                                 <thead>
@@ -139,25 +153,12 @@
                         </div>
                     </div>
                 </div>
-                
-                <div class="card">
+
+                <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0">Cadastro de Turmas</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE TURMAS</h5>
                     </div>
                     <div class="card-body">
-                        <form id="turmaForm" class="row g-3 mb-4">
-                            <div class="col-md-8">
-                                <input type="hidden" id="turmaId">
-                                <label for="nomeTurma" class="form-label">Nome da Turma</label>
-                                <input type="text" class="form-control" id="nomeTurma" placeholder="Ex: Informática 3º Ano" required>
-                            </div>
-                            <div class="col-md-4 d-flex align-items-end">
-                                <button type="submit" class="btn btn-primary w-100" id="btnSalvarTurma">
-                                    <i class="bi bi-plus-circle me-2"></i>Adicionar
-                                </button>
-                            </div>
-                        </form>
-                        
                         <div class="table-responsive">
                             <table class="table table-striped table-hover">
                                 <thead>
@@ -211,6 +212,67 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                     <button type="button" class="btn btn-danger" id="btnConfirmarExclusao">Excluir</button>
+                </div>
+            </div>
+</div>
+</div>
+
+    <div class="modal fade" id="laboratorioModal" tabindex="-1" aria-labelledby="laboratorioModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="laboratorioModalLabel">Novo Laboratório</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="laboratorioForm" class="row g-3">
+                        <input type="hidden" id="laboratorioId">
+                        <div class="col-12">
+                            <label for="nomeLaboratorio" class="form-label">Nome do Laboratório</label>
+                            <input type="text" class="form-control" id="nomeLaboratorio" required>
+                        </div>
+                        <div class="col-12">
+                            <label for="classeIconeLaboratorio" class="form-label">Classe do Ícone</label>
+                            <input type="text" class="form-control" id="classeIconeLaboratorio">
+                            <small class="form-text text-muted">
+                                Cole a classe do <a href="https://icons.getbootstrap.com/" target="_blank">Bootstrap Icons</a> aqui.
+                            </small>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" form="laboratorioForm" class="btn btn-primary" id="btnSalvarLaboratorio">
+                        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                        <span class="btn-text"><i class="bi bi-plus-circle me-2"></i>Adicionar</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="turmaModal" tabindex="-1" aria-labelledby="turmaModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="turmaModalLabel">Nova Turma</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="turmaForm" class="row g-3">
+                        <input type="hidden" id="turmaId">
+                        <div class="col-12">
+                            <label for="nomeTurma" class="form-label">Nome da Turma</label>
+                            <input type="text" class="form-control" id="nomeTurma" required>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" form="turmaForm" class="btn btn-primary" id="btnSalvarTurma">
+                        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                        <span class="btn-text"><i class="bi bi-plus-circle me-2"></i>Adicionar</span>
+                    </button>
                 </div>
             </div>
         </div>

--- a/src/static/usuarios.html
+++ b/src/static/usuarios.html
@@ -70,16 +70,40 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4 text-center">Gerenciamento de Usuários</h2>
-                
-                <div id="alertContainer"></div>
-                
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h2 class="mb-0">Gerenciamento de Usuários</h2>
+                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#usuarioModal">
+                        <i class="bi bi-person-plus me-2"></i>ADICIONAR USUÁRIO
+                    </button>
+                </div>
+
                 <div class="card mb-4">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="card-title mb-0">Lista de Usuários</h5>
-                        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#usuarioModal">
-                            <i class="bi bi-person-plus me-2"></i>Novo Usuário
-                        </button>
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-4">
+                                <label for="filtroUsuario" class="form-label">Buscar</label>
+                                <input type="text" class="form-control" id="filtroUsuario" placeholder="Nome ou email...">
+                            </div>
+                        </div>
+                        <div class="row mt-3">
+                            <div class="col-12">
+                                <button type="button" class="btn btn-primary me-2" onclick="aplicarFiltros()">
+                                    <i class="bi bi-search me-1"></i>Filtrar
+                                </button>
+                                <button type="button" class="btn btn-outline-secondary" onclick="limparFiltros()">
+                                    <i class="bi bi-x-circle me-1"></i>Limpar
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE USUÁRIOS</h5>
                     </div>
                     <div class="card-body">
                         <div class="table-responsive">


### PR DESCRIPTION
## Summary
- padroniza cabeçalhos e botões de ação
- adiciona cards de filtro e de listas
- move formulários de cadastro para modais

## Testing
- `pytest -q` *(fails: test_atualizar_ocupacao_turno_invalido, test_atualizar_senha_requer_verificacao)*

------
https://chatgpt.com/codex/tasks/task_e_686d685320f883238e03d51e80100112