### PR TITLE
Improve header layout and add filters

### DIFF
--- a/src/static/corpo-docente.html
+++ b/src/static/corpo-docente.html
@@ -102,7 +102,7 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <div class="d-flex justify-content-between align-items-center mb-4">
+                <div class="page-header">
                     <h2 class="mb-0">Gestão de Corpo Docente</h2>
                     <button id="btnAdicionarNovo" class="btn btn-primary">
                         <i class="bi bi-plus-circle me-2"></i>NOVO INSTRUTOR
@@ -114,6 +114,28 @@
                         <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
                     </div>
                     <div class="card-body">
+                        <div class="row g-3 align-items-end">
+                            <div class="col-md-4">
+                                <label for="filtroNome" class="form-label">Nome</label>
+                                <input type="text" class="form-control" id="filtroNome" placeholder="Nome do instrutor">
+                            </div>
+                            <div class="col-md-3">
+                                <label for="filtroStatus" class="form-label">Status</label>
+                                <select id="filtroStatus" class="form-select">
+                                    <option value="">Todos</option>
+                                    <option value="ativo">Ativo</option>
+                                    <option value="inativo">Inativo</option>
+                                </select>
+                            </div>
+                            <div class="col-md-5 text-end">
+                                <button id="btnAplicarFiltros" type="button" class="btn btn-primary me-2">
+                                    <i class="bi bi-search me-1"></i>Filtrar
+                                </button>
+                                <button id="btnLimparFiltros" type="button" class="btn btn-outline-secondary">
+                                    <i class="bi bi-x-circle me-1"></i>Limpar
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -33,6 +33,17 @@ body {
   flex: 1;
 }
 
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #dee2e6;
+}
+
 .card, .btn, .badge, .form-control, .form-select, .modal-content, .input-group-text {
   border-radius: 4px;
 }
@@ -103,6 +114,7 @@ small, .small {
   border-right: 1px solid #dee2e6;
   padding: 20px;
   height: 100%;
+  min-width: 230px;
 }
 
 .sidebar .nav-link {

--- a/src/static/gerenciar-salas.html
+++ b/src/static/gerenciar-salas.html
@@ -102,7 +102,7 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <div class="d-flex justify-content-between align-items-center mb-4">
+                <div class="page-header">
                     <h2 class="mb-0">Gerenciar Salas</h2>
                     <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalSala" onclick="novaSala()">
                         <i class="bi bi-plus-circle me-2"></i>Adicionar

--- a/src/static/gerenciar-turmas.html
+++ b/src/static/gerenciar-turmas.html
@@ -110,7 +110,7 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <div class="d-flex justify-content-between align-items-center mb-4">
+                <div class="page-header">
                     <h2 class="mb-0">Gerenciar Turmas</h2>
                     <button class="btn btn-primary" onclick="novaTurma()">
                         <i class="bi bi-plus-circle me-2"></i>ADICIONAR TURMA

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -87,7 +87,7 @@
             </div>
             
             <main class="col-lg-9">
-                <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                <div class="page-header">
                     <h1 class="h2">Dashboard - Agenda de Laboratórios</h1>
                     <div class="btn-toolbar mb-2 mb-md-0">
                         <a href="/novo-agendamento.html" class="btn btn-primary">

--- a/src/static/js/corpo-docente.js
+++ b/src/static/js/corpo-docente.js
@@ -6,6 +6,10 @@ class GerenciadorInstrutores {
 
         this.tabelaBody = document.getElementById('tabelaCorpoDocente');
         this.btnAdicionar = document.getElementById('btnAdicionarNovo');
+        this.btnAplicarFiltros = document.getElementById('btnAplicarFiltros');
+        this.btnLimparFiltros = document.getElementById('btnLimparFiltros');
+        this.filtroNome = document.getElementById('filtroNome');
+        this.filtroStatus = document.getElementById('filtroStatus');
         this.modalInstrutor = new bootstrap.Modal(document.getElementById('modalInstrutor'));
         this.modalExcluir = new bootstrap.Modal(document.getElementById('modalExcluirInstrutor'));
         this.form = document.getElementById('formInstrutor');
@@ -18,6 +22,12 @@ class GerenciadorInstrutores {
 
     registrarEventos() {
         this.btnAdicionar.addEventListener('click', () => this.novoInstrutor());
+        if (this.btnAplicarFiltros) {
+            this.btnAplicarFiltros.addEventListener('click', () => this.aplicarFiltros());
+        }
+        if (this.btnLimparFiltros) {
+            this.btnLimparFiltros.addEventListener('click', () => this.limparFiltros());
+        }
         this.form.addEventListener('submit', (e) => {
             e.preventDefault();
             this.salvarInstrutor();
@@ -67,9 +77,9 @@ class GerenciadorInstrutores {
         `;
     }
 
-    renderizarTabela() {
+    renderizarTabela(lista = this.instrutores) {
         this.tabelaBody.innerHTML = '';
-        this.instrutores.forEach(inst => {
+        lista.forEach(inst => {
             const row = document.createElement('tr');
             row.dataset.id = inst.id;
             row.innerHTML = `
@@ -93,6 +103,23 @@ class GerenciadorInstrutores {
         } catch (err) {
             exibirAlerta('Erro ao carregar instrutores', 'danger');
         }
+    }
+
+    aplicarFiltros() {
+        const termo = (this.filtroNome.value || '').toLowerCase();
+        const status = this.filtroStatus.value;
+        const filtrados = this.instrutores.filter(i => {
+            const matchNome = i.nome.toLowerCase().includes(termo);
+            const matchStatus = !status || i.status === status;
+            return matchNome && matchStatus;
+        });
+        this.renderizarTabela(filtrados);
+    }
+
+    limparFiltros() {
+        if (this.filtroNome) this.filtroNome.value = '';
+        if (this.filtroStatus) this.filtroStatus.value = '';
+        this.renderizarTabela();
     }
 
     novoInstrutor() {


### PR DESCRIPTION
## Summary
- add `.page-header` style and sidebar width
- update dashboards to use the new header style
- add filter form for corpo docente page
- enable filtering in corpo-docente.js

## Testing
- `pytest -q` *(fails: test_atualizar_ocupacao_turno_invalido, test_atualizar_senha_requer_verificacao)*

------
https://chatgpt.com/codex/tasks/task_e_686d9a1e6ff08323a37d6f72bae3f6ed