### PR TITLE
Add .gitignore with standard Python patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.py[cod]
+*.egg
+*.egg-info/
+
+# Virtual environment directories
+.venv/
+venv/
+env/
+
+# Environment and configuration files
+.env
+.env.*
+
+# OS/editor artifacts
+.DS_Store
+*.swp


### PR DESCRIPTION
## Summary
- add `.gitignore` covering caches, virtualenvs, environment files and OS/editor artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_686dcb10919883238251148bc70873c0