### PR TITLE
Fix schedule availability logic and edit prefill

### DIFF
--- a/src/routes/agendamento.py
+++ b/src/routes/agendamento.py
@@ -481,12 +481,18 @@ def agenda_diaria_laboratorios():
 
         horarios_ocupados = set()
         for ag in agendamentos_do_turno:
-            try:
-                horarios_agendados = json.loads(ag.horarios)
-                for h in horarios_agendados:
-                    horarios_ocupados.add(h)
-            except (json.JSONDecodeError, TypeError):
+            horarios_agendados = ag.horarios
+            if isinstance(horarios_agendados, str):
+                try:
+                    horarios_agendados = json.loads(horarios_agendados)
+                except json.JSONDecodeError:
+                    horarios_agendados = []
+
+            if not isinstance(horarios_agendados, list):
                 continue
+
+            for h in horarios_agendados:
+                horarios_ocupados.add(h)
 
         horarios_disponiveis = [h for h in horarios_possiveis if h not in horarios_ocupados]
 

--- a/src/static/novo-agendamento.html
+++ b/src/static/novo-agendamento.html
@@ -523,7 +523,7 @@
                     document.getElementById('data').value = agendamento.data.split('T')[0];
                     
                     // Aguarda o carregamento dos laboratórios e turmas antes de selecionar
-                    setTimeout(() => {
+                    setTimeout(async () => {
                         const labSelect = document.getElementById('laboratorio');
                         const optionLab = Array.from(labSelect.options).find(o => o.textContent === agendamento.laboratorio);
                         if (optionLab) {
@@ -531,28 +531,24 @@
                         }
                         document.getElementById('turma').value = agendamento.turma;
                         document.getElementById('turno').value = agendamento.turno;
-                        
+
                         // Verifica horários disponíveis e renderiza os horários do turno
-                        verificarHorariosDisponiveis();
-                        
+                        await verificarHorariosDisponiveis();
+
                         // Marca os horários selecionados
                         const horariosSelecionados = JSON.parse(agendamento.horarios);
-                        setTimeout(() => {
-                            document.querySelectorAll('input[name="horarios"]').forEach(checkbox => {
-                                if (horariosSelecionados.includes(checkbox.value)) {
-                                    checkbox.checked = true;
-                                }
-                            });
-                        }, 500);
-                        
+                        document.querySelectorAll('input[name="horarios"]').forEach(checkbox => {
+                            if (horariosSelecionados.includes(checkbox.value)) {
+                                checkbox.checked = true;
+                            }
+                        });
+
                         // Se for administrador, seleciona o usuário responsável
                         if (isAdmin() && agendamento.usuario_id) {
-                            setTimeout(() => {
-                                const selectUsuario = document.getElementById('usuario_id');
-                                if (selectUsuario) {
-                                    selectUsuario.value = agendamento.usuario_id;
-                                }
-                            }, 500);
+                            const selectUsuario = document.getElementById('usuario_id');
+                            if (selectUsuario) {
+                                selectUsuario.value = agendamento.usuario_id;
+                            }
                         }
                     }, 500);
                 } catch (error) {


### PR DESCRIPTION
## Summary
- handle JSON lists when parsing booked slots
- await schedule availability when editing reservations so previously booked slots are selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee36cb1a48323946462cff66457bd