### PR TITLE
Fix available hours display in schedule

### DIFF
--- a/src/static/novo-agendamento.html
+++ b/src/static/novo-agendamento.html
@@ -182,6 +182,7 @@
             let modoEdicao = false;
             let agendamentoId = null;
             let horariosOcupados = [];
+            let horariosAgendamentoAtual = [];
             
             // Horários disponíveis por turno
             const horariosPorTurno = {
@@ -397,31 +398,12 @@
                 }
 
                 try {
-                    // Busca os agendamentos existentes para o laboratório, data e turno selecionados
-                    const agendamentosExistentes = await chamarAPI(`/agendamentos/verificar-disponibilidade?data=${data}&laboratorio=${encodeURIComponent(laboratorio)}&turno=${encodeURIComponent(turno)}`);
-                    
-                    // Extrai os horários já ocupados
-                    horariosOcupados = [];
-                    agendamentosExistentes.forEach(agendamento => {
-                        try {
-                            const horarios = JSON.parse(agendamento.horarios);
-                            horariosOcupados = [...horariosOcupados, ...horarios];
-                        } catch (e) {
-                            console.error('Erro ao processar horários:', e);
-                        }
-                    });
-                    
-                    // Se estiver em modo de edição, não considera os horários do próprio agendamento como ocupados
-                    if (modoEdicao && agendamentoId) {
-                        const agendamentoAtual = agendamentosExistentes.find(a => a.id === parseInt(agendamentoId));
-                        if (agendamentoAtual) {
-                            try {
-                                const horariosAtuais = JSON.parse(agendamentoAtual.horarios);
-                                horariosOcupados = horariosOcupados.filter(h => !horariosAtuais.includes(h));
-                            } catch (e) {
-                                console.error('Erro ao processar horários do agendamento atual:', e);
-                            }
-                        }
+                    const resultado = await chamarAPI(`/agendamentos/verificar-disponibilidade?data=${data}&laboratorio=${encodeURIComponent(laboratorio)}&turno=${encodeURIComponent(turno)}`);
+
+                    horariosOcupados = Array.isArray(resultado.horarios_reservados) ? resultado.horarios_reservados : [];
+
+                    if (modoEdicao && horariosAgendamentoAtual.length > 0) {
+                        horariosOcupados = horariosOcupados.filter(h => !horariosAgendamentoAtual.includes(h));
                     }
                     
                     // Renderiza os horários disponíveis
@@ -532,13 +514,15 @@
                         document.getElementById('turma').value = agendamento.turma;
                         document.getElementById('turno').value = agendamento.turno;
 
+                        // Guarda horários atuais para que não sejam considerados ocupados
+                        horariosAgendamentoAtual = Array.isArray(agendamento.horarios) ? agendamento.horarios : JSON.parse(agendamento.horarios || '[]');
+
                         // Verifica horários disponíveis e renderiza os horários do turno
                         await verificarHorariosDisponiveis();
 
                         // Marca os horários selecionados
-                        const horariosSelecionados = JSON.parse(agendamento.horarios);
                         document.querySelectorAll('input[name="horarios"]').forEach(checkbox => {
-                            if (horariosSelecionados.includes(checkbox.value)) {
+                            if (horariosAgendamentoAtual.includes(checkbox.value)) {
                                 checkbox.checked = true;
                             }
                         });

--- a/tests/test_agendamento_routes.py
+++ b/tests/test_agendamento_routes.py
@@ -75,8 +75,10 @@ def test_verificar_disponibilidade_e_conflitos(client, login_admin):
         'turno': 'Manhã'
     }, headers=headers)
     assert resp_check.status_code == 200
-    resultados = resp_check.get_json()
-    assert any(a['id'] == ag_id for a in resultados)
+    dados = resp_check.get_json()
+    assert 'horarios_reservados' in dados
+    assert 'laboratorio_id' in dados
+    assert '08:00' in dados['horarios_reservados']
 
     # Consulta disponibilidade em data diferente (deve estar livre)
     resp_livre = client.get('/api/agendamentos/verificar-disponibilidade', query_string={
@@ -85,7 +87,8 @@ def test_verificar_disponibilidade_e_conflitos(client, login_admin):
         'turno': 'Manhã'
     }, headers=headers)
     assert resp_livre.status_code == 200
-    assert resp_livre.get_json() == []
+    dados_livres = resp_livre.get_json()
+    assert dados_livres['horarios_reservados'] == []
 
     # Tenta criar agendamento parcialmente sobreposto
     resp_conf = client.post('/api/agendamentos', json={


### PR DESCRIPTION
## Summary
- ensure `/agendamentos/verificar-disponibilidade` aggregates reserved hours
- adjust frontend to handle reserved hours array and mark checkboxes on edit
- update tests for new API format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ee5fc7800832396fc20e9d0185b66