### PR TITLE
Fix topbar layout and remove username field

### DIFF
--- a/src/static/calendario-salas.html
+++ b/src/static/calendario-salas.html
@@ -16,7 +16,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Controle de Ocupação</span>
+                <span class="navbar-brand-text" title="Controle de Ocupação">Controle de Ocupação</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/calendario.html
+++ b/src/static/calendario.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Agenda de Laboratórios</span>
+                <span class="navbar-brand-text" title="Agenda de Laboratórios">Agenda de Laboratórios</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/corpo-docente.html
+++ b/src/static/corpo-docente.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Controle de Ocupação</span>
+                <span class="navbar-brand-text" title="Controle de Ocupação">Controle de Ocupação</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -82,30 +82,27 @@ small, .small {
   color: #ffffff;
 }
 
+.navbar-brand {
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  min-width: 0;
+}
+
 .navbar-brand img {
   height: 30px;
   margin-right: 10px;
 }
 
-/* Garante que nomes de sistema longos não ultrapassem a barra lateral */
 .navbar-brand-text {
-  display: inline-block;
-  max-width: 220px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-@media (max-width: 991.98px) {
+@media (max-width: 600px) {
   .navbar-brand-text {
-    max-width: 180px;
-  }
-}
-
-@media (max-width: 767.98px) {
-  .navbar-brand-text {
-    max-width: 140px;
-    font-size: 0.9rem;
+    display: none;
   }
 }
 

--- a/src/static/dashboard-salas.html
+++ b/src/static/dashboard-salas.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Controle de Ocupação</span>
+                <span class="navbar-brand-text" title="Controle de Ocupação">Controle de Ocupação</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/gerenciar-salas.html
+++ b/src/static/gerenciar-salas.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Controle de Ocupação</span>
+                <span class="navbar-brand-text" title="Controle de Ocupação">Controle de Ocupação</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/gerenciar-turmas.html
+++ b/src/static/gerenciar-turmas.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Controle de Ocupação</span>
+                <span class="navbar-brand-text" title="Controle de Ocupação">Controle de Ocupação</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Agenda de Laboratórios</span>
+                <span class="navbar-brand-text" title="Agenda de Laboratórios">Agenda de Laboratórios</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/laboratorios-turmas.html
+++ b/src/static/laboratorios-turmas.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Agenda de Laboratórios</span>
+                <span class="navbar-brand-text" title="Agenda de Laboratórios">Agenda de Laboratórios</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/novo-agendamento-sala.html
+++ b/src/static/novo-agendamento-sala.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Controle de Ocupação</span>
+                <span class="navbar-brand-text" title="Controle de Ocupação">Controle de Ocupação</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/novo-agendamento.html
+++ b/src/static/novo-agendamento.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Agenda de Laboratórios</span>
+                <span class="navbar-brand-text" title="Agenda de Laboratórios">Agenda de Laboratórios</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/perfil-salas.html
+++ b/src/static/perfil-salas.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Controle de Ocupação</span>
+                <span class="navbar-brand-text" title="Controle de Ocupação">Controle de Ocupação</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/perfil-usuarios.html
+++ b/src/static/perfil-usuarios.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Gerenciamento de Usuarios</span>
+                <span class="navbar-brand-text" title="Gerenciamento de Usuarios">Gerenciamento de Usuarios</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/perfil.html
+++ b/src/static/perfil.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Agenda de Laboratórios</span>
+                <span class="navbar-brand-text" title="Agenda de Laboratórios">Agenda de Laboratórios</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="#">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Seleção de Sistema</span>
+                <span class="navbar-brand-text" title="Seleção de Sistema">Seleção de Sistema</span>
             </a>
             <div class="ms-auto">
                 <ul class="navbar-nav">

--- a/src/static/usuarios.html
+++ b/src/static/usuarios.html
@@ -15,7 +15,7 @@
         <div class="container-fluid">
             <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
                 <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
-                <span class="navbar-brand-text">Gerenciamento de Usuários</span>
+                <span class="navbar-brand-text" title="Gerenciamento de Usuários">Gerenciamento de Usuários</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -153,10 +153,6 @@
                             <input type="email" class="form-control" id="email" name="email" required>
                         </div>
                         
-                        <div class="mb-3">
-                            <label for="username" class="form-label">Nome de Usuário</label>
-                            <input type="text" class="form-control" id="username" name="username" required>
-                        </div>
                         
                         <div class="mb-3">
                             <label for="senha" class="form-label">Senha</label>
@@ -282,21 +278,19 @@
                 const usuarioId = document.getElementById('usuarioId').value;
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
-                const username = document.getElementById('username').value;
                 const senha = document.getElementById('senha').value;
                 const tipo = document.getElementById('tipo').value;
-                
+
                 // Validação básica
-                if (!nome || !email || !username || (!usuarioId && !senha)) {
+                if (!nome || !email || (!usuarioId && !senha)) {
                     exibirAlerta('Preencha todos os campos obrigatórios', 'warning');
                     return;
                 }
-                
+
                 try {
                     const dadosUsuario = {
                         nome,
                         email,
-                        username,
                         tipo
                     };
                     
@@ -336,7 +330,6 @@
                     document.getElementById('usuarioId').value = usuario.id;
                     document.getElementById('nome').value = usuario.nome;
                     document.getElementById('email').value = usuario.email;
-                    document.getElementById('username').value = usuario.username;
                     document.getElementById('senha').value = '';
                     document.getElementById('tipo').value = usuario.tipo;
                     


### PR DESCRIPTION
## Summary
- make page title spans show full text and add `title` attribute
- remove username field from user form and its JS logic
- update navbar CSS for flexible layout

## Testing
- `pytest -q` *(fails: email-validator not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eeb0daec883238a4d2fc0b7bd28ba