### PR TITLE
Fix admin demotion permissions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@ import sys
 from datetime import datetime, timedelta
 import jwt
 
+os.environ['ADMIN_EMAIL'] = 'admin@example.com'
+os.environ['ADMIN_USERNAME'] = 'admin'
+
 import pytest
 from flask import Flask
 


### PR DESCRIPTION
## Summary
- restrict changing an admin to common unless requestor is the root admin
- expose root admin identity in tests
- test demotion rules

## Testing
- `pytest tests/test_user_routes.py::test_non_root_admin_cannot_downgrade_admin -q`
- `pytest tests/test_user_routes.py::test_root_admin_can_downgrade_admin -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eeeb61e70832393b7c3e2d43f5308