### PR TITLE
Switch auth to HttpOnly cookies

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -10,13 +10,16 @@ from src.models.user import User
 
 
 def verificar_autenticacao(req):
-    """Verifica o token JWT no cabeçalho Authorization."""
+    """Verifica o token JWT no cabeçalho Authorization ou cookie."""
     auth_header = req.headers.get('Authorization')
-    if not auth_header or not auth_header.startswith('Bearer '):
+    token = None
+    if auth_header and auth_header.startswith('Bearer '):
+        token = auth_header.split(' ')[1]
+    else:
+        token = req.cookies.get('access_token')
+    if not token:
         g.token_message = None
         return False, None
-
-    token = auth_header.split(' ')[1]
     try:
         dados = jwt.decode(token, current_app.config['SECRET_KEY'], algorithms=['HS256'])
         jti = dados.get('jti')

--- a/src/static/js/calendario-salas.js
+++ b/src/static/js/calendario-salas.js
@@ -87,7 +87,6 @@ async function carregarOcupacoes(dataInicio, dataFim) {
         
         const response = await fetch(`${API_URL}/ocupacoes/calendario?${params.toString()}`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -129,7 +128,6 @@ async function carregarResumoPeriodo(dataInicio, dataFim) {
 
         const response = await fetch(`${API_URL}/ocupacoes/resumo-periodo?${params.toString()}`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
 
@@ -300,7 +298,6 @@ async function carregarSalasParaFiltro() {
     try {
         const response = await fetch(`${API_URL}/salas?status=ativa`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -324,7 +321,6 @@ async function carregarInstrutoresParaFiltro() {
     try {
         const response = await fetch(`${API_URL}/instrutores?status=ativo`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -348,7 +344,6 @@ async function carregarTiposOcupacao() {
     try {
         const response = await fetch(`${API_URL}/ocupacoes/tipos`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -623,7 +618,6 @@ async function confirmarExclusaoOcupacao(modo) {
         const response = await fetch(url, {
             method: 'DELETE',
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         

--- a/src/static/js/dashboard-salas.js
+++ b/src/static/js/dashboard-salas.js
@@ -9,7 +9,6 @@ let relatorioMensal = {};
 async function carregarIndicadoresMensais() {
     try {
         const salasResp = await fetch(`${API_URL}/salas?status=ativa`, {
-            headers: { 'Authorization': `Bearer ${getToken()}` }
         });
         const salas = salasResp.ok ? await salasResp.json() : [];
         const totalSalas = salas.length;
@@ -22,7 +21,6 @@ async function carregarIndicadoresMensais() {
             const iniStr = inicio.toISOString().split('T')[0];
             const fimStr = fim.toISOString().split('T')[0];
             const resp = await fetch(`${API_URL}/ocupacoes?data_inicio=${iniStr}&data_fim=${fimStr}&status=confirmado`, {
-                headers: { 'Authorization': `Bearer ${getToken()}` }
             });
             const ocup = resp.ok ? await resp.json() : [];
             const salasOcupadas = new Set(ocup.map(o => o.sala_id)).size;
@@ -54,7 +52,6 @@ async function carregarEstatisticasGerais() {
         // Carrega total de salas ativas
         const responseSalas = await fetch(`${API_URL}/salas?status=ativa`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -66,7 +63,6 @@ async function carregarEstatisticasGerais() {
         // Carrega total de instrutores ativos
         const responseInstrutores = await fetch(`${API_URL}/instrutores?status=ativo`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -79,7 +75,6 @@ async function carregarEstatisticasGerais() {
         const hoje = new Date().toISOString().split('T')[0];
         const responseHoje = await fetch(`${API_URL}/ocupacoes?data_inicio=${hoje}&data_fim=${hoje}&status=confirmado`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -93,7 +88,6 @@ async function carregarEstatisticasGerais() {
         const fimSemana = getFimSemana();
         const responseSemana = await fetch(`${API_URL}/ocupacoes?data_inicio=${inicioSemana}&data_fim=${fimSemana}&status=confirmado`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -117,7 +111,6 @@ async function carregarProximasOcupacoes() {
         
         const response = await fetch(`${API_URL}/ocupacoes?data_inicio=${hoje}&data_fim=${fimPeriodo}&status=confirmado`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -207,7 +200,6 @@ async function carregarRelatorioMensal() {
         if (isAdmin()) {
             const response = await fetch(`${API_URL}/ocupacoes/relatorio?data_inicio=${dataInicio}&data_fim=${dataFim}`, {
                 headers: {
-                    'Authorization': `Bearer ${getToken()}`
                 }
             });
             
@@ -234,7 +226,6 @@ async function carregarDadosBasicos(dataInicio, dataFim) {
         // Carrega ocupações do usuário no período
         const response = await fetch(`${API_URL}/ocupacoes?data_inicio=${dataInicio}&data_fim=${dataFim}`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -486,7 +477,6 @@ async function carregarTendenciaMensal() {
     try {
         const ano = new Date().getFullYear();
         const response = await fetch(`${API_URL}/ocupacoes/tendencia?ano=${ano}`, {
-            headers: { 'Authorization': `Bearer ${getToken()}` }
         });
         if (response.ok) {
             const dados = await response.json();

--- a/src/static/js/nova-ocupacao.js
+++ b/src/static/js/nova-ocupacao.js
@@ -42,7 +42,6 @@ async function carregarTiposOcupacao() {
     try {
         const response = await fetch(`${API_URL}/ocupacoes/tipos`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -66,7 +65,6 @@ async function carregarSalas() {
     try {
         const response = await fetch(`${API_URL}/salas?status=ativa`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -90,7 +88,6 @@ async function carregarInstrutores() {
     try {
         const response = await fetch(`${API_URL}/instrutores?status=ativo`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -114,7 +111,6 @@ async function carregarTurmasSelect() {
     try {
         const response = await fetch(`${API_URL}/turmas`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         if (response.ok) {
@@ -168,7 +164,6 @@ async function carregarOcupacaoParaEdicao(id) {
     try {
         const response = await fetch(`${API_URL}/ocupacoes/${id}`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -241,7 +236,6 @@ async function verificarDisponibilidade() {
 
         const response = await fetch(`${API_URL}/ocupacoes/verificar-disponibilidade?${params.toString()}`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
 
@@ -301,7 +295,6 @@ async function salvarOcupacao() {
             method: method,
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${getToken()}`
             },
             body: JSON.stringify(formData)
         });

--- a/src/static/js/salas.js
+++ b/src/static/js/salas.js
@@ -35,7 +35,6 @@ class GerenciadorSalas {
         try {
             const response = await fetch(`${API_URL}/salas/recursos`, {
                 headers: {
-                    'Authorization': `Bearer ${getToken()}`
                 }
             });
         
@@ -82,7 +81,6 @@ class GerenciadorSalas {
         
         const response = await fetch(`${API_URL}/salas?${params.toString()}`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
 
@@ -214,7 +212,6 @@ class GerenciadorSalas {
     try {
         const response = await fetch(`${API_URL}/salas/${id}`, {
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         
@@ -294,7 +291,6 @@ class GerenciadorSalas {
             method: isEdicao ? 'PUT' : 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${getToken()}`
             },
             body: JSON.stringify(formData)
         });
@@ -362,7 +358,6 @@ class GerenciadorSalas {
         const response = await fetch(`${API_URL}/salas/${salaId}`, {
             method: 'DELETE',
             headers: {
-                'Authorization': `Bearer ${getToken()}`
             }
         });
         

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -23,6 +23,9 @@ def test_login(client):
     json_data = response.get_json()
     assert 'token' in json_data
     assert 'refresh_token' in json_data
+    cookies = response.headers.getlist('Set-Cookie')
+    assert any('access_token=' in c for c in cookies)
+    assert any('refresh_token=' in c for c in cookies)
 
 
 def test_listar_usuarios(client, login_admin):


### PR DESCRIPTION
## Summary
- support getting tokens from cookies
- set JWT tokens as HttpOnly cookies on login and refresh
- clear cookies on logout
- update frontend to rely on cookies instead of localStorage
- check cookies in login test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687024c71a1c8323be6e39183262ad24