### PR TITLE
Adiciona backend Redis para controle de acesso

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ Consulte o arquivo [CHANGELOG.md](CHANGELOG.md) para detalhes das versões.
    export SECRET_KEY="sua-chave-secreta"
    export ADMIN_EMAIL="seu-email-admin"
    export ADMIN_PASSWORD="senha-segura"
+   export REDIS_URL="redis://localhost:6379/0"
    ```
 
    A aplicação também reconhece a variável `FLASK_SECRET_KEY`. Uma das duas deve estar definida; se nenhuma estiver presente, a aplicação aborta a inicialização. Use um valor longo e aleatório (por exemplo, `export SECRET_KEY=$(openssl rand -hex 32)`).
 
    Se `DATABASE_URL` não for informado ou estiver vazio, o sistema utiliza por padrão um banco SQLite local (`agenda_laboratorio.db`).
+
+   Um servidor Redis precisa estar ativo no endereço definido em `REDIS_URL` para que a limitação de requisições e a revogação de tokens funcionem corretamente.
 
 3. Execute as migrações do banco para criar as tabelas necessárias:
 

--- a/src/limiter.py
+++ b/src/limiter.py
@@ -7,7 +7,7 @@ import os
 
 limiter = Limiter(
     get_remote_address,
-    storage_uri=os.environ.get("REDIS_URL", "memory://"),
+    storage_uri=os.environ.get("REDIS_URL", "redis://localhost:6379/0"),
     storage_options={"socket_connect_timeout": 30},
     strategy="fixed-window",
 )

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import logging
 from flask import Flask
 from flask_migrate import Migrate
 from src.limiter import limiter
+from src.redis_client import init_redis
 
 from src.models import db
 from src.routes.agendamento import agendamento_bp
@@ -84,6 +85,7 @@ def create_app():
 
     app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['REDIS_URL'] = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
 
     secret_key = os.getenv('SECRET_KEY') or os.getenv('FLASK_SECRET_KEY')
     if not secret_key:
@@ -94,6 +96,7 @@ def create_app():
 
     db.init_app(app)
     migrate.init_app(app, db)
+    init_redis(app)
     limiter.init_app(app)
 
     app.register_blueprint(user_bp, url_prefix='/api')

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -1,46 +1,24 @@
-"""
-Fornece conexao com Redis, usando DummyRedis quando o servidor nao esta disponivel.
-"""
+"""Inicializa a conexão com o Redis usada pela aplicação."""
+
 import os
-import time
-
-try:
-    from redis import Redis
-except ImportError:  # pragma: no cover - pacote redis ausente
-    Redis = None
-
-class DummyRedis:
-    """Implementacao em memoria usada quando o servidor Redis nao esta disponivel."""
-
-    def __init__(self):
-        self.store = {}
-
-    def setex(self, name, time_delta, value):
-        seconds = int(time_delta.total_seconds()) if hasattr(time_delta, "total_seconds") else int(time_delta)
-        expire_at = int(time.time()) + seconds
-        self.store[name] = (value, expire_at)
-
-    def get(self, name):
-        item = self.store.get(name)
-        if not item:
-            return None
-        value, exp = item
-        if exp < time.time():
-            self.store.pop(name, None)
-            return None
-        return value
+from redis import Redis
 
 
-def _create_client():
-    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-    if Redis is not None:
-        try:
-            client = Redis.from_url(url)
-            client.ping()
-            return client
-        except Exception:
-            pass
-    return DummyRedis()
+def init_redis(app=None):
+    """Cria o cliente Redis e o registra opcionalmente no app."""
+    url = (
+        app.config.get("REDIS_URL")
+        if app is not None
+        else os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    )
+
+    client = Redis.from_url(url)
+    client.ping()
+
+    if app is not None:
+        app.redis_conn = client
+    return client
 
 
-redis_conn = _create_client()
+redis_conn = init_redis()
+


### PR DESCRIPTION
## Summary
- configure Redis client as Flask extension
- use Redis backend for request limits
- document Redis requirement and setup

## Testing
- `REDIS_URL=redis://localhost:6379/0 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870275cf5348323b84d9a24799ed0e5