### PR TITLE
Refactor Dockerfile and add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,34 @@
-# Usar uma imagem base oficial e slim para menor tamanho
-FROM python:3.11-slim
+FROM python:3.11-slim AS builder
 
-# Definir variáveis de ambiente para Python e Poetry
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=false \
     POETRY_VIRTUALENVS_CREATE=false
 
-# Definir o diretório de trabalho
 WORKDIR /app
 
-# Instalar o Poetry
 RUN pip install poetry
 
-# Copiar apenas os arquivos de dependência primeiro para aproveitar o cache do Docker
 COPY poetry.lock pyproject.toml ./
 
-# Garantir que o arquivo lock esteja sincronizado com o pyproject
 RUN poetry lock --no-interaction
-
-# Instalar as dependências de produção
 RUN poetry install --no-root --without dev
 
-# Copiar o restante do código-fonte da aplicação
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local /usr/local
 COPY ./src ./src
 
-# Expor a porta que o Gunicorn usará
 EXPOSE 8080
 
-# Comando para iniciar a aplicação
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
+
 CMD ["gunicorn", "src.main:app", "--bind", "0.0.0.0:8080"]


### PR DESCRIPTION
## Summary
- use multi-stage build in Dockerfile
- install curl for runtime
- add a healthcheck to verify the service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687036ace58883238816ec56c321a022