### PR TITLE
Add env example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Example environment configuration for Conecta SENAI
+# Copy this file to `.env` and adjust the values as needed.
+
+# Database connection URL. If empty, a local SQLite file will be used.
+DATABASE_URL=postgresql://usuario:senha@localhost:5432/agenda
+
+# Secret key used to sign JWT tokens.
+SECRET_KEY=changeme
+# Alternatively use FLASK_SECRET_KEY instead of SECRET_KEY.
+#FLASK_SECRET_KEY=changeme
+
+# Default administrator credentials
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=senha-segura
+ADMIN_USERNAME=admin
+
+# Redis connection URL for rate limiting and token revocation
+REDIS_URL=redis://localhost:6379/0
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ env/
 # Environment and configuration files
 .env
 .env.*
+!.env.example
 
 # OS/editor artifacts
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ Consulte o arquivo [CHANGELOG.md](CHANGELOG.md) para detalhes das versões.
    poetry install
    ```
 
-2. Defina as variáveis de ambiente antes de rodar a aplicação ou os testes:
+2. Copie o arquivo `.env.example` para `.env` e ajuste as variáveis de ambiente:
 
    ```bash
-   export DATABASE_URL="postgresql://usuario:senha@host:5432/banco"
-   export SECRET_KEY="sua-chave-secreta"
-   export ADMIN_EMAIL="seu-email-admin"
-   export ADMIN_PASSWORD="senha-segura"
-   export REDIS_URL="redis://localhost:6379/0"
+   cp .env.example .env
+   # edite o arquivo .env com seus dados
    ```
+Todas as variáveis disponíveis estão listadas em `.env.example`.
 
    A aplicação também reconhece a variável `FLASK_SECRET_KEY`. Uma das duas deve estar definida; se nenhuma estiver presente, a aplicação aborta a inicialização. Use um valor longo e aleatório (por exemplo, `export SECRET_KEY=$(openssl rand -hex 32)`).
 
@@ -57,13 +55,13 @@ Consulte o arquivo [CHANGELOG.md](CHANGELOG.md) para detalhes das versões.
 
 Uma alternativa é rodar a aplicação em um container Docker. Para construir a imagem execute:
 
-```bash
+   ```bash
 docker build -t agenda-senai .
 ```
 
 Em seguida, inicie o container usando as variáveis definidas em um arquivo `.env`:
 
-```bash
+   ```bash
 docker run -p 8000:8000 --env-file .env agenda-senai
 ```
 


### PR DESCRIPTION
## Summary
- provide `.env.example` listing required environment variables
- document environment setup in README
- allow `.env.example` to be committed

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: Error 111 connecting to localhost:6379)*

------
https://chatgpt.com/codex/tasks/task_e_687037f7f88c8323a1c5c56468d95746