### PR TITLE
Add warning logs for invalid logins

### DIFF
--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -310,6 +310,11 @@ def login():
             senha_ok = False
 
         if not senha_ok:
+            current_app.logger.warning(
+                "Tentativa de login inválida para %s do IP %s",
+                email,
+                request.remote_addr,
+            )
             return jsonify(success=False, message="Credenciais inválidas"), 401
 
         access_token = gerar_token_acesso(usuario)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import jwt
 
 os.environ['ADMIN_EMAIL'] = 'admin@example.com'
 os.environ['ADMIN_USERNAME'] = 'admin'
+os.environ['DISABLE_REDIS'] = '1'
 
 import pytest
 from flask import Flask


### PR DESCRIPTION
## Summary
- log client IP and warn when login fails
- allow tests to run without Redis by using dummy client
- capture invalid login logs in user route tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870462ebce0832390aa06757b166d2d