### PR TITLE
Alterar exibição de usuários no dropdown de responsável

### DIFF
--- a/src/static/novo-agendamento.html
+++ b/src/static/novo-agendamento.html
@@ -488,7 +488,7 @@
                     usuarios.forEach(usuario => {
                         const option = document.createElement('option');
                         option.value = usuario.id;
-                        option.textContent = `${usuario.nome} (${usuario.username})`;
+                        option.textContent = `${usuario.nome} (${usuario.email})`;
                         selectUsuario.appendChild(option);
                     });
                 } catch (error) {


### PR DESCRIPTION
## Summary
- update user dropdown to show emails instead of usernames

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871549c8e348323a29ffd6464573d1b