### PR TITLE
Add instructor rateio module

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ A aplicação ficará disponível em [http://localhost:8000](http://localhost:80
 | `POST` | `/api/ocupacoes` | Criação de ocupação de sala |
 | `GET` | `/api/ocupacoes` | Consulta de ocupações |
 | `DELETE` | `/api/ocupacoes/<id>` | Remoção de ocupação |
+| `POST` | `/api/centros-custo` | Criação de centro de custo |
+| `POST` | `/api/apontamentos` | Registro de apontamento de horas |
+| `GET` | `/api/rateio/relatorio` | Relatório de rateio |
 
 ## Integração Contínua
 

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,9 @@ from src.routes.ocupacao import ocupacao_bp
 from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.user import user_bp
+from src.routes.centro_custo import centro_custo_bp
+from src.routes.apontamento import apontamento_bp
+from src.routes.rateio import rateio_bp
 from src.models.recurso import Recurso
 
 migrate = Migrate()
@@ -111,6 +114,9 @@ def create_app():
     app.register_blueprint(sala_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
+    app.register_blueprint(centro_custo_bp, url_prefix='/api')
+    app.register_blueprint(apontamento_bp, url_prefix='/api')
+    app.register_blueprint(rateio_bp, url_prefix='/api')
 
     @app.route('/')
     def index():

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -6,10 +6,14 @@ db = SQLAlchemy()
 from .refresh_token import RefreshToken  # noqa: E402
 from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
+from .centro_custo import CentroCusto  # noqa: E402
+from .apontamento import Apontamento  # noqa: E402
 
 __all__ = [
     "db",
     "RefreshToken",
     "Recurso",
     "AuditLog",
+    "CentroCusto",
+    "Apontamento",
 ]

--- a/src/models/apontamento.py
+++ b/src/models/apontamento.py
@@ -1,0 +1,45 @@
+"""Modelo de apontamento de horas de instrutores."""
+from datetime import datetime, date
+from decimal import Decimal
+from src.models import db
+
+class Apontamento(db.Model):
+    """Registro de horas trabalhadas para rateio de custos."""
+    __tablename__ = 'apontamentos'
+
+    id = db.Column(db.Integer, primary_key=True)
+    data = db.Column(db.Date, nullable=False)
+    horas = db.Column(db.Numeric(10, 2), nullable=False)
+    descricao = db.Column(db.Text)
+    status = db.Column(db.String(20), default='Pendente')
+    instrutor_id = db.Column(db.Integer, db.ForeignKey('instrutores.id'), nullable=False)
+    centro_custo_id = db.Column(db.Integer, db.ForeignKey('centros_custo.id'), nullable=False)
+    ocupacao_id = db.Column(db.Integer, db.ForeignKey('ocupacoes.id'))
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+
+    instrutor = db.relationship('Instrutor', backref='apontamentos', lazy=True)
+    centro_custo = db.relationship('CentroCusto', backref='apontamentos', lazy=True)
+
+    def __init__(self, data, horas, descricao, instrutor_id, centro_custo_id, status='Pendente', ocupacao_id=None):
+        self.data = data if isinstance(data, date) else datetime.strptime(data, '%Y-%m-%d').date()
+        self.horas = Decimal(horas)
+        self.descricao = descricao
+        self.status = status
+        self.instrutor_id = instrutor_id
+        self.centro_custo_id = centro_custo_id
+        self.ocupacao_id = ocupacao_id
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'data': self.data.isoformat() if self.data else None,
+            'horas': float(self.horas) if self.horas is not None else None,
+            'descricao': self.descricao,
+            'status': self.status,
+            'instrutor_id': self.instrutor_id,
+            'centro_custo_id': self.centro_custo_id,
+            'ocupacao_id': self.ocupacao_id,
+        }
+
+    def __repr__(self):
+        return f'<Apontamento {self.id} - Instrutor {self.instrutor_id}>'

--- a/src/models/centro_custo.py
+++ b/src/models/centro_custo.py
@@ -1,0 +1,27 @@
+"""Modelo de centro de custo."""
+from src.models import db
+
+class CentroCusto(db.Model):
+    """Tabela de centros de custo para rateio."""
+    __tablename__ = 'centros_custo'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(100), unique=True, nullable=False)
+    descricao = db.Column(db.Text)
+    ativo = db.Column(db.Boolean, default=True)
+
+    def __init__(self, nome, descricao=None, ativo=True):
+        self.nome = nome
+        self.descricao = descricao
+        self.ativo = ativo
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'nome': self.nome,
+            'descricao': self.descricao,
+            'ativo': self.ativo,
+        }
+
+    def __repr__(self):
+        return f'<CentroCusto {self.nome}>'

--- a/src/models/instrutor.py
+++ b/src/models/instrutor.py
@@ -15,6 +15,7 @@ class Instrutor(db.Model):
     area_atuacao = db.Column(db.String(100))  # Departamento ou área de especialização
     disponibilidade = db.Column(db.JSON)
     status = db.Column(db.String(20), default='ativo')  # ativo, inativo, licenca
+    custo_hora = db.Column(db.Numeric(10, 2), default=0)
     observacoes = db.Column(db.Text)
     data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
     data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -23,13 +24,14 @@ class Instrutor(db.Model):
     ocupacoes = db.relationship('Ocupacao', backref='instrutor', lazy=True)
     
     def __init__(self, nome, email=None, telefone=None, area_atuacao=None,
-                 disponibilidade=None, status='ativo'):
+                 disponibilidade=None, status='ativo', custo_hora=0):
         self.nome = nome
         self.email = email
         self.telefone = telefone
         self.area_atuacao = area_atuacao
         self.disponibilidade = disponibilidade or []
         self.status = status
+        self.custo_hora = custo_hora
     
     def get_disponibilidade(self):
         """
@@ -109,6 +111,7 @@ class Instrutor(db.Model):
             'observacoes': self.observacoes,
             'disponibilidade': self.get_disponibilidade(),
             'status': self.status,
+            'custo_hora': float(self.custo_hora) if self.custo_hora is not None else 0,
             'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
             'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None
         }

--- a/src/routes/apontamento.py
+++ b/src/routes/apontamento.py
@@ -1,0 +1,69 @@
+"""Rotas para apontamentos de instrutores."""
+from flask import Blueprint, request, jsonify
+from sqlalchemy import extract
+from src.models import db
+from src.models.apontamento import Apontamento
+from src.models.instrutor import Instrutor
+from src.models.centro_custo import CentroCusto
+from src.routes.user import verificar_autenticacao, verificar_admin
+from sqlalchemy.exc import SQLAlchemyError
+from src.utils.error_handler import handle_internal_error
+
+apontamento_bp = Blueprint('apontamento', __name__)
+
+@apontamento_bp.route('/apontamentos', methods=['POST'])
+def criar_apontamento():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    data = request.json or {}
+    instrutor_id = data.get('instrutor_id') or user.id
+    if not verificar_admin(user) and instrutor_id != user.id:
+        return jsonify({'erro': 'Permissão negada'}), 403
+    instrutor = db.session.get(Instrutor, instrutor_id)
+    centro = db.session.get(CentroCusto, data.get('centro_custo_id'))
+    if not instrutor or not centro:
+        return jsonify({'erro': 'Dados inválidos'}), 400
+    try:
+        apont = Apontamento(
+            data=data.get('data'),
+            horas=data.get('horas'),
+            descricao=data.get('descricao'),
+            instrutor_id=instrutor_id,
+            centro_custo_id=centro.id,
+        )
+        db.session.add(apont)
+        db.session.commit()
+        return jsonify(apont.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+@apontamento_bp.route('/apontamentos', methods=['GET'])
+def listar_apontamentos():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    query = Apontamento.query
+    if not verificar_admin(user):
+        query = query.filter(Apontamento.instrutor_id == user.id)
+    apontamentos = query.order_by(Apontamento.data.desc()).all()
+    return jsonify([a.to_dict() for a in apontamentos])
+
+@apontamento_bp.route('/apontamentos/<int:apontamento_id>', methods=['PUT'])
+def atualizar_status(apontamento_id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado or not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    apont = db.session.get(Apontamento, apontamento_id)
+    if not apont:
+        return jsonify({'erro': 'Apontamento não encontrado'}), 404
+    status = (request.json or {}).get('status')
+    if status:
+        apont.status = status
+    try:
+        db.session.commit()
+        return jsonify(apont.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)

--- a/src/routes/centro_custo.py
+++ b/src/routes/centro_custo.py
@@ -1,0 +1,78 @@
+"""Rotas para centros de custo."""
+from flask import Blueprint, request, jsonify
+from src.models import db
+from src.models.centro_custo import CentroCusto
+from src.routes.user import verificar_autenticacao, verificar_admin
+from sqlalchemy.exc import SQLAlchemyError
+from src.utils.error_handler import handle_internal_error
+
+centro_custo_bp = Blueprint('centro_custo', __name__)
+
+@centro_custo_bp.route('/centros-custo', methods=['GET'])
+def listar_centros_custo():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado or not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    centros = CentroCusto.query.all()
+    return jsonify([c.to_dict() for c in centros])
+
+@centro_custo_bp.route('/centros-custo', methods=['POST'])
+def criar_centro_custo():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado or not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    data = request.json or {}
+    nome = data.get('nome')
+    if not nome:
+        return jsonify({'erro': 'Nome é obrigatório'}), 400
+    if CentroCusto.query.filter_by(nome=nome).first():
+        return jsonify({'erro': 'Centro de custo já existe'}), 400
+    centro = CentroCusto(nome=nome, descricao=data.get('descricao'), ativo=data.get('ativo', True))
+    try:
+        db.session.add(centro)
+        db.session.commit()
+        return jsonify(centro.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+@centro_custo_bp.route('/centros-custo/<int:id>', methods=['PUT'])
+def atualizar_centro_custo(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado or not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    centro = db.session.get(CentroCusto, id)
+    if not centro:
+        return jsonify({'erro': 'Centro de custo não encontrado'}), 404
+    data = request.json or {}
+    if 'nome' in data:
+        nome = data['nome']
+        if nome and nome != centro.nome and CentroCusto.query.filter_by(nome=nome).first():
+            return jsonify({'erro': 'Nome já utilizado'}), 400
+        centro.nome = nome or centro.nome
+    if 'descricao' in data:
+        centro.descricao = data['descricao']
+    if 'ativo' in data:
+        centro.ativo = bool(data['ativo'])
+    try:
+        db.session.commit()
+        return jsonify(centro.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+@centro_custo_bp.route('/centros-custo/<int:id>', methods=['DELETE'])
+def remover_centro_custo(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado or not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    centro = db.session.get(CentroCusto, id)
+    if not centro:
+        return jsonify({'erro': 'Centro de custo não encontrado'}), 404
+    try:
+        db.session.delete(centro)
+        db.session.commit()
+        return jsonify({'mensagem': 'Removido'})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)

--- a/src/routes/instrutor.py
+++ b/src/routes/instrutor.py
@@ -38,8 +38,11 @@ def listar_instrutores():
     
     # Ordena por nome
     instrutores = query.order_by(Instrutor.nome).all()
-    
-    return jsonify([instrutor.to_dict() for instrutor in instrutores])
+    result = [i.to_dict() for i in instrutores]
+    if not verificar_admin(user):
+        for r in result:
+            r.pop('custo_hora', None)
+    return jsonify(result)
 
 @instrutor_bp.route('/instrutores/<int:id>', methods=['GET'])
 def obter_instrutor(id):
@@ -53,8 +56,10 @@ def obter_instrutor(id):
     instrutor = db.session.get(Instrutor, id)
     if not instrutor:
         return jsonify({'erro': 'Instrutor não encontrado'}), 404
-    
-    return jsonify(instrutor.to_dict())
+    data_resp = instrutor.to_dict()
+    if not verificar_admin(user):
+        data_resp.pop('custo_hora', None)
+    return jsonify(data_resp)
 
 @instrutor_bp.route('/instrutores', methods=['POST'])
 def criar_instrutor():
@@ -90,7 +95,8 @@ def criar_instrutor():
             telefone=payload.telefone,
             area_atuacao=payload.area_atuacao,
             disponibilidade=payload.disponibilidade,
-            status=status
+            status=status,
+            custo_hora=payload.custo_hora or 0
         )
         novo_instrutor.observacoes = payload.observacoes
         
@@ -155,11 +161,17 @@ def atualizar_instrutor(id):
 
     if payload.observacoes is not None:
         instrutor.observacoes = payload.observacoes
+
+    if payload.custo_hora is not None:
+        instrutor.custo_hora = payload.custo_hora
     
     
     try:
         db.session.commit()
-        return jsonify(instrutor.to_dict())
+        data_resp = instrutor.to_dict()
+        if not verificar_admin(user):
+            data_resp.pop('custo_hora', None)
+        return jsonify(data_resp)
     except SQLAlchemyError as e:
         db.session.rollback()
         return handle_internal_error(e)

--- a/src/routes/ocupacao.py
+++ b/src/routes/ocupacao.py
@@ -4,6 +4,8 @@ from src.models import db
 from src.models.ocupacao import Ocupacao
 from src.models.sala import Sala
 from src.models.instrutor import Instrutor
+from src.models.apontamento import Apontamento
+from src.models.centro_custo import CentroCusto
 from src.routes.user import verificar_autenticacao, verificar_admin
 from src.auth import admin_required
 from sqlalchemy.exc import SQLAlchemyError
@@ -309,6 +311,21 @@ def criar_ocupacao():
             dia += timedelta(days=1)
 
         db.session.commit()
+        auto_apontar = data.get('auto_apontar') and payload.instrutor_id and data.get('centro_custo_id')
+        if auto_apontar:
+            centro = db.session.get(CentroCusto, data.get('centro_custo_id'))
+            for oc in ocupacoes_criadas:
+                horas = oc.get_duracao_minutos() / 60
+                apont = Apontamento(
+                    data=oc.data,
+                    horas=horas,
+                    descricao=oc.curso_evento,
+                    instrutor_id=oc.instrutor_id,
+                    centro_custo_id=centro.id,
+                    ocupacao_id=oc.id,
+                )
+                db.session.add(apont)
+            db.session.commit()
         for oc in ocupacoes_criadas:
             log_action(user.id, 'create', 'Ocupacao', oc.id, oc.to_dict())
 

--- a/src/routes/rateio.py
+++ b/src/routes/rateio.py
@@ -1,0 +1,52 @@
+"""Rotas para cálculo de rateio de instrutores."""
+from flask import Blueprint, request, jsonify
+from sqlalchemy import extract
+from src.models import db
+from src.models.apontamento import Apontamento
+from src.models.instrutor import Instrutor
+from src.models.centro_custo import CentroCusto
+from src.routes.user import verificar_autenticacao, verificar_admin
+
+rateio_bp = Blueprint('rateio', __name__)
+
+@rateio_bp.route('/rateio/relatorio', methods=['GET'])
+def relatorio_rateio():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado or not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    mes = request.args.get('mes', type=int)
+    ano = request.args.get('ano', type=int)
+    if not mes or not ano:
+        return jsonify({'erro': 'Informe mes e ano'}), 400
+    aps = (
+        Apontamento.query
+        .filter(extract('month', Apontamento.data) == mes)
+        .filter(extract('year', Apontamento.data) == ano)
+        .all()
+    )
+    resultado = {}
+    for a in aps:
+        cc = resultado.setdefault(a.centro_custo_id, {'total_horas': 0, 'total_custo': 0, 'instrutores': {}})
+        cc['total_horas'] += float(a.horas)
+        custo = float(a.horas) * float(a.instrutor.custo_hora)
+        cc['total_custo'] += custo
+        inst = cc['instrutores'].setdefault(a.instrutor_id, {'total_horas': 0, 'total_custo': 0})
+        inst['total_horas'] += float(a.horas)
+        inst['total_custo'] += custo
+    saida = []
+    for cc_id, dados in resultado.items():
+        instrutores = [
+            {
+                'instrutor_id': iid,
+                'total_horas': info['total_horas'],
+                'total_custo': info['total_custo'],
+            }
+            for iid, info in dados['instrutores'].items()
+        ]
+        saida.append({
+            'centro_custo_id': cc_id,
+            'total_horas': dados['total_horas'],
+            'total_custo': dados['total_custo'],
+            'instrutores': instrutores,
+        })
+    return jsonify(saida)

--- a/src/schemas/instrutor.py
+++ b/src/schemas/instrutor.py
@@ -9,6 +9,7 @@ class InstrutorCreateSchema(BaseModel):
     disponibilidade: Optional[List[str]] = Field(default_factory=list)
     status: Optional[str] = 'ativo'
     observacoes: Optional[str] = None
+    custo_hora: Optional[float] = 0
 
 class InstrutorUpdateSchema(BaseModel):
     nome: Optional[str] = None
@@ -18,3 +19,4 @@ class InstrutorUpdateSchema(BaseModel):
     disponibilidade: Optional[List[str]] = None
     status: Optional[str] = None
     observacoes: Optional[str] = None
+    custo_hora: Optional[float] = None

--- a/src/static/apontamentos.html
+++ b/src/static/apontamentos.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Apontamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+    <div class="container-fluid">
+        <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+            <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+            <span class="navbar-brand-text">Gestão Financeira</span>
+        </a>
+    </div>
+</nav>
+
+<div class="container-fluid py-4">
+    <div class="card">
+        <div class="card-header"><h5 class="mb-0">Apontamentos</h5></div>
+        <div class="card-body">
+            <form id="apontForm" class="row g-3">
+                <div class="col-md-3">
+                    <input type="date" id="apontData" class="form-control" required>
+                </div>
+                <div class="col-md-2">
+                    <input type="number" step="0.25" id="apontHoras" class="form-control" placeholder="Horas" required>
+                </div>
+                <div class="col-md-5">
+                    <input type="text" id="apontDesc" class="form-control" placeholder="Descrição">
+                </div>
+                <div class="col-md-2">
+                    <button type="submit" class="btn btn-primary w-100">Registrar</button>
+                </div>
+            </form>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped table-hover mb-0">
+                <thead><tr><th>Data</th><th>Horas</th><th>Status</th></tr></thead>
+                <tbody id="apontTable"><tr><td colspan="3" class="text-center">...</td></tr></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<footer class="mt-5 py-3 bg-dark text-white text-center">
+    <span>Conecta SENAI</span>
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/apontamentos.js"></script>
+</body>
+</html>

--- a/src/static/dashboard-rateio.html
+++ b/src/static/dashboard-rateio.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard Rateio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+    <div class="container-fluid">
+        <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+            <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+            <span class="navbar-brand-text">Gestão Financeira</span>
+        </a>
+    </div>
+</nav>
+
+<div class="container-fluid py-4">
+    <div class="card mb-4">
+        <div class="card-header"><h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5></div>
+        <div class="card-body">
+            <form id="filtroForm" class="row g-3">
+                <div class="col-md-3">
+                    <input type="number" id="filtroMes" class="form-control" placeholder="Mês" min="1" max="12">
+                </div>
+                <div class="col-md-3">
+                    <input type="number" id="filtroAno" class="form-control" placeholder="Ano">
+                </div>
+                <div class="col-md-3">
+                    <button type="submit" class="btn btn-primary">Gerar</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="card">
+        <div class="card-header"><h5 class="mb-0">Relatório</h5></div>
+        <div class="card-body">
+            <canvas id="graficoRateio"></canvas>
+            <div class="table-responsive mt-4">
+                <table class="table table-striped table-hover">
+                    <thead><tr><th>Centro de Custo</th><th>Total Horas</th><th>Total Custo</th></tr></thead>
+                    <tbody id="tabelaRateio"><tr><td colspan="3" class="text-center">...</td></tr></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<footer class="mt-5 py-3 bg-dark text-white text-center">
+    <span>Conecta SENAI</span>
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="/js/dashboard-rateio.js"></script>
+</body>
+</html>

--- a/src/static/gerenciar-centros-custo.html
+++ b/src/static/gerenciar-centros-custo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Centros de Custo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text">Gestão Financeira</span>
+            </a>
+        </div>
+    </nav>
+
+    <div class="container-fluid py-4">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Centros de Custo</h5>
+                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#centroModal">Novo</button>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover">
+                        <thead><tr><th>ID</th><th>Nome</th><th>Ações</th></tr></thead>
+                        <tbody id="centroTable"><tr><td colspan="3" class="text-center">...</td></tr></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="mt-5 py-3 bg-dark text-white text-center">
+        <span>Conecta SENAI</span>
+    </footer>
+
+    <div class="modal fade" id="centroModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Centro de Custo</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="centroForm">
+                        <input type="hidden" id="centroId">
+                        <div class="mb-3">
+                            <label class="form-label">Nome</label>
+                            <input type="text" class="form-control" id="centroNome" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Descrição</label>
+                            <textarea class="form-control" id="centroDesc"></textarea>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" form="centroForm" class="btn btn-primary">Salvar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/centros-custo.js"></script>
+</body>
+</html>

--- a/src/static/usuarios.html
+++ b/src/static/usuarios.html
@@ -65,6 +65,18 @@
                         <a class="nav-link" href="/perfil-usuarios.html">
                             <i class="bi bi-person"></i> Meu Perfil
                         </a>
+                        <div class="mt-3">
+                            <strong class="text-muted">Gestão Financeira</strong>
+                        </div>
+                        <a class="nav-link" href="/gerenciar-centros-custo.html">
+                            <i class="bi bi-wallet2"></i> Centros de Custo
+                        </a>
+                        <a class="nav-link" href="/apontamentos.html">
+                            <i class="bi bi-clock-history"></i> Apontamentos
+                        </a>
+                        <a class="nav-link" href="/dashboard-rateio.html">
+                            <i class="bi bi-graph-up"></i> Dashboard Rateio
+                        </a>
                     </div>
                 </div>
             </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,9 @@ from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.agendamento import agendamento_bp
 from src.routes.instrutor import instrutor_bp
+from src.routes.centro_custo import centro_custo_bp
+from src.routes.apontamento import apontamento_bp
+from src.routes.rateio import rateio_bp
 
 @pytest.fixture
 def app():
@@ -34,6 +37,9 @@ def app():
     app.register_blueprint(turma_bp, url_prefix='/api')
     app.register_blueprint(agendamento_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
+    app.register_blueprint(centro_custo_bp, url_prefix='/api')
+    app.register_blueprint(apontamento_bp, url_prefix='/api')
+    app.register_blueprint(rateio_bp, url_prefix='/api')
 
     with app.app_context():
         db.create_all()
@@ -53,6 +59,12 @@ def app():
         db.session.add(comum)
         sala = Sala(nome='Sala Teste', capacidade=10)
         db.session.add(sala)
+        from src.models.centro_custo import CentroCusto
+        from src.models.instrutor import Instrutor
+        cc = CentroCusto(nome='CC1')
+        db.session.add(cc)
+        instr = Instrutor(nome='Inst1', custo_hora=50)
+        db.session.add(instr)
         db.session.commit()
     return app
 

--- a/tests/test_apontamento.py
+++ b/tests/test_apontamento.py
@@ -1,0 +1,28 @@
+from datetime import date
+
+
+def test_criar_listar_apontamento(client, login_admin):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    # pega instrutor e centro custo padrões criados no fixture
+    resp_instr = client.get('/api/instrutores', headers=headers)
+    instr_id = resp_instr.get_json()[0]['id']
+    resp_cc = client.get('/api/centros-custo', headers=headers)
+    cc_id = resp_cc.get_json()[0]['id']
+
+    resp = client.post(
+        '/api/apontamentos',
+        json={
+            'data': date.today().isoformat(),
+            'horas': 2,
+            'descricao': 'Aula',
+            'instrutor_id': instr_id,
+            'centro_custo_id': cc_id,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201
+
+    resp = client.get('/api/apontamentos', headers=headers)
+    dados = resp.get_json()
+    assert any(a['instrutor_id'] == instr_id for a in dados)

--- a/tests/test_centro_custo.py
+++ b/tests/test_centro_custo.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+def test_crud_centro_custo(client, login_admin):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.post('/api/centros-custo', json={'nome': 'Financeiro'}, headers=headers)
+    assert resp.status_code == 201
+    cid = resp.get_json()['id']
+
+    resp = client.get('/api/centros-custo', headers=headers)
+    assert any(c['id'] == cid for c in resp.get_json())
+
+    resp = client.put(f'/api/centros-custo/{cid}', json={'descricao': 'Depto'}, headers=headers)
+    assert resp.status_code == 200
+
+    resp = client.delete(f'/api/centros-custo/{cid}', headers=headers)
+    assert resp.status_code == 200

--- a/tests/test_rateio.py
+++ b/tests/test_rateio.py
@@ -1,0 +1,38 @@
+from datetime import date
+
+
+def test_relatorio_rateio(client, login_admin):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    resp_instr = client.get('/api/instrutores', headers=headers)
+    instr_id = resp_instr.get_json()[0]['id']
+    resp_cc = client.get('/api/centros-custo', headers=headers)
+    cc_id = resp_cc.get_json()[0]['id']
+
+    client.post(
+        '/api/apontamentos',
+        json={
+            'data': date(2024, 1, 15).isoformat(),
+            'horas': 3,
+            'descricao': 'Ativ',
+            'instrutor_id': instr_id,
+            'centro_custo_id': cc_id,
+        },
+        headers=headers,
+    )
+    client.post(
+        '/api/apontamentos',
+        json={
+            'data': date(2024, 1, 20).isoformat(),
+            'horas': 2,
+            'descricao': 'Ativ2',
+            'instrutor_id': instr_id,
+            'centro_custo_id': cc_id,
+        },
+        headers=headers,
+    )
+
+    resp = client.get('/api/rateio/relatorio', query_string={'mes': 1, 'ano': 2024}, headers=headers)
+    assert resp.status_code == 200
+    dados = resp.get_json()
+    assert dados[0]['total_horas'] == 5


### PR DESCRIPTION
## Summary
- add CentroCusto and Apontamento models
- expose APIs for centros de custo, apontamentos and rateio reports
- extend instrutor with custo_hora and protect field
- auto create apontamentos when ocupacao created
- add new frontend pages for financial management
- register blueprints and update sidebar menu
- add tests for new endpoints

## Testing
- `pytest tests/test_centro_custo.py tests/test_apontamento.py tests/test_rateio.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719c7ec4ec8323a8b93ecf97abc603