### PR TITLE
Implement basic Controle de Rateio module

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,9 @@ from src.routes.ocupacao import ocupacao_bp
 from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.user import user_bp
+from src.routes.centro_custo import centro_custo_bp
+from src.routes.apontamento import apontamento_bp
+from src.routes.rateio import rateio_bp
 from src.models.recurso import Recurso
 
 migrate = Migrate()
@@ -111,6 +114,9 @@ def create_app():
     app.register_blueprint(sala_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
+    app.register_blueprint(centro_custo_bp, url_prefix='/api')
+    app.register_blueprint(apontamento_bp, url_prefix='/api')
+    app.register_blueprint(rateio_bp, url_prefix='/api')
 
     @app.route('/')
     def index():

--- a/src/models/apontamento.py
+++ b/src/models/apontamento.py
@@ -1,0 +1,40 @@
+"""Modelo de Apontamento de horas."""
+from src.models import db
+from datetime import datetime
+
+class Apontamento(db.Model):
+    __tablename__ = 'apontamentos'
+
+    id = db.Column(db.Integer, primary_key=True)
+    data = db.Column(db.Date, nullable=False)
+    horas = db.Column(db.Numeric(10, 2), nullable=False)
+    descricao = db.Column(db.String(255))
+    status = db.Column(db.String(20), default='pendente')
+    instrutor_id = db.Column(db.Integer, db.ForeignKey('instrutores.id'), nullable=False)
+    centro_custo_id = db.Column(db.Integer, db.ForeignKey('centros_custo.id'), nullable=False)
+    ocupacao_id = db.Column(db.Integer, db.ForeignKey('ocupacoes.id'), nullable=True)
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+    data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    instrutor = db.relationship('Instrutor', backref='apontamentos')
+    centro_custo = db.relationship('CentroCusto', backref='apontamentos')
+
+    def valor_total(self):
+        custo = getattr(self.instrutor, 'custo_hora', 0) or 0
+        return float(self.horas) * float(custo)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'data': self.data.isoformat() if self.data else None,
+            'horas': float(self.horas),
+            'descricao': self.descricao,
+            'status': self.status,
+            'instrutor_id': self.instrutor_id,
+            'centro_custo_id': self.centro_custo_id,
+            'ocupacao_id': self.ocupacao_id,
+            'valor_total': self.valor_total()
+        }
+
+    def __repr__(self):
+        return f'<Apontamento {self.id}>'

--- a/src/models/centro_custo.py
+++ b/src/models/centro_custo.py
@@ -1,0 +1,24 @@
+"""Modelo de Centro de Custo."""
+from src.models import db
+from datetime import datetime
+
+class CentroCusto(db.Model):
+    __tablename__ = 'centros_custo'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(100), nullable=False, unique=True)
+    descricao = db.Column(db.String(255))
+    ativo = db.Column(db.Boolean, default=True)
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+    data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'nome': self.nome,
+            'descricao': self.descricao,
+            'ativo': self.ativo
+        }
+
+    def __repr__(self):
+        return f'<CentroCusto {self.nome}>'

--- a/src/models/instrutor.py
+++ b/src/models/instrutor.py
@@ -15,6 +15,7 @@ class Instrutor(db.Model):
     area_atuacao = db.Column(db.String(100))  # Departamento ou área de especialização
     disponibilidade = db.Column(db.JSON)
     status = db.Column(db.String(20), default='ativo')  # ativo, inativo, licenca
+    custo_hora = db.Column(db.Numeric(10, 2), default=0)
     observacoes = db.Column(db.Text)
     data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
     data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -109,6 +110,7 @@ class Instrutor(db.Model):
             'observacoes': self.observacoes,
             'disponibilidade': self.get_disponibilidade(),
             'status': self.status,
+            'custo_hora': float(self.custo_hora) if self.custo_hora is not None else None,
             'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
             'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None
         }

--- a/src/routes/apontamento.py
+++ b/src/routes/apontamento.py
@@ -1,0 +1,51 @@
+"""Rotas para apontamentos de instrutores."""
+from flask import Blueprint, request, jsonify
+from src.models import db
+from src.models.apontamento import Apontamento
+from src.routes.user import verificar_autenticacao, verificar_admin
+from sqlalchemy.exc import SQLAlchemyError
+from src.utils.error_handler import handle_internal_error
+from pydantic import ValidationError
+from src.schemas import ApontamentoCreateSchema
+
+apontamento_bp = Blueprint('apontamento', __name__)
+
+@apontamento_bp.route('/apontamentos', methods=['POST'])
+def criar_apontamento():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    data = request.json or {}
+    try:
+        payload = ApontamentoCreateSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+
+    apont = Apontamento(
+        data=payload.data,
+        horas=payload.horas,
+        descricao=payload.descricao,
+        status=payload.status,
+        instrutor_id=payload.instrutor_id,
+        centro_custo_id=payload.centro_custo_id,
+        ocupacao_id=payload.ocupacao_id
+    )
+    try:
+        db.session.add(apont)
+        db.session.commit()
+        return jsonify(apont.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+@apontamento_bp.route('/apontamentos', methods=['GET'])
+def listar_apontamentos():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+
+    apontamentos = Apontamento.query.order_by(Apontamento.data.desc()).all()
+    return jsonify([a.to_dict() for a in apontamentos])

--- a/src/routes/centro_custo.py
+++ b/src/routes/centro_custo.py
@@ -1,0 +1,95 @@
+"""Rotas para centros de custo."""
+from flask import Blueprint, request, jsonify
+from src.models import db
+from src.models.centro_custo import CentroCusto
+from src.routes.user import verificar_autenticacao, verificar_admin
+from sqlalchemy.exc import SQLAlchemyError
+from src.utils.error_handler import handle_internal_error
+from pydantic import ValidationError
+from src.schemas import CentroCustoCreateSchema, CentroCustoUpdateSchema
+
+centro_custo_bp = Blueprint('centro_custo', __name__)
+
+@centro_custo_bp.route('/centros-custo', methods=['GET'])
+def listar_centros_custo():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    centros = CentroCusto.query.order_by(CentroCusto.nome).all()
+    return jsonify([c.to_dict() for c in centros])
+
+@centro_custo_bp.route('/centros-custo', methods=['POST'])
+def criar_centro_custo():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+
+    data = request.json or {}
+    try:
+        payload = CentroCustoCreateSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+
+    novo = CentroCusto(nome=payload.nome, descricao=payload.descricao, ativo=payload.ativo)
+    try:
+        db.session.add(novo)
+        db.session.commit()
+        return jsonify(novo.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+@centro_custo_bp.route('/centros-custo/<int:id>', methods=['PUT'])
+def atualizar_centro_custo(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+
+    centro = db.session.get(CentroCusto, id)
+    if not centro:
+        return jsonify({'erro': 'Centro de custo não encontrado'}), 404
+
+    data = request.json or {}
+    try:
+        payload = CentroCustoUpdateSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+
+    if payload.nome is not None:
+        centro.nome = payload.nome
+    if payload.descricao is not None:
+        centro.descricao = payload.descricao
+    if payload.ativo is not None:
+        centro.ativo = payload.ativo
+
+    try:
+        db.session.commit()
+        return jsonify(centro.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+@centro_custo_bp.route('/centros-custo/<int:id>', methods=['DELETE'])
+def remover_centro_custo(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+
+    centro = db.session.get(CentroCusto, id)
+    if not centro:
+        return jsonify({'erro': 'Centro de custo não encontrado'}), 404
+
+    try:
+        db.session.delete(centro)
+        db.session.commit()
+        return jsonify({'mensagem': 'Removido com sucesso'})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)

--- a/src/routes/rateio.py
+++ b/src/routes/rateio.py
@@ -1,0 +1,42 @@
+"""Rota para relatório financeiro de rateio."""
+from flask import Blueprint, request, jsonify
+from sqlalchemy import func
+from src.models import db
+from src.models.apontamento import Apontamento
+from src.routes.user import verificar_autenticacao, verificar_admin
+
+rateio_bp = Blueprint('rateio', __name__)
+
+@rateio_bp.route('/rateio/relatorio', methods=['GET'])
+def relatorio_rateio():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+
+    inicio = request.args.get('inicio')
+    fim = request.args.get('fim')
+
+    query = db.session.query(
+        Apontamento.instrutor_id,
+        Apontamento.centro_custo_id,
+        func.sum(Apontamento.horas * (Apontamento.instrutor.custo_hora)).label('custo')
+    ).join(Apontamento.instrutor)
+
+    if inicio:
+        query = query.filter(Apontamento.data >= inicio)
+    if fim:
+        query = query.filter(Apontamento.data <= fim)
+
+    query = query.group_by(Apontamento.instrutor_id, Apontamento.centro_custo_id)
+
+    resultados = [
+        {
+            'instrutor_id': r.instrutor_id,
+            'centro_custo_id': r.centro_custo_id,
+            'custo': float(r.custo or 0)
+        }
+        for r in query.all()
+    ]
+    return jsonify({'resultados': resultados})

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,9 +1,13 @@
 from .sala import SalaCreateSchema, SalaUpdateSchema
 from .instrutor import InstrutorCreateSchema, InstrutorUpdateSchema
 from .ocupacao import OcupacaoCreateSchema, OcupacaoUpdateSchema
+from .centro_custo import CentroCustoCreateSchema, CentroCustoUpdateSchema
+from .apontamento import ApontamentoCreateSchema, ApontamentoUpdateSchema
 
 __all__ = [
     'SalaCreateSchema', 'SalaUpdateSchema',
     'InstrutorCreateSchema', 'InstrutorUpdateSchema',
     'OcupacaoCreateSchema', 'OcupacaoUpdateSchema',
+    'CentroCustoCreateSchema', 'CentroCustoUpdateSchema',
+    'ApontamentoCreateSchema', 'ApontamentoUpdateSchema',
 ]

--- a/src/schemas/apontamento.py
+++ b/src/schemas/apontamento.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from datetime import date
+
+class ApontamentoCreateSchema(BaseModel):
+    data: date
+    horas: float = Field(gt=0)
+    descricao: Optional[str] = None
+    status: Optional[str] = 'pendente'
+    instrutor_id: int
+    centro_custo_id: int
+    ocupacao_id: Optional[int] = None
+
+class ApontamentoUpdateSchema(BaseModel):
+    data: Optional[date] = None
+    horas: Optional[float] = Field(default=None, gt=0)
+    descricao: Optional[str] = None
+    status: Optional[str] = None
+    instrutor_id: Optional[int] = None
+    centro_custo_id: Optional[int] = None
+    ocupacao_id: Optional[int] = None

--- a/src/schemas/centro_custo.py
+++ b/src/schemas/centro_custo.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+class CentroCustoCreateSchema(BaseModel):
+    nome: str
+    descricao: Optional[str] = None
+    ativo: Optional[bool] = True
+
+class CentroCustoUpdateSchema(BaseModel):
+    nome: Optional[str] = None
+    descricao: Optional[str] = None
+    ativo: Optional[bool] = None

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -82,6 +82,16 @@
                         <a class="nav-link" href="/perfil.html">
                             <i class="bi bi-person"></i> Meu Perfil
                         </a>
+                        <h5 class="mt-4">Gestão Financeira</h5>
+                        <a class="nav-link admin-only" href="/rateio/apontamentos.html">
+                            <i class="bi bi-clock"></i> Apontamentos
+                        </a>
+                        <a class="nav-link admin-only" href="/rateio/dashboard-rateio.html">
+                            <i class="bi bi-graph-up"></i> Dashboard de Rateio
+                        </a>
+                        <a class="nav-link admin-only" href="/rateio/gerenciar-centros-custo.html">
+                            <i class="bi bi-folder"></i> Centros de Custo
+                        </a>
                     </div>
                 </div>
             </div>

--- a/src/static/rateio/apontamentos.html
+++ b/src/static/rateio/apontamentos.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Apontamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Apontamentos">Apontamentos</span>
+            </a>
+        </div>
+    </nav>
+    <div class="container-fluid py-4">
+        <h2 class="mb-4">Lançar Apontamento</h2>
+        <form id="formApont">
+            <div class="row g-3">
+                <div class="col-md-3">
+                    <label class="form-label">Data</label>
+                    <input type="date" class="form-control" id="apontData" required>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Horas</label>
+                    <input type="number" step="0.5" class="form-control" id="apontHoras" required>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">Descrição</label>
+                    <input type="text" class="form-control" id="apontDesc">
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary mt-3">Salvar</button>
+        </form>
+        <hr>
+        <table class="table" id="tabelaApont">
+            <thead>
+                <tr>
+                    <th>Data</th>
+                    <th>Horas</th>
+                    <th>Instrutor</th>
+                    <th>Centro de Custo</th>
+                    <th>Valor</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/rateio/dashboard-rateio.html
+++ b/src/static/rateio/dashboard-rateio.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard de Rateio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/chart.js" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Rateio">Rateio</span>
+            </a>
+        </div>
+    </nav>
+    <div class="container-fluid py-4">
+        <h2 class="mb-4">Dashboard de Rateio</h2>
+        <div class="row">
+            <div class="col-md-6">
+                <canvas id="grafHoras"></canvas>
+            </div>
+            <div class="col-md-6">
+                <canvas id="grafCustos"></canvas>
+            </div>
+        </div>
+        <table class="table mt-4" id="tabelaRateio">
+            <thead>
+                <tr>
+                    <th>Instrutor</th>
+                    <th>Centro de Custo</th>
+                    <th>Horas</th>
+                    <th>Custo</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/rateio/gerenciar-centros-custo.html
+++ b/src/static/rateio/gerenciar-centros-custo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Centros de Custo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Centros de Custo">Centros de Custo</span>
+            </a>
+        </div>
+    </nav>
+    <div class="container-fluid py-4">
+        <h2 class="mb-4">Gerenciar Centros de Custo</h2>
+        <table class="table" id="tabelaCentros">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Nome</th>
+                    <th>Descrição</th>
+                    <th>Ações</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -90,6 +90,20 @@
                     </div>
                 </div>
             </div>
+            <div class="col-md-5 mb-4 admin-only">
+                <div class="card sistema-card h-100" onclick="window.location.href='/rateio/dashboard-rateio.html'">
+                    <div class="card-body text-center p-5">
+                        <div class="sistema-icon">
+                            <i class="fas fa-chart-pie"></i>
+                        </div>
+                        <h3 class="card-title">Controle de Rateio</h3>
+                        <p class="card-text">Gestão de horas e custos por instrutor e centro de custo.</p>
+                        <div class="mt-4">
+                            <span class="badge bg-success">Disponível</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,9 @@ from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.agendamento import agendamento_bp
 from src.routes.instrutor import instrutor_bp
+from src.routes.centro_custo import centro_custo_bp
+from src.routes.apontamento import apontamento_bp
+from src.routes.rateio import rateio_bp
 
 @pytest.fixture
 def app():
@@ -34,6 +37,9 @@ def app():
     app.register_blueprint(turma_bp, url_prefix='/api')
     app.register_blueprint(agendamento_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
+    app.register_blueprint(centro_custo_bp, url_prefix='/api')
+    app.register_blueprint(apontamento_bp, url_prefix='/api')
+    app.register_blueprint(rateio_bp, url_prefix='/api')
 
     with app.app_context():
         db.create_all()

--- a/tests/test_apontamento.py
+++ b/tests/test_apontamento.py
@@ -1,0 +1,32 @@
+from src.models.instrutor import Instrutor
+from src.models.centro_custo import CentroCusto
+from src.models.apontamento import Apontamento
+from src.models import db
+
+
+def test_criar_apontamento(client, app, login_admin):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    with app.app_context():
+        instrutor = Instrutor(nome='A')
+        instrutor.custo_hora = 10
+        db.session.add(instrutor)
+        centro = CentroCusto(nome='CC')
+        db.session.add(centro)
+        db.session.commit()
+        instrutor_id = instrutor.id
+        centro_id = centro.id
+
+    resp = client.post('/api/apontamentos', json={
+        'data': '2025-01-01',
+        'horas': 2,
+        'instrutor_id': instrutor_id,
+        'centro_custo_id': centro_id
+    }, headers=headers)
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data['valor_total'] == 20
+
+    resp = client.get('/api/apontamentos', headers=headers)
+    assert resp.status_code == 200
+

--- a/tests/test_centro_custo.py
+++ b/tests/test_centro_custo.py
@@ -1,0 +1,19 @@
+from src.models.centro_custo import CentroCusto
+
+
+def test_criar_listar_centro_custo(client, login_admin):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.post('/api/centros-custo', json={'nome': 'Projeto X'}, headers=headers)
+    assert resp.status_code == 201
+    cid = resp.get_json()['id']
+
+    resp = client.get('/api/centros-custo', headers=headers)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert any(c['id'] == cid for c in data)
+
+
+def test_centro_custo_non_admin_forbidden(client, non_admin_auth_headers):
+    resp = client.post('/api/centros-custo', json={'nome': 'P'}, headers=non_admin_auth_headers)
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- create models CentroCusto and Apontamento
- expose new API routes for CentroCusto, Apontamento and financial report
- add `custo_hora` to Instrutor model
- integrate new blueprints in application factory
- add rateio pages and navigation links
- add tests for new endpoints

## Testing
- `pip install pyjwt`
- `pip install flask`
- `pip install flask_sqlalchemy`
- `pip install Flask-Limiter`
- `pip install redis`
- `pip install requests`
- `pip install pydantic`
- `pip install 'pydantic[email]'`
- `pip install openpyxl`
- `pip install reportlab`
- `pytest tests/test_apontamento.py::test_criar_apontamento -q`
- `pytest -q`
- `flask db migrate -m "Adiciona modelos de centro de custo e apontamento" && flask db upgrade` *(fails: bash: command not found: flask)*

------
https://chatgpt.com/codex/tasks/task_e_6871b04fad8c8323a76e026700b197aa