### PR TITLE
Implement Controle de Rateio de Instrutores module

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from src.routes.ocupacao import ocupacao_bp
 from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.user import user_bp
+from src.routes.rateio import rateio_bp
 from src.models.recurso import Recurso
 
 migrate = Migrate()
@@ -111,6 +112,7 @@ def create_app():
     app.register_blueprint(sala_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
+    app.register_blueprint(rateio_bp, url_prefix='/api')
 
     @app.route('/')
     def index():

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -6,10 +6,14 @@ db = SQLAlchemy()
 from .refresh_token import RefreshToken  # noqa: E402
 from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
+from .rateio_parametro import RateioParametro  # noqa: E402
+from .rateio_lancamento import RateioLancamento  # noqa: E402
 
 __all__ = [
     "db",
     "RefreshToken",
     "Recurso",
     "AuditLog",
+    "RateioParametro",
+    "RateioLancamento",
 ]

--- a/src/models/rateio_lancamento.py
+++ b/src/models/rateio_lancamento.py
@@ -1,0 +1,49 @@
+"""Modelo de lançamentos de rateio."""
+from datetime import datetime, date
+from src.models import db
+
+class RateioLancamento(db.Model):
+    """Lançamentos mensais por instrutor."""
+    __tablename__ = 'rateio_lancamentos'
+    __table_args__ = (db.UniqueConstraint('instrutor_id', 'mes', 'ano', name='uix_instrutor_mes_ano'),)
+
+    id = db.Column(db.Integer, primary_key=True)
+    instrutor_id = db.Column(db.Integer, db.ForeignKey('instrutores.id'), nullable=False)
+    parametro_id = db.Column(db.Integer, db.ForeignKey('rateio_parametros.id'), nullable=False)
+    data_referencia = db.Column(db.Date, nullable=False)
+    mes = db.Column(db.Integer, nullable=False)
+    ano = db.Column(db.Integer, nullable=False)
+    valor_total = db.Column(db.Float, nullable=False)
+    horas_trabalhadas = db.Column(db.Float, nullable=False)
+    observacoes = db.Column(db.Text)
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+    data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    parametro = db.relationship('RateioParametro', backref='lancamentos')
+
+    def __init__(self, instrutor_id, parametro_id, data_referencia, valor_total, horas_trabalhadas, observacoes=None):
+        self.instrutor_id = instrutor_id
+        self.parametro_id = parametro_id
+        if isinstance(data_referencia, str):
+            data_referencia = datetime.strptime(data_referencia, '%Y-%m-%d').date()
+        self.data_referencia = data_referencia
+        self.mes = data_referencia.month
+        self.ano = data_referencia.year
+        self.valor_total = valor_total
+        self.horas_trabalhadas = horas_trabalhadas
+        self.observacoes = observacoes
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'instrutor_id': self.instrutor_id,
+            'parametro_id': self.parametro_id,
+            'data_referencia': self.data_referencia.isoformat(),
+            'mes': self.mes,
+            'ano': self.ano,
+            'valor_total': self.valor_total,
+            'horas_trabalhadas': self.horas_trabalhadas,
+            'observacoes': self.observacoes,
+            'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
+            'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None,
+        }

--- a/src/models/rateio_parametro.py
+++ b/src/models/rateio_parametro.py
@@ -1,0 +1,26 @@
+"""Modelo de parâmetros de rateio."""
+from datetime import datetime
+from src.models import db
+
+class RateioParametro(db.Model):
+    """Parâmetros para cálculo de rateio de instrutores."""
+    __tablename__ = 'rateio_parametros'
+
+    id = db.Column(db.Integer, primary_key=True)
+    filial = db.Column(db.String(100), nullable=False)
+    uo = db.Column(db.String(100), nullable=False)
+    cr = db.Column(db.String(50), nullable=False)
+    classe_valor = db.Column(db.String(100), nullable=False)
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+    data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'filial': self.filial,
+            'uo': self.uo,
+            'cr': self.cr,
+            'classe_valor': self.classe_valor,
+            'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
+            'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None,
+        }

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -12,7 +12,7 @@ class User(db.Model):
         nome (str): Nome completo do usuário
         email (str): Email do usuário (único)
         senha_hash (str): Hash da senha do usuário
-        tipo (str): Tipo de usuário ('comum' ou 'admin')
+        tipo (str): Tipo de usuário ('comum', 'financeiro' ou 'admin')
         data_criacao (datetime): Data de criação do registro
         data_atualizacao (datetime): Data da última atualização do registro
     """
@@ -37,7 +37,7 @@ class User(db.Model):
             nome (str): Nome completo do usuário
             email (str): Email do usuário
             senha (str): Senha do usuário (será armazenada como hash)
-            tipo (str, opcional): Tipo de usuário ('comum' ou 'admin'). Padrão é 'comum'.
+            tipo (str, opcional): Tipo de usuário ('comum', 'financeiro' ou 'admin'). Padrão é 'comum'.
         """
         self.nome = nome
         self.email = email

--- a/src/routes/rateio.py
+++ b/src/routes/rateio.py
@@ -1,0 +1,225 @@
+"""Rotas para controle de rateio de instrutores."""
+from flask import Blueprint, request, jsonify
+from sqlalchemy.exc import SQLAlchemyError
+from datetime import datetime
+
+from src.models import db
+from src.models.rateio_parametro import RateioParametro
+from src.models.rateio_lancamento import RateioLancamento
+from src.models.instrutor import Instrutor
+from src.routes.user import verificar_autenticacao
+from src.utils.error_handler import handle_internal_error
+from src.schemas import (
+    RateioParametroCreateSchema,
+    RateioParametroUpdateSchema,
+    RateioLancamentoCreateSchema,
+    RateioLancamentoUpdateSchema,
+)
+from pydantic import ValidationError
+
+rateio_bp = Blueprint('rateio', __name__)
+
+
+def has_finance_permission(user):
+    return user is not None and user.tipo in ['admin', 'financeiro']
+
+
+@rateio_bp.route('/rateio/parametros', methods=['GET'])
+def listar_parametros():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not has_finance_permission(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+
+    params = RateioParametro.query.order_by(RateioParametro.id).all()
+    return jsonify([p.to_dict() for p in params])
+
+
+@rateio_bp.route('/rateio/parametros', methods=['POST'])
+def criar_parametro():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not has_finance_permission(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    data = request.json or {}
+    try:
+        payload = RateioParametroCreateSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+    try:
+        param = RateioParametro(
+            filial=payload.filial,
+            uo=payload.uo,
+            cr=payload.cr,
+            classe_valor=payload.classe_valor,
+        )
+        db.session.add(param)
+        db.session.commit()
+        return jsonify(param.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@rateio_bp.route('/rateio/parametros/<int:id>', methods=['PUT'])
+def atualizar_parametro(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not has_finance_permission(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    param = db.session.get(RateioParametro, id)
+    if not param:
+        return jsonify({'erro': 'Parâmetro não encontrado'}), 404
+    data = request.json or {}
+    try:
+        payload = RateioParametroUpdateSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+    if payload.filial is not None:
+        param.filial = payload.filial
+    if payload.uo is not None:
+        param.uo = payload.uo
+    if payload.cr is not None:
+        param.cr = payload.cr
+    if payload.classe_valor is not None:
+        param.classe_valor = payload.classe_valor
+    try:
+        db.session.commit()
+        return jsonify(param.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@rateio_bp.route('/rateio/parametros/<int:id>', methods=['DELETE'])
+def remover_parametro(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not has_finance_permission(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    param = db.session.get(RateioParametro, id)
+    if not param:
+        return jsonify({'erro': 'Parâmetro não encontrado'}), 404
+    try:
+        db.session.delete(param)
+        db.session.commit()
+        return jsonify({'mensagem': 'Parâmetro removido'})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@rateio_bp.route('/rateio/lancamentos', methods=['GET'])
+def listar_lancamentos():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not has_finance_permission(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    instrutor_id = request.args.get('instrutor_id', type=int)
+    mes = request.args.get('mes', type=int)
+    ano = request.args.get('ano', type=int)
+    query = RateioLancamento.query
+    if instrutor_id:
+        query = query.filter(RateioLancamento.instrutor_id == instrutor_id)
+    if mes:
+        query = query.filter(RateioLancamento.mes == mes)
+    if ano:
+        query = query.filter(RateioLancamento.ano == ano)
+    lancamentos = query.order_by(RateioLancamento.data_referencia).all()
+    return jsonify([l.to_dict() for l in lancamentos])
+
+
+@rateio_bp.route('/rateio/lancamentos', methods=['POST'])
+def criar_lancamento():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not has_finance_permission(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    data = request.json or {}
+    try:
+        payload = RateioLancamentoCreateSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+    existe = RateioLancamento.query.filter_by(
+        instrutor_id=payload.instrutor_id,
+        mes=datetime.strptime(payload.data_referencia, '%Y-%m-%d').month,
+        ano=datetime.strptime(payload.data_referencia, '%Y-%m-%d').year,
+    ).first()
+    if existe:
+        return jsonify({'erro': 'Lançamento já existe para este instrutor e mês'}), 400
+    try:
+        lanc = RateioLancamento(
+            instrutor_id=payload.instrutor_id,
+            parametro_id=payload.parametro_id,
+            data_referencia=payload.data_referencia,
+            valor_total=payload.valor_total,
+            horas_trabalhadas=payload.horas_trabalhadas,
+            observacoes=payload.observacoes,
+        )
+        db.session.add(lanc)
+        db.session.commit()
+        return jsonify(lanc.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@rateio_bp.route('/rateio/lancamentos/<int:id>', methods=['PUT'])
+def atualizar_lancamento(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not has_finance_permission(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    lanc = db.session.get(RateioLancamento, id)
+    if not lanc:
+        return jsonify({'erro': 'Lançamento não encontrado'}), 404
+    data = request.json or {}
+    try:
+        payload = RateioLancamentoUpdateSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+    if payload.parametro_id is not None:
+        lanc.parametro_id = payload.parametro_id
+    if payload.data_referencia is not None:
+        data_ref = datetime.strptime(payload.data_referencia, '%Y-%m-%d').date()
+        lanc.data_referencia = data_ref
+        lanc.mes = data_ref.month
+        lanc.ano = data_ref.year
+    if payload.valor_total is not None:
+        lanc.valor_total = payload.valor_total
+    if payload.horas_trabalhadas is not None:
+        lanc.horas_trabalhadas = payload.horas_trabalhadas
+    if payload.observacoes is not None:
+        lanc.observacoes = payload.observacoes
+    try:
+        db.session.commit()
+        return jsonify(lanc.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@rateio_bp.route('/rateio/lancamentos/<int:id>', methods=['DELETE'])
+def remover_lancamento(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not has_finance_permission(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    lanc = db.session.get(RateioLancamento, id)
+    if not lanc:
+        return jsonify({'erro': 'Lançamento não encontrado'}), 404
+    try:
+        db.session.delete(lanc)
+        db.session.commit()
+        return jsonify({'mensagem': 'Lançamento removido'})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -212,7 +212,7 @@ def atualizar_usuario(id):
     
     # Apenas administradores podem alterar o tipo de usuário
     if 'tipo' in data and verificar_admin(user):
-        if data['tipo'] not in ['comum', 'admin']:
+        if data['tipo'] not in ['comum', 'admin', 'financeiro']:
             return jsonify({'erro': 'Tipo de usuário inválido'}), 400
 
         novo_tipo = data['tipo']

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,9 +1,17 @@
 from .sala import SalaCreateSchema, SalaUpdateSchema
 from .instrutor import InstrutorCreateSchema, InstrutorUpdateSchema
 from .ocupacao import OcupacaoCreateSchema, OcupacaoUpdateSchema
+from .rateio import (
+    RateioParametroCreateSchema,
+    RateioParametroUpdateSchema,
+    RateioLancamentoCreateSchema,
+    RateioLancamentoUpdateSchema,
+)
 
 __all__ = [
     'SalaCreateSchema', 'SalaUpdateSchema',
     'InstrutorCreateSchema', 'InstrutorUpdateSchema',
     'OcupacaoCreateSchema', 'OcupacaoUpdateSchema',
+    'RateioParametroCreateSchema', 'RateioParametroUpdateSchema',
+    'RateioLancamentoCreateSchema', 'RateioLancamentoUpdateSchema',
 ]

--- a/src/schemas/rateio.py
+++ b/src/schemas/rateio.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class RateioParametroCreateSchema(BaseModel):
+    filial: str
+    uo: str
+    cr: str
+    classe_valor: str
+
+
+class RateioParametroUpdateSchema(BaseModel):
+    filial: Optional[str] = None
+    uo: Optional[str] = None
+    cr: Optional[str] = None
+    classe_valor: Optional[str] = None
+
+
+class RateioLancamentoCreateSchema(BaseModel):
+    instrutor_id: int
+    parametro_id: int
+    data_referencia: str
+    valor_total: float
+    horas_trabalhadas: float
+    observacoes: Optional[str] = None
+
+
+class RateioLancamentoUpdateSchema(BaseModel):
+    parametro_id: Optional[int] = None
+    data_referencia: Optional[str] = None
+    valor_total: Optional[float] = None
+    horas_trabalhadas: Optional[float] = None
+    observacoes: Optional[str] = None

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -45,6 +45,7 @@ async function realizarLogin(email, senha, recaptchaToken = '') {
                 // Armazena os dados do usuário no localStorage
                 localStorage.setItem('usuario', JSON.stringify(data.usuario));
                 localStorage.setItem('isAdmin', data.usuario.tipo === 'admin');
+                localStorage.setItem('isFinanceiro', data.usuario.tipo === 'financeiro');
 
                 // Após o login, redireciona sempre para a página de seleção de sistema
                 window.location.href = '/selecao-sistema.html';
@@ -109,8 +110,17 @@ function isAdmin() {
     return usuario && usuario.tipo === 'admin';
 }
 
+function isFinanceiro() {
+    const usuario = getUsuarioLogado();
+    return usuario && usuario.tipo === 'financeiro';
+}
+
 function isUserAdmin() {
     return localStorage.getItem('isAdmin') === 'true';
+}
+
+function isUserFinanceiro() {
+    return localStorage.getItem('isFinanceiro') === 'true';
 }
 
 // Função para ajustar a visibilidade dos elementos com base no papel do usuário

--- a/src/static/js/rateio.js
+++ b/src/static/js/rateio.js
@@ -1,0 +1,123 @@
+class RateioParametros {
+    constructor() {
+        this.tabelaBody = document.getElementById('tabelaParametros');
+        const form = document.getElementById('formParametro');
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.salvar();
+        });
+        this.carregar();
+    }
+
+    async carregar() {
+        try {
+            const lista = await chamarAPI('/rateio/parametros');
+            this.tabelaBody.innerHTML = '';
+            lista.forEach(p => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${escapeHTML(p.filial)}</td><td>${escapeHTML(p.uo)}</td><td>${escapeHTML(p.cr)}</td><td>${escapeHTML(p.classe_valor)}</td>`;
+                this.tabelaBody.appendChild(tr);
+            });
+        } catch (e) {
+            exibirAlerta('Erro ao carregar parâmetros', 'danger');
+        }
+    }
+
+    async salvar() {
+        const dados = {
+            filial: document.getElementById('paramFilial').value,
+            uo: document.getElementById('paramUo').value,
+            cr: document.getElementById('paramCr').value,
+            classe_valor: document.getElementById('paramClasse').value
+        };
+        try {
+            await chamarAPI('/rateio/parametros', 'POST', dados);
+            exibirAlerta('Parâmetro salvo', 'success');
+            document.getElementById('formParametro').reset();
+            this.carregar();
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+}
+
+class RateioLancamentos {
+    constructor() {
+        this.instrutorSelect = document.getElementById('selectInstrutor');
+        this.tabelaBody = document.getElementById('tabelaLancamentos');
+        this.mesSelecionado = null;
+        document.querySelectorAll('.mes-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                this.mesSelecionado = parseInt(btn.dataset.mes);
+                this.carregar();
+            });
+        });
+        document.getElementById('formLancamento').addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.salvar();
+        });
+        this.carregarInstrutores();
+    }
+
+    async carregarInstrutores() {
+        try {
+            const insts = await chamarAPI('/instrutores');
+            this.instrutorSelect.innerHTML = '<option value="">Selecione</option>';
+            insts.forEach(i => {
+                const opt = document.createElement('option');
+                opt.value = i.id;
+                opt.textContent = i.nome;
+                this.instrutorSelect.appendChild(opt);
+            });
+        } catch {
+            exibirAlerta('Erro ao carregar instrutores', 'danger');
+        }
+    }
+
+    async carregar() {
+        const instrutorId = this.instrutorSelect.value;
+        if (!instrutorId || !this.mesSelecionado) return;
+        const ano = new Date().getFullYear();
+        try {
+            const lancs = await chamarAPI(`/rateio/lancamentos?instrutor_id=${instrutorId}&mes=${this.mesSelecionado}&ano=${ano}`);
+            this.tabelaBody.innerHTML = '';
+            lancs.forEach(l => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${l.data_referencia}</td><td>${l.valor_total}</td><td>${l.horas_trabalhadas}</td><td>${escapeHTML(l.observacoes||'')}</td>`;
+                this.tabelaBody.appendChild(tr);
+            });
+        } catch {
+            exibirAlerta('Erro ao carregar lançamentos', 'danger');
+        }
+    }
+
+    async salvar() {
+        const instrutorId = this.instrutorSelect.value;
+        if (!instrutorId || !this.mesSelecionado) return;
+        const dados = {
+            instrutor_id: parseInt(instrutorId),
+            parametro_id: parseInt(document.getElementById('lancParametro').value),
+            data_referencia: document.getElementById('lancData').value,
+            valor_total: parseFloat(document.getElementById('lancValor').value),
+            horas_trabalhadas: parseFloat(document.getElementById('lancHoras').value),
+            observacoes: document.getElementById('lancObs').value
+        };
+        try {
+            await chamarAPI('/rateio/lancamentos', 'POST', dados);
+            exibirAlerta('Lançamento salvo', 'success');
+            document.getElementById('formLancamento').reset();
+            this.carregar();
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('formParametro')) {
+        new RateioParametros();
+    }
+    if (document.getElementById('formLancamento')) {
+        new RateioLancamentos();
+    }
+});

--- a/src/static/rateio-cadastro.html
+++ b/src/static/rateio-cadastro.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cadastro de Parâmetros de Rateio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="/selecao-sistema.html">Controle de Rateio</a>
+        </div>
+    </nav>
+    <div class="container mt-4">
+        <div class="card mb-4">
+            <div class="card-header"><strong>Novo Parâmetro</strong></div>
+            <div class="card-body">
+                <form id="formParametro">
+                    <div class="row g-3">
+                        <div class="col-md-3"><input id="paramFilial" class="form-control" placeholder="Filial" required></div>
+                        <div class="col-md-3"><input id="paramUo" class="form-control" placeholder="UO" required></div>
+                        <div class="col-md-3"><input id="paramCr" class="form-control" placeholder="CR" required></div>
+                        <div class="col-md-3"><input id="paramClasse" class="form-control" placeholder="Classe de Valor" required></div>
+                    </div>
+                    <div class="mt-3"><button class="btn btn-primary" type="submit">Salvar</button></div>
+                </form>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header"><strong>Parâmetros Cadastrados</strong></div>
+            <div class="card-body p-0">
+                <table class="table mb-0">
+                    <thead><tr><th>Filial</th><th>UO</th><th>CR</th><th>Classe</th></tr></thead>
+                    <tbody id="tabelaParametros"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/rateio.js"></script>
+</body>
+</html>

--- a/src/static/rateio-lancamentos.html
+++ b/src/static/rateio-lancamentos.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lançamentos de Rateio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="/selecao-sistema.html">Controle de Rateio</a>
+        </div>
+    </nav>
+    <div class="container mt-4">
+        <div class="mb-3">
+            <label class="form-label">Instrutor</label>
+            <select id="selectInstrutor" class="form-select"></select>
+        </div>
+        <div class="d-flex gap-2 mb-3">
+            <button class="btn btn-outline-primary mes-btn" data-mes="1">Jan</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="2">Fev</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="3">Mar</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="4">Abr</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="5">Mai</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="6">Jun</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="7">Jul</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="8">Ago</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="9">Set</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="10">Out</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="11">Nov</button>
+            <button class="btn btn-outline-primary mes-btn" data-mes="12">Dez</button>
+        </div>
+        <div class="card mb-4">
+            <div class="card-header"><strong>Novo Lançamento</strong></div>
+            <div class="card-body">
+                <form id="formLancamento">
+                    <div class="row g-3">
+                        <div class="col-md-3"><input id="lancData" type="date" class="form-control" required></div>
+                        <div class="col-md-3"><input id="lancValor" type="number" step="0.01" class="form-control" placeholder="Valor" required></div>
+                        <div class="col-md-3"><input id="lancHoras" type="number" step="0.1" class="form-control" placeholder="Horas" required></div>
+                        <div class="col-md-3"><input id="lancParametro" type="number" class="form-control" placeholder="Centro de Custo" required></div>
+                    </div>
+                    <div class="row g-3 mt-2">
+                        <div class="col"><input id="lancObs" class="form-control" placeholder="Observações"></div>
+                    </div>
+                    <div class="mt-3"><button class="btn btn-primary" type="submit">Salvar Lançamento</button></div>
+                </form>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header"><strong>Lançamentos</strong></div>
+            <div class="card-body p-0">
+                <table class="table mb-0">
+                    <thead><tr><th>Data</th><th>Valor</th><th>Horas</th><th>Obs.</th></tr></thead>
+                    <tbody id="tabelaLancamentos"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/rateio.js"></script>
+</body>
+</html>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -63,7 +63,7 @@
                 </div>
             </div>
 
-            <div class="col-md-5 mb-4 admin-only">
+            <div class="col-md-5 mb-4 admin-only" onclick="window.location.href='/rateio-cadastro.html'">
                 <div class="card sistema-card h-100">
                     <div class="card-body text-center p-5">
                         <div class="sistema-icon">
@@ -72,7 +72,7 @@
                         <h3 class="card-title">Agenda de Treinamentos</h3>
                         <p class="card-text">Módulo para programação e gestão de treinamentos por área técnica.</p>
                         <div class="mt-4">
-                            <span class="badge" style="background-color: orange; color: white;">Em Desenvolvimento</span>
+                            <span class="badge bg-success">Disponível</span>
                         </div>
                     </div>
                 </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.agendamento import agendamento_bp
 from src.routes.instrutor import instrutor_bp
+from src.routes.rateio import rateio_bp
 
 @pytest.fixture
 def app():
@@ -34,6 +35,7 @@ def app():
     app.register_blueprint(turma_bp, url_prefix='/api')
     app.register_blueprint(agendamento_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
+    app.register_blueprint(rateio_bp, url_prefix='/api')
 
     with app.app_context():
         db.create_all()
@@ -51,6 +53,13 @@ def app():
             tipo='comum'
         )
         db.session.add(comum)
+        financeiro = User(
+            nome='Financeiro',
+            email='financeiro@example.com',
+            senha='Password1!',
+            tipo='financeiro'
+        )
+        db.session.add(financeiro)
         sala = Sala(nome='Sala Teste', capacidade=10)
         db.session.add(sala)
         db.session.commit()
@@ -79,6 +88,18 @@ def login_admin():
     def _login(client):
         with client.application.app_context():
             user = User.query.filter_by(email='admin@example.com').first()
+            token = gerar_token_acesso(user)
+            refresh = gerar_refresh_token(user)
+        return token, refresh
+
+    return _login
+
+
+@pytest.fixture
+def login_financeiro():
+    def _login(client):
+        with client.application.app_context():
+            user = User.query.filter_by(email='financeiro@example.com').first()
             token = gerar_token_acesso(user)
             refresh = gerar_refresh_token(user)
         return token, refresh

--- a/tests/test_rateio_routes.py
+++ b/tests/test_rateio_routes.py
@@ -1,0 +1,95 @@
+import jwt
+from datetime import datetime, timedelta
+from src.models.user import User
+
+
+def admin_headers(app):
+    with app.app_context():
+        user = User.query.filter_by(email='admin@example.com').first()
+        token = jwt.encode(
+            {
+                'user_id': user.id,
+                'nome': user.nome,
+                'perfil': user.tipo,
+                'exp': datetime.utcnow() + timedelta(hours=1),
+            },
+            app.config['SECRET_KEY'],
+            algorithm='HS256',
+        )
+        return {'Authorization': f'Bearer {token}'}
+
+
+def financeiro_headers(app):
+    with app.app_context():
+        user = User.query.filter_by(email='financeiro@example.com').first()
+        token = jwt.encode(
+            {
+                'user_id': user.id,
+                'nome': user.nome,
+                'perfil': user.tipo,
+                'exp': datetime.utcnow() + timedelta(hours=1),
+            },
+            app.config['SECRET_KEY'],
+            algorithm='HS256',
+        )
+        return {'Authorization': f'Bearer {token}'}
+
+
+def test_parametro_crud(client, app):
+    headers = admin_headers(app)
+    resp = client.post(
+        '/api/rateio/parametros',
+        json={'filial': 'F1', 'uo': 'U1', 'cr': 'CR1', 'classe_valor': 'A'},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    pid = resp.get_json()['id']
+
+    resp = client.get('/api/rateio/parametros', headers=headers)
+    assert resp.status_code == 200
+    assert any(p['id'] == pid for p in resp.get_json())
+
+    resp = client.put(
+        f'/api/rateio/parametros/{pid}',
+        json={'classe_valor': 'B'},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()['classe_valor'] == 'B'
+
+    resp = client.delete(f'/api/rateio/parametros/{pid}', headers=headers)
+    assert resp.status_code == 200
+
+
+def test_parametro_permission(client, app, non_admin_auth_headers):
+    resp = client.post(
+        '/api/rateio/parametros',
+        json={'filial': 'F1', 'uo': 'U1', 'cr': 'CR1', 'classe_valor': 'A'},
+        headers=non_admin_auth_headers,
+    )
+    assert resp.status_code == 403
+
+
+def test_lancamento_duplicate(client, app):
+    headers = admin_headers(app)
+    # create parametro and instrutor
+    p = client.post(
+        '/api/rateio/parametros',
+        json={'filial': 'F1', 'uo': 'U1', 'cr': 'CR1', 'classe_valor': 'A'},
+        headers=headers,
+    ).get_json()
+    inst_resp = client.post('/api/instrutores', json={'nome': 'Inst'}, headers=headers)
+    assert inst_resp.status_code == 201
+    instr_id = inst_resp.get_json()['id']
+
+    data = {
+        'instrutor_id': instr_id,
+        'parametro_id': p['id'],
+        'data_referencia': '2024-05-10',
+        'valor_total': 100.0,
+        'horas_trabalhadas': 10.0,
+    }
+    r1 = client.post('/api/rateio/lancamentos', json=data, headers=headers)
+    assert r1.status_code == 201
+    r2 = client.post('/api/rateio/lancamentos', json=data, headers=headers)
+    assert r2.status_code == 400


### PR DESCRIPTION
## Summary
- add models for rateio parameters and launches
- add endpoints for rateio management
- allow financeiro user type
- add rateio frontend pages and JS
- update selection page to enable rateio module
- extend tests for rateio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a9aee6948323a358c15eb6dfd670