### PR TITLE
Add Controle de Rateio module

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from src.routes.ocupacao import ocupacao_bp
 from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.user import user_bp
+from src.routes.rateio import rateio_bp
 from src.models.recurso import Recurso
 
 migrate = Migrate()
@@ -111,6 +112,7 @@ def create_app():
     app.register_blueprint(sala_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
+    app.register_blueprint(rateio_bp, url_prefix='/api')
 
     @app.route('/')
     def index():

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -6,10 +6,13 @@ db = SQLAlchemy()
 from .refresh_token import RefreshToken  # noqa: E402
 from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
+from .rateio import RateioConfig, LancamentoRateio  # noqa: E402
 
 __all__ = [
     "db",
     "RefreshToken",
     "Recurso",
     "AuditLog",
+    "RateioConfig",
+    "LancamentoRateio",
 ]

--- a/src/models/rateio.py
+++ b/src/models/rateio.py
@@ -1,0 +1,54 @@
+from src.models import db
+from datetime import datetime
+
+class RateioConfig(db.Model):
+    """Modelo para armazenar as configuracoes de rateio."""
+    __tablename__ = 'rateio_configs'
+
+    id = db.Column(db.Integer, primary_key=True)
+    filial = db.Column(db.String(100), nullable=False)
+    uo = db.Column('unidade_organizacional', db.String(100), nullable=False)
+    cr = db.Column('centro_resultado', db.String(100), nullable=False)
+    classe_valor = db.Column(db.String(100), nullable=False)
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        db.UniqueConstraint('filial', 'unidade_organizacional', 'centro_resultado', 'classe_valor', name='_rateio_config_uc'),
+    )
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'filial': self.filial,
+            'uo': self.uo,
+            'cr': self.cr,
+            'classe_valor': self.classe_valor,
+            'descricao': f"{self.filial} | {self.uo} | {self.cr} | {self.classe_valor}",
+        }
+
+class LancamentoRateio(db.Model):
+    """Modelo para os lancamentos de rateio mensais por instrutor."""
+    __tablename__ = 'lancamentos_rateio'
+
+    id = db.Column(db.Integer, primary_key=True)
+    instrutor_id = db.Column(db.Integer, db.ForeignKey('instrutores.id'), nullable=False, index=True)
+    mes = db.Column(db.Integer, nullable=False)
+    ano = db.Column(db.Integer, nullable=False)
+    rateio_config_id = db.Column(db.Integer, db.ForeignKey('rateio_configs.id'), nullable=False)
+    percentual = db.Column(db.Float, nullable=False)
+
+    instrutor = db.relationship('Instrutor', backref='lancamentos_rateio')
+    rateio_config = db.relationship('RateioConfig', backref='lancamentos')
+
+    __table_args__ = (db.Index('ix_lancamento_instrutor_periodo', 'instrutor_id', 'ano', 'mes'),)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'instrutor_id': self.instrutor_id,
+            'mes': self.mes,
+            'ano': self.ano,
+            'rateio_config_id': self.rateio_config_id,
+            'percentual': self.percentual,
+            'rateio_config': self.rateio_config.to_dict() if self.rateio_config else None,
+        }

--- a/src/routes/rateio.py
+++ b/src/routes/rateio.py
@@ -1,0 +1,106 @@
+from flask import Blueprint, request, jsonify
+from sqlalchemy.exc import IntegrityError
+from src.models import db
+from src.models.rateio import RateioConfig, LancamentoRateio
+from src.auth import admin_required
+from src.utils.error_handler import handle_internal_error
+from src.schemas import RateioConfigCreateSchema, LancamentoRateioSchema
+from pydantic import ValidationError
+
+rateio_bp = Blueprint('rateio', __name__)
+
+
+@rateio_bp.route('/rateio-configs', methods=['GET'])
+@admin_required
+def listar_configs():
+    configs = RateioConfig.query.order_by(RateioConfig.filial, RateioConfig.uo).all()
+    return jsonify([c.to_dict() for c in configs])
+
+
+@rateio_bp.route('/rateio-configs', methods=['POST'])
+@admin_required
+def criar_config():
+    data = request.json or {}
+    try:
+        payload = RateioConfigCreateSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+
+    try:
+        nova_config = RateioConfig(**payload.model_dump())
+        db.session.add(nova_config)
+        db.session.commit()
+        return jsonify(nova_config.to_dict()), 201
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({'erro': 'Esta configuração de rateio já existe.'}), 409
+    except Exception as e:  # pragma: no cover - proteção extra
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@rateio_bp.route('/rateio-configs/<int:id>', methods=['DELETE'])
+@admin_required
+def deletar_config(id):
+    config = db.session.get(RateioConfig, id)
+    if not config:
+        return jsonify({'erro': 'Configuração não encontrada'}), 404
+
+    if LancamentoRateio.query.filter_by(rateio_config_id=id).first():
+        return jsonify({'erro': 'Configuração em uso, não pode ser excluída.'}), 400
+
+    db.session.delete(config)
+    db.session.commit()
+    return jsonify({'mensagem': 'Configuração excluída com sucesso'})
+
+
+@rateio_bp.route('/rateio/lancamentos', methods=['GET'])
+@admin_required
+def get_lancamentos():
+    instrutor_id = request.args.get('instrutor_id', type=int)
+    ano = request.args.get('ano', type=int)
+    mes = request.args.get('mes', type=int)
+
+    if not all([instrutor_id, ano, mes]):
+        return jsonify({'erro': 'Parâmetros instrutor_id, ano e mes são obrigatórios'}), 400
+
+    lancamentos = LancamentoRateio.query.filter_by(
+        instrutor_id=instrutor_id, ano=ano, mes=mes
+    ).all()
+
+    return jsonify([l.to_dict() for l in lancamentos])
+
+
+@rateio_bp.route('/rateio/lancamentos', methods=['POST'])
+@admin_required
+def salvar_lancamentos():
+    data = request.json or {}
+    try:
+        payload = LancamentoRateioSchema(**data)
+    except ValidationError as e:
+        return jsonify({'erro': e.errors()}), 400
+
+    total_percentual = sum(item.percentual for item in payload.lancamentos)
+    if total_percentual > 100:
+        return jsonify({'erro': f'O percentual total ({total_percentual}%) não pode exceder 100%.'}), 400
+
+    try:
+        LancamentoRateio.query.filter_by(instrutor_id=payload.instrutor_id, ano=payload.ano, mes=payload.mes).delete()
+
+        novos = []
+        for item in payload.lancamentos:
+            if item.percentual > 0:
+                novo = LancamentoRateio(
+                    instrutor_id=payload.instrutor_id,
+                    ano=payload.ano,
+                    mes=payload.mes,
+                    rateio_config_id=item.rateio_config_id,
+                    percentual=item.percentual,
+                )
+                novos.append(novo)
+        db.session.add_all(novos)
+        db.session.commit()
+        return jsonify({'mensagem': 'Lançamentos salvos com sucesso!'}), 201
+    except Exception as e:  # pragma: no cover - segurança
+        db.session.rollback()
+        return handle_internal_error(e)

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,9 +1,11 @@
 from .sala import SalaCreateSchema, SalaUpdateSchema
 from .instrutor import InstrutorCreateSchema, InstrutorUpdateSchema
 from .ocupacao import OcupacaoCreateSchema, OcupacaoUpdateSchema
+from .rateio import RateioConfigCreateSchema, LancamentoRateioSchema
 
 __all__ = [
     'SalaCreateSchema', 'SalaUpdateSchema',
     'InstrutorCreateSchema', 'InstrutorUpdateSchema',
     'OcupacaoCreateSchema', 'OcupacaoUpdateSchema',
+    'RateioConfigCreateSchema', 'LancamentoRateioSchema',
 ]

--- a/src/schemas/rateio.py
+++ b/src/schemas/rateio.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, Field
+from typing import List
+
+class RateioConfigCreateSchema(BaseModel):
+    filial: str
+    uo: str
+    cr: str
+    classe_valor: str
+
+class LancamentoItemSchema(BaseModel):
+    rateio_config_id: int
+    percentual: float = Field(gt=0)
+
+class LancamentoRateioSchema(BaseModel):
+    instrutor_id: int
+    ano: int
+    mes: int
+    lancamentos: List[LancamentoItemSchema]

--- a/src/static/js/rateio-config.js
+++ b/src/static/js/rateio-config.js
@@ -1,0 +1,67 @@
+class RateioConfigApp {
+    constructor() {
+        this.tableBody = document.getElementById('configsTableBody');
+        this.btnSalvar = document.getElementById('btnSalvarConfig');
+        this.modal = new bootstrap.Modal(document.getElementById('configModal'));
+        this.form = document.getElementById('configForm');
+        this.registrarEventos();
+        this.carregarConfigs();
+    }
+
+    registrarEventos() {
+        this.btnSalvar.addEventListener('click', () => this.salvar());
+    }
+
+    async carregarConfigs() {
+        try {
+            const configs = await chamarAPI('/rateio-configs');
+            this.tableBody.innerHTML = configs.map(c => `
+                <tr data-id="${c.id}">
+                    <td>${escapeHTML(c.filial)}</td>
+                    <td>${escapeHTML(c.uo)}</td>
+                    <td>${escapeHTML(c.cr)}</td>
+                    <td>${escapeHTML(c.classe_valor)}</td>
+                    <td><button class="btn btn-sm btn-danger btn-excluir" data-id="${c.id}"><i class="bi bi-trash"></i></button></td>
+                </tr>`).join('');
+            this.tableBody.querySelectorAll('.btn-excluir').forEach(btn => {
+                btn.addEventListener('click', (e) => this.excluir(e.currentTarget.dataset.id));
+            });
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+
+    async salvar() {
+        const data = {
+            filial: this.form.filial.value,
+            uo: this.form.uo.value,
+            cr: this.form.cr.value,
+            classe_valor: this.form.classe_valor.value
+        };
+        try {
+            await chamarAPI('/rateio-configs', 'POST', data);
+            this.modal.hide();
+            this.form.reset();
+            await this.carregarConfigs();
+            exibirAlerta('Configuração salva!', 'success');
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+
+    async excluir(id) {
+        if (!confirm('Excluir esta configuração?')) return;
+        try {
+            await chamarAPI(`/rateio-configs/${id}`, 'DELETE');
+            await this.carregarConfigs();
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    verificarAutenticacao();
+    verificarPermissaoAdmin();
+    new RateioConfigApp();
+});

--- a/src/static/js/rateio-instrutores.js
+++ b/src/static/js/rateio-instrutores.js
@@ -1,0 +1,225 @@
+class GerenciadorInstrutores {
+    constructor() {
+        this.instrutores = [];
+        this.instrutorAtual = null;
+        this.instrutorParaExcluir = null;
+
+        this.tabelaBody = document.getElementById('tabelaCorpoDocente');
+        this.btnAdicionar = document.getElementById('btnAdicionarNovo');
+        this.btnAplicarFiltros = document.getElementById('btnAplicarFiltros');
+        this.btnLimparFiltros = document.getElementById('btnLimparFiltros');
+        this.filtroNome = document.getElementById('filtroNome');
+        this.filtroStatus = document.getElementById('filtroStatus');
+        this.modalInstrutor = new bootstrap.Modal(document.getElementById('modalInstrutor'));
+        this.modalExcluir = new bootstrap.Modal(document.getElementById('modalExcluirInstrutor'));
+        this.form = document.getElementById('formInstrutor');
+        this.btnSalvar = document.getElementById('btnSalvarInstrutor');
+
+        this.registrarEventos();
+        this.carregarAreas();
+        this.carregarInstrutores();
+    }
+
+    registrarEventos() {
+        this.btnAdicionar.addEventListener('click', () => this.novoInstrutor());
+        if (this.btnAplicarFiltros) {
+            this.btnAplicarFiltros.addEventListener('click', () => this.aplicarFiltros());
+        }
+        if (this.btnLimparFiltros) {
+            this.btnLimparFiltros.addEventListener('click', () => this.limparFiltros());
+        }
+        this.form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.salvarInstrutor();
+        });
+        this.tabelaBody.addEventListener('click', (e) => {
+            const editBtn = e.target.closest('.btn-editar');
+            const delBtn = e.target.closest('.btn-excluir');
+            if (editBtn) {
+                const id = editBtn.closest('tr').dataset.id;
+                this.abrirEdicao(id);
+            }
+            if (delBtn) {
+                const row = delBtn.closest('tr');
+                const id = row.dataset.id;
+                const nome = row.querySelector('td').textContent.trim();
+                this.excluirInstrutor(id, nome);
+            }
+        });
+        document.getElementById('confirmarExcluirInstrutor')
+            .addEventListener('click', () => this.confirmarExclusao());
+    }
+
+    async carregarAreas() {
+        try {
+            const areas = await chamarAPI('/instrutores/areas-atuacao');
+            const select = document.getElementById('instrutorArea');
+            select.innerHTML = '<option value="">Selecione...</option>';
+            areas.forEach(a => {
+                const opt = document.createElement('option');
+                opt.value = a.valor;
+                opt.textContent = a.nome;
+                select.appendChild(opt);
+            });
+        } catch (e) {
+            console.error('Erro ao carregar áreas', e);
+        }
+    }
+
+
+
+    badgesDisponibilidade(list) {
+        const disp = list || [];
+        return `
+            <span class="badge ${disp.includes('manha') ? 'bg-success' : 'bg-light text-dark'}">M</span>
+            <span class="badge ${disp.includes('tarde') ? 'bg-success' : 'bg-light text-dark'}">T</span>
+            <span class="badge ${disp.includes('noite') ? 'bg-success' : 'bg-light text-dark'}">N</span>
+        `;
+    }
+
+    renderizarTabela(lista = this.instrutores) {
+        this.tabelaBody.innerHTML = '';
+        lista.forEach(inst => {
+            const row = document.createElement('tr');
+            row.dataset.id = inst.id;
+            row.innerHTML = `
+                <td><strong>${escapeHTML(inst.nome)}</strong><br><small class="text-muted">${escapeHTML(inst.email || '')}</small></td>
+                <td>${escapeHTML(inst.area_atuacao || '')}</td>
+                <td><span class="badge ${inst.status === 'ativo' ? 'bg-success' : 'bg-secondary'}">${inst.status}</span></td>
+                <td><div class="d-flex gap-1">${this.badgesDisponibilidade(inst.disponibilidade)}</div></td>
+                <td class="text-end">
+                    <button class="btn btn-sm btn-outline-primary btn-editar"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-sm btn-outline-danger btn-excluir"><i class="bi bi-trash"></i></button>
+                </td>`;
+            this.tabelaBody.appendChild(row);
+        });
+    }
+
+    async carregarInstrutores() {
+        try {
+            const dados = await chamarAPI('/instrutores');
+            this.instrutores = dados;
+            this.renderizarTabela();
+        } catch (err) {
+            exibirAlerta('Erro ao carregar instrutores', 'danger');
+        }
+    }
+
+    aplicarFiltros() {
+        const termo = (this.filtroNome.value || '').toLowerCase();
+        const status = this.filtroStatus.value;
+        const filtrados = this.instrutores.filter(i => {
+            const matchNome = i.nome.toLowerCase().includes(termo);
+            const matchStatus = !status || i.status === status;
+            return matchNome && matchStatus;
+        });
+        this.renderizarTabela(filtrados);
+    }
+
+    limparFiltros() {
+        if (this.filtroNome) this.filtroNome.value = '';
+        if (this.filtroStatus) this.filtroStatus.value = '';
+        this.renderizarTabela();
+    }
+
+    novoInstrutor() {
+        this.instrutorAtual = null;
+        this.form.reset();
+        document.getElementById('instrutorId').value = '';
+        document.getElementById('modalInstrutorLabel').textContent = 'Novo Instrutor';
+        this.btnSalvar.querySelector('.btn-text').textContent = 'Salvar';
+        this.modalInstrutor.show();
+    }
+
+    preencherFormulario(instr) {
+        document.getElementById('instrutorId').value = instr.id;
+        document.getElementById('instrutorNome').value = instr.nome || '';
+        document.getElementById('instrutorEmail').value = instr.email || '';
+        document.getElementById('instrutorArea').value = instr.area_atuacao || '';
+        document.getElementById('instrutorStatus').value = instr.status || 'ativo';
+        document.getElementById('instrutorObservacoes').value = instr.observacoes || '';
+
+
+        const disp = instr.disponibilidade || [];
+        document.getElementById('dispManha').checked = disp.includes('manha');
+        document.getElementById('dispTarde').checked = disp.includes('tarde');
+        document.getElementById('dispNoite').checked = disp.includes('noite');
+    }
+
+    async abrirEdicao(id) {
+        try {
+            const instrutor = await chamarAPI(`/instrutores/${id}`);
+            this.instrutorAtual = instrutor;
+            this.preencherFormulario(instrutor);
+            document.getElementById('modalInstrutorLabel').textContent = 'Editar Instrutor';
+            this.btnSalvar.querySelector('.btn-text').textContent = 'Atualizar';
+            this.modalInstrutor.show();
+        } catch (e) {
+            exibirAlerta('Erro ao carregar dados do instrutor', 'danger');
+        }
+    }
+
+    coletarFormData() {
+        const formData = {
+            nome: document.getElementById('instrutorNome').value.trim(),
+            email: document.getElementById('instrutorEmail').value.trim(),
+            area_atuacao: document.getElementById('instrutorArea').value,
+            status: document.getElementById('instrutorStatus').value,
+            observacoes: document.getElementById('instrutorObservacoes').value.trim(),
+            disponibilidade: []
+        };
+        if (document.getElementById('dispManha').checked) formData.disponibilidade.push('manha');
+        if (document.getElementById('dispTarde').checked) formData.disponibilidade.push('tarde');
+        if (document.getElementById('dispNoite').checked) formData.disponibilidade.push('noite');
+        return formData;
+    }
+
+    async salvarInstrutor() {
+        const dados = this.coletarFormData();
+        if (!dados.nome || !dados.email) {
+            exibirAlerta('Preencha nome e e-mail.', 'warning');
+            return;
+        }
+        const spinner = this.btnSalvar.querySelector('.spinner-border');
+        this.btnSalvar.disabled = true;
+        spinner.classList.remove('d-none');
+
+        const isEdicao = !!this.instrutorAtual;
+        const endpoint = isEdicao ? `/instrutores/${this.instrutorAtual.id}` : '/instrutores';
+        const method = isEdicao ? 'PUT' : 'POST';
+        try {
+            await chamarAPI(endpoint, method, dados);
+            exibirAlerta(`Instrutor ${isEdicao ? 'atualizado' : 'cadastrado'} com sucesso!`, 'success');
+            this.modalInstrutor.hide();
+            this.carregarInstrutores();
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        } finally {
+            this.btnSalvar.disabled = false;
+            spinner.classList.add('d-none');
+        }
+    }
+
+    excluirInstrutor(id, nome) {
+        this.instrutorParaExcluir = id;
+        document.getElementById('nomeInstrutorExcluir').textContent = nome;
+        this.modalExcluir.show();
+    }
+
+    async confirmarExclusao() {
+        try {
+            await chamarAPI(`/instrutores/${this.instrutorParaExcluir}`, 'DELETE');
+            exibirAlerta('Instrutor excluído com sucesso!', 'success');
+            this.modalExcluir.hide();
+            this.carregarInstrutores();
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    verificarAutenticacao();
+    verificarPermissaoAdmin();
+    window.gerenciadorInstrutores = new GerenciadorInstrutores();
+});

--- a/src/static/js/rateio-lancamentos.js
+++ b/src/static/js/rateio-lancamentos.js
@@ -1,0 +1,143 @@
+class LancamentosApp {
+    constructor() {
+        this.selectInstrutor = document.getElementById('selectInstrutor');
+        this.selectAno = document.getElementById('selectAno');
+        this.selectConfig = document.getElementById('selectConfig');
+        this.inputPercentual = document.getElementById('inputPercentual');
+        this.btnAdicionar = document.getElementById('btnAdicionarLancamento');
+        this.btnSalvar = document.getElementById('btnSalvarLancamentos');
+        this.mesesContainer = document.getElementById('mesesContainer');
+        this.mesesTimeline = document.getElementById('mesesTimeline');
+        this.areaLancamento = document.getElementById('areaLancamento');
+        this.lancamentosContainer = document.getElementById('lancamentosContainer');
+        this.tituloLancamento = document.getElementById('tituloLancamento');
+        this.totalPercentual = document.getElementById('totalPercentual');
+        this.mesAtual = null;
+        this.anoAtual = new Date().getFullYear();
+        this.registrarEventos();
+        this.carregarInstrutores();
+        this.preencherAnos();
+        this.carregarConfigs();
+    }
+
+    registrarEventos() {
+        this.selectAno.addEventListener('change', () => this.renderizarMeses());
+        this.selectInstrutor.addEventListener('change', () => this.renderizarMeses());
+        this.btnAdicionar.addEventListener('click', () => this.adicionarItem());
+        this.btnSalvar.addEventListener('click', () => this.salvar());
+    }
+
+    async carregarInstrutores() {
+        try {
+            const instrutores = await chamarAPI('/instrutores');
+            this.selectInstrutor.innerHTML = '<option value="">Selecione</option>' +
+                instrutores.map(i => `<option value="${i.id}">${escapeHTML(i.nome)}</option>`).join('');
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+
+    preencherAnos() {
+        const ano = new Date().getFullYear();
+        let options = '';
+        for (let a = ano - 1; a <= ano + 1; a++) {
+            options += `<option value="${a}" ${a === ano ? 'selected' : ''}>${a}</option>`;
+        }
+        this.selectAno.innerHTML = options;
+    }
+
+    async carregarConfigs() {
+        try {
+            const configs = await chamarAPI('/rateio-configs');
+            this.selectConfig.innerHTML = '<option value="">Selecione</option>' +
+                configs.map(c => `<option value="${c.id}">${escapeHTML(c.descricao)}</option>`).join('');
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+
+    renderizarMeses() {
+        const instrutorId = this.selectInstrutor.value;
+        if (!instrutorId) return;
+        this.mesesContainer.innerHTML = '';
+        for (let m = 1; m <= 12; m++) {
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-outline-secondary';
+            btn.textContent = m.toString().padStart(2, '0');
+            btn.addEventListener('click', () => this.carregarLancamentos(m));
+            this.mesesContainer.appendChild(btn);
+        }
+        this.mesesTimeline.style.display = 'block';
+    }
+
+    async carregarLancamentos(mes) {
+        this.mesAtual = mes;
+        const instrutorId = this.selectInstrutor.value;
+        const ano = parseInt(this.selectAno.value, 10);
+        this.tituloLancamento.textContent = `Lançamentos para ${mes.toString().padStart(2, '0')}/${ano}`;
+        try {
+            const lancamentos = await chamarAPI(`/rateio/lancamentos?instrutor_id=${instrutorId}&ano=${ano}&mes=${mes}`);
+            this.lancamentosContainer.innerHTML = '';
+            lancamentos.forEach(l => this.criarLinha(l));
+            this.atualizarTotal();
+            this.areaLancamento.style.display = 'block';
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+
+    criarLinha(lancamento) {
+        const div = document.createElement('div');
+        div.className = 'input-group mb-2';
+        div.dataset.id = lancamento.rateio_config_id;
+        div.innerHTML = `
+            <span class="input-group-text flex-grow-1">${escapeHTML(lancamento.rateio_config.descricao)}</span>
+            <input type="number" class="form-control percentual" value="${lancamento.percentual}" min="0" max="100">
+            <button class="btn btn-outline-danger btn-remover" type="button"><i class="bi bi-trash"></i></button>`;
+        div.querySelector('.btn-remover').addEventListener('click', () => {
+            div.remove();
+            this.atualizarTotal();
+        });
+        div.querySelector('.percentual').addEventListener('input', () => this.atualizarTotal());
+        this.lancamentosContainer.appendChild(div);
+    }
+
+    adicionarItem() {
+        const configId = this.selectConfig.value;
+        const percent = parseFloat(this.inputPercentual.value || '0');
+        if (!configId || percent <= 0) return;
+        const selected = this.selectConfig.selectedOptions[0].textContent;
+        this.criarLinha({ rateio_config_id: configId, percentual: percent, rateio_config: { descricao: selected } });
+        this.inputPercentual.value = '';
+        this.atualizarTotal();
+    }
+
+    atualizarTotal() {
+        const valores = Array.from(this.lancamentosContainer.querySelectorAll('.percentual')).map(i => parseFloat(i.value) || 0);
+        const total = valores.reduce((a, b) => a + b, 0);
+        this.totalPercentual.textContent = total.toFixed(2);
+    }
+
+    async salvar() {
+        const instrutorId = this.selectInstrutor.value;
+        const ano = parseInt(this.selectAno.value, 10);
+        const mes = this.mesAtual;
+        if (!instrutorId || !mes) return;
+        const lancamentos = Array.from(this.lancamentosContainer.children).map(div => ({
+            rateio_config_id: parseInt(div.dataset.id, 10),
+            percentual: parseFloat(div.querySelector('.percentual').value || '0')
+        }));
+        try {
+            await chamarAPI('/rateio/lancamentos', 'POST', { instrutor_id: parseInt(instrutorId, 10), ano, mes, lancamentos });
+            exibirAlerta('Lançamentos salvos!', 'success');
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+        }
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    verificarAutenticacao();
+    verificarPermissaoAdmin();
+    new LancamentosApp();
+});

--- a/src/static/rateio-config.html
+++ b/src/static/rateio-config.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Configurações de Rateio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text">Controle de Rateio</span>
+            </a>
+        </div>
+    </nav>
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-3 d-none d-lg-block">
+                <div class="sidebar rounded shadow-sm">
+                    <div class="nav flex-column">
+                        <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-list"></i> Lançamentos</a>
+                        <a class="nav-link active" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
+                        <a class="nav-link" href="/rateio-instrutores.html"><i class="bi bi-people"></i> Instrutores</a>
+                    </div>
+                </div>
+            </div>
+            <main class="col-lg-9 col-md-12">
+                <div class="page-header d-flex justify-content-between align-items-center">
+                    <h2 class="mb-0">Configurações de Rateio</h2>
+                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#configModal">
+                        <i class="bi bi-plus-circle me-2"></i>NOVA CONFIGURAÇÃO
+                    </button>
+                </div>
+                <div class="card mt-4">
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover">
+                                <thead>
+                                    <tr>
+                                        <th>Filial</th>
+                                        <th>UO</th>
+                                        <th>CR</th>
+                                        <th>Classe de Valor</th>
+                                        <th>Ações</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="configsTableBody"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <div class="modal fade" id="configModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Nova Configuração de Rateio</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="configForm">
+                        <div class="mb-3">
+                            <label for="filial" class="form-label">Filial</label>
+                            <input type="text" class="form-control" id="filial" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="uo" class="form-label">Unidade Organizacional (UO)</label>
+                            <input type="text" class="form-control" id="uo" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="cr" class="form-label">Centro de Resultado (CR)</label>
+                            <input type="text" class="form-control" id="cr" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="classe_valor" class="form-label">Classe de Valor</label>
+                            <input type="text" class="form-control" id="classe_valor" required>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" class="btn btn-primary" id="btnSalvarConfig">Salvar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/rateio-config.js"></script>
+</body>
+</html>

--- a/src/static/rateio-instrutores.html
+++ b/src/static/rateio-instrutores.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestão de Instrutores - Controle de Rateio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Exo+2:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAIEAYAAADIFSHsAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAAAAAAAAPlDu38AAAAHdElNRQfpBgoBOhQj05UdAAADXUlEQVRIx92UbUzUdQDHP7/73zXgyjs6uPA8Kg82BgyYFDLNbt1YuWkOcqvZow8V4pouXYLQA3OSTHCGBBtl6RuaY7nVKtwCshU2EQRbK7BJhweUHOw87gTugfv/f72IttYbhRe59Xn/3b6f74uvsFpdrqam4ccBIK2DWyGRSNAe1Y7LfFjblWdZcQg2VjjrHKcheGGmLFoJ39T19nuq4KX3ntyYHYLwZ9FCNRcGbEMlXiukD6c6zQegs7TH5KkG+6b7ku+RMFY08W1wC/gGAlnhT2B3y7PHVo3AYdtHLT0GKGzLed9mg5ncuReijXCuqzc02giKouwXO27Z/l/4A7oF8c23nYkSQwMiRInB6oac6uXLQHVp3fIcBI7MPhx5HlIqLenGHkh6LfF0wna4kj9S7/saPMnX+wIDkOlytFqC8MzVJ5SMPZC119FniQNzeNlQXB8U3MjOSimGla22kyYV8iYziqz1kLIjadSYD9Yf7+1NMIAMy0xZu1jxv0k0LQxA2W1ndAgEiCThEdXQ++LPRde3grt2fHw6G9JrUucSi8HhsP9iPgOaTyuWd4N6VkuTN0GdVN+UzeCd8uXOlsLkO/7yuQdgnWvVyhWfgjESHzQkgLPpodX29XBjbfBgeBBcwwVj91+Eu07pm3XNIDvp4dpSxf+ps0TkZvbJzyGp3DwSPw0Pltl2m0YhWj7/lrofpk74j83lQNgebYhtg5QSi874FTh+tX9grofAczOm6Hpo93b/4K6BkTf+qAiYYPm2JI8xH7xW31NzVdB6vH3voAKqqtZrJyE+M67SUACzVaEP59uBt0Upa5Y+gH7RCQN6dCDShE+8C2fN5yfcW+DS5cGLE3qIbpiv0Log2DZ7JPI6nM+8/N24EwwX9BVKEELd4bZYB3T6e8qvbYXgyzNfRrbDgZKGNd/ng9KiuMXHMF8Tq9X6YfrKzRMRJwxYhgq9jaBoSp2YgtChyCNqKihduoO6XQC8upQhxF8nKOWikwo6BMhLDDIB8ieZIMtBbGCdcAAdtPA0yC+kX+4E+hnCCxwV+3gMyCNDJIP4XXSwC3DJV2gDeZVR/CBcFJAKwi3a2QkyKrOpBfkbY0yDOMwenCDOiKMUA2EixP7LAf4nLHyAP3Cni9wZYp1/AkYRW5V0uSBfAAAAAElFTkSuQmCC">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Controle de Ocupação">Controle de Ocupação</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/dashboard-salas.html">
+                            <i class="bi bi-speedometer2 me-1"></i> Dashboard
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/calendario-salas.html">
+                            <i class="bi bi-calendar3 me-1"></i> Calendário
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link admin-only" href="/gerenciar-salas.html">
+                            <i class="fa-solid fa-door-open me-1"></i> Gerenciar Salas
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active admin-only" href="/rateio-instrutores.html">
+                            <i class="bi bi-person-badge me-1"></i> Corpo Docente
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link admin-only" href="/gerenciar-turmas.html">
+                            <i class="fa-solid fa-users-cog me-1"></i> Gerenciar Turmas
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link admin-only" href="/novo-agendamento-sala.html">
+                            <i class="bi bi-plus-circle me-1"></i> Nova Ocupação
+                        </a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-person-circle me-1"></i>
+                            <span id="userName">Usuário</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                            <li>
+                                <a class="dropdown-item" href="/perfil-salas.html">
+                                    <i class="bi bi-person me-2"></i>Meu Perfil
+                                </a>
+                            </li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <a class="dropdown-item" href="#" onclick="realizarLogout()">
+                                    <i class="bi bi-box-arrow-right me-2"></i>Sair
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-3 d-none d-lg-block">
+                <div class="sidebar rounded shadow-sm">
+                    <h5 class="mb-3">Menu Principal</h5>
+                    <div class="nav flex-column">
+                        <a class="nav-link" href="/dashboard-salas.html">
+                            <i class="bi bi-speedometer2"></i> Dashboard
+                        </a>
+                        <a class="nav-link" href="/calendario-salas.html">
+                            <i class="bi bi-calendar3"></i> Calendário
+                        </a>
+                        <a class="nav-link admin-only" href="/gerenciar-salas.html">
+                            <i class="fa-solid fa-door-open"></i> Gerenciar Salas
+                        </a>
+                        <a class="nav-link active admin-only" href="/rateio-instrutores.html">
+                            <i class="bi bi-person-badge"></i> Corpo Docente
+                        </a>
+                        <a class="nav-link admin-only" href="/gerenciar-turmas.html">
+                            <i class="fa-solid fa-users-cog"></i> Gerenciar Turmas
+                        </a>
+                        <a class="nav-link admin-only" href="/novo-agendamento-sala.html">
+                            <i class="bi bi-plus-circle"></i> Nova Ocupação
+                        </a>
+                        <a class="nav-link" href="/perfil-salas.html">
+                            <i class="bi bi-person"></i> Meu Perfil
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <main class="col-lg-9 col-md-12">
+                <div class="page-header">
+                    <h2 class="mb-0">Gestão de Instrutores</h2>
+                    <button id="btnAdicionarNovo" class="btn btn-primary">
+                        <i class="bi bi-plus-circle me-2"></i>NOVO INSTRUTOR
+                    </button>
+                </div>
+
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-3 align-items-end">
+                            <div class="col-md-4">
+                                <label for="filtroNome" class="form-label">Nome</label>
+                                <input type="text" class="form-control" id="filtroNome" placeholder="Nome do instrutor">
+                            </div>
+                            <div class="col-md-3">
+                                <label for="filtroStatus" class="form-label">Status</label>
+                                <select id="filtroStatus" class="form-select">
+                                    <option value="">Todos</option>
+                                    <option value="ativo">Ativo</option>
+                                    <option value="inativo">Inativo</option>
+                                </select>
+                            </div>
+                            <div class="col-md-5 text-end">
+                                <button id="btnAplicarFiltros" type="button" class="btn btn-primary me-2">
+                                    <i class="bi bi-search me-1"></i>Filtrar
+                                </button>
+                                <button id="btnLimparFiltros" type="button" class="btn btn-outline-secondary">
+                                    <i class="bi bi-x-circle me-1"></i>Limpar
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE INSTRUTORES</h5>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th scope="col">NOME</th>
+                                        <th scope="col">ÁREA DE ATUAÇÃO</th>
+                                        <th scope="col">STATUS</th>
+                                        <th scope="col">DISPONIBILIDADE</th>
+                                        <th scope="col" class="text-end">AÇÕES</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="tabelaCorpoDocente">
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <div class="modal fade" id="modalInstrutor" tabindex="-1" aria-labelledby="modalInstrutorLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="modalInstrutorLabel">Novo Instrutor</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="formInstrutor">
+                        <input type="hidden" id="instrutorId">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="instrutorNome" class="form-label">Nome *</label>
+                                    <input type="text" class="form-control" id="instrutorNome" required>
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="instrutorEmail" class="form-label">E-mail *</label>
+                                    <input type="email" class="form-control" id="instrutorEmail" required>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <div class="mb-3">
+                                    <label for="instrutorArea" class="form-label">Área de Atuação *</label>
+                                    <select class="form-select" id="instrutorArea" required></select>
+                                </div>
+                            </div>
+                            <div class="col-md-3">
+                                <div class="mb-3">
+                                    <label for="instrutorStatus" class="form-label">Status</label>
+                                    <select class="form-select" id="instrutorStatus">
+                                        <option value="ativo">Ativo</option>
+                                        <option value="inativo">Inativo</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="instrutorObservacoes" class="form-label">Observações</label>
+                            <textarea class="form-control" id="instrutorObservacoes" rows="3"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Disponibilidade</label>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" id="dispManha" value="manha">
+                                <label class="form-check-label" for="dispManha">M</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" id="dispTarde" value="tarde">
+                                <label class="form-check-label" for="dispTarde">T</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" id="dispNoite" value="noite">
+                                <label class="form-check-label" for="dispNoite">N</label>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" form="formInstrutor" class="btn btn-primary" id="btnSalvarInstrutor">
+                        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                        <span class="btn-text"><i class="bi bi-check-circle me-1"></i>Salvar</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="modalExcluirInstrutor" tabindex="-1" aria-labelledby="modalExcluirInstrutorLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="modalExcluirInstrutorLabel">Confirmar Exclusão</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Tem certeza que deseja excluir o instrutor <strong id="nomeInstrutorExcluir"></strong>?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" id="confirmarExcluirInstrutor" class="btn btn-danger">
+                        <i class="bi bi-trash me-1"></i>Excluir
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/rateio-instrutores.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            if (!isUserAdmin()) {
+                document.body.classList.add('read-only');
+            }
+        });
+    </script>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
+</body>
+</html>

--- a/src/static/rateio-lancamentos.html
+++ b/src/static/rateio-lancamentos.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Lançamento de Rateio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text">Controle de Rateio</span>
+            </a>
+        </div>
+    </nav>
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-3 d-none d-lg-block">
+                <div class="sidebar rounded shadow-sm">
+                    <div class="nav flex-column">
+                        <a class="nav-link active" href="/rateio-lancamentos.html"><i class="bi bi-list"></i> Lançamentos</a>
+                        <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
+                        <a class="nav-link" href="/rateio-instrutores.html"><i class="bi bi-people"></i> Instrutores</a>
+                    </div>
+                </div>
+            </div>
+            <main class="col-lg-9 col-md-12">
+                <div class="page-header">
+                    <h2 class="mb-0">Lançamento de Rateio</h2>
+                </div>
+
+                <div class="card mb-4">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="selectInstrutor" class="form-label">Selecione o Instrutor</label>
+                                <select id="selectInstrutor" class="form-select"></select>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <label for="selectAno" class="form-label">Ano</label>
+                                <select id="selectAno" class="form-select"></select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="mesesTimeline" class="mb-4" style="display: none;">
+                    <h5>Selecione o Mês</h5>
+                    <div class="d-flex flex-wrap gap-2" id="mesesContainer"></div>
+                </div>
+
+                <div id="areaLancamento" class="card" style="display: none;">
+                    <div class="card-header">
+                        <h5 class="mb-0" id="tituloLancamento">Lançamentos para Mês/Ano</h5>
+                    </div>
+                    <div class="card-body">
+                        <div id="lancamentosContainer"></div>
+                        <hr>
+                        <div class="row align-items-center">
+                            <div class="col-md-6">
+                                <label for="selectConfig" class="form-label">Adicionar Rateio</label>
+                                <select id="selectConfig" class="form-select"></select>
+                            </div>
+                            <div class="col-md-3">
+                                <label for="inputPercentual" class="form-label">Percentual (%)</label>
+                                <input type="number" id="inputPercentual" class="form-control" min="1" max="100">
+                            </div>
+                            <div class="col-md-3 pt-4">
+                                <button id="btnAdicionarLancamento" class="btn btn-outline-primary w-100">Adicionar</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card-footer d-flex justify-content-between align-items-center">
+                        <div>
+                            <strong>Total Lançado: <span id="totalPercentual">0</span>%</strong>
+                        </div>
+                        <button id="btnSalvarLancamentos" class="btn btn-success">
+                            <i class="bi bi-save me-2"></i>Salvar Lançamentos do Mês
+                        </button>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/rateio-lancamentos.js"></script>
+</body>
+</html>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -94,7 +94,7 @@
             </div>
 
             <div class="col-md-5 mb-4 admin-only">
-                <div class="card sistema-card h-100">
+                <div class="card sistema-card h-100" onclick="window.location.href='/rateio-lancamentos.html'">
                     <div class="card-body text-center p-5">
                         <div class="sistema-icon">
                             <i class="fas fa-coins"></i>
@@ -102,7 +102,7 @@
                         <h3 class="card-title">Controle de Rateio</h3>
                         <p class="card-text">Módulo para apuração de horas de instrutores e rateio de custos.</p>
                         <div class="mt-4">
-                            <span class="badge" style="background-color: orange; color: white;">Em Desenvolvimento</span>
+                            <span class="badge bg-success">Disponível</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- introduce RateioConfig and LancamentoRateio models
- implement rateio API endpoints
- register new blueprint in the app
- add pydantic schemas for rateio
- include frontend pages and scripts for the new module
- expose module via selection page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872aed4e9cc8323bab4c2b8055d473a