### PR TITLE
Fix admin visibility in menus

### DIFF
--- a/src/static/dashboard-salas.html
+++ b/src/static/dashboard-salas.html
@@ -106,7 +106,7 @@
                 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                     <h1 class="h2">Dashboard - Controle de Ocupação</h1>
                     <div class="btn-toolbar mb-2 mb-md-0">
-                        <button type="button" class="btn btn-primary" onclick="window.location.href='/novo-agendamento-sala.html'">
+                        <button type="button" class="btn btn-primary admin-only" onclick="window.location.href='/novo-agendamento-sala.html'">
                             <i class="bi bi-plus-circle me-1"></i>
                             Nova Ocupação
                         </button>
@@ -180,7 +180,7 @@
                             </div>
                             <div class="card-body">
                                 <div class="row">
-                                    <div class="col-6 col-md-4 col-lg-3 mb-3">
+                                    <div class="col-6 col-md-4 col-lg-3 mb-3 admin-only">
                                         <a href="/novo-agendamento-sala.html" class="action-tile">
                                             <i class="bi bi-plus-circle"></i>
                                             <span>Nova Ocupação</span>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -152,12 +152,11 @@
                 document.getElementById('userName').textContent = usuario.nome;
             }
 
-            // LÓGICA PARA OCULTAR O CARD DE ADMIN PARA USUÁRIOS COMUNS
+            // LÓGICA PARA OCULTAR OS CARDS DE ADMIN PARA USUÁRIOS COMUNS
             if (!isAdmin()) {
-                const adminCard = document.querySelector('.admin-only');
-                if (adminCard) {
-                    adminCard.style.display = 'none';
-                }
+                document.querySelectorAll('.admin-only').forEach(el => {
+                    el.style.display = 'none';
+                });
             }
 
             // Configura o botão de logout


### PR DESCRIPTION
## Summary
- enforce admin-only visibility in system selection screen
- hide admin quick actions for non-admins in occupancy dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755db2e3588323a35167ba94905264