### PR TITLE
Fix calendar permissions for common users

### DIFF
--- a/src/routes/ocupacao.py
+++ b/src/routes/ocupacao.py
@@ -87,9 +87,6 @@ def listar_ocupacoes():
     if curso_evento:
         query = query.filter(Ocupacao.curso_evento.ilike(f'%{curso_evento}%'))
     
-    # Controle de acesso: usuários comuns só veem suas próprias ocupações
-    if not verificar_admin(user):
-        query = query.filter(Ocupacao.usuario_id == user.id)
     
     # Ordena por data e horário
     ocupacoes = query.order_by(Ocupacao.data, Ocupacao.horario_inicio).all()
@@ -106,10 +103,7 @@ def exportar_ocupacoes():
 
     formato = request.args.get('formato', 'csv').lower()
 
-    if verificar_admin(user):
-        ocupacoes = Ocupacao.query.all()
-    else:
-        ocupacoes = Ocupacao.query.filter_by(usuario_id=user.id).all()
+    ocupacoes = Ocupacao.query.all()
 
     if formato == 'pdf':
         buffer = BytesIO()
@@ -169,9 +163,6 @@ def obter_ocupacao(id):
     if not ocupacao:
         return jsonify({'erro': 'Ocupação não encontrada'}), 404
 
-    # Controle de acesso: usuários comuns só podem ver suas próprias ocupações
-    if not verificar_admin(user) and ocupacao.usuario_id != user.id:
-        return jsonify({'erro': 'Permissão negada'}), 403
 
     dados = ocupacao.to_dict()
 
@@ -594,9 +585,6 @@ def obter_ocupacoes_calendario():
             Ocupacao.horario_fim == fim
         )
     
-    # Controle de acesso: usuários comuns só veem suas próprias ocupações
-    if not verificar_admin(user):
-        query = query.filter(Ocupacao.usuario_id == user.id)
     
     ocupacoes = query.order_by(Ocupacao.data, Ocupacao.horario_inicio).all()
     
@@ -684,8 +672,6 @@ def obter_resumo_periodo():
             Ocupacao.horario_fim == fim
         )
 
-    if not verificar_admin(user):
-        query = query.filter(Ocupacao.usuario_id == user.id)
 
     ocupacoes = query.all()
 

--- a/src/static/calendario-salas.html
+++ b/src/static/calendario-salas.html
@@ -209,7 +209,7 @@
                 </div>
 
                 <div class="d-flex justify-content-end mt-4">
-                    <a href="/novo-agendamento-sala.html" class="btn btn-primary">
+                    <a href="/novo-agendamento-sala.html" class="btn btn-primary admin-only">
                         <i class="bi bi-plus-circle me-2"></i>Nova Ocupação
                     </a>
                 </div>

--- a/src/static/js/calendario-salas.js
+++ b/src/static/js/calendario-salas.js
@@ -42,7 +42,9 @@ function inicializarCalendario() {
             return `+${num} mais`;
         },
         eventClick: function(info) {
-            mostrarDetalhesOcupacao(info.event.extendedProps);
+            if (isUserAdmin()) {
+                mostrarDetalhesOcupacao(info.event.extendedProps);
+            }
         },
         dateClick: function(info) {
             mostrarResumoDia(info.dateStr);


### PR DESCRIPTION
## Summary
- show all ocupacoes to any authenticated user
- remove user filter from calendar endpoints
- allow non-admins to fetch ocupacao details
- hide "Nova Ocupação" action for non-admins
- disable event click for non-admin users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756005bab08323a36b2dc95c62d611