### PR TITLE
Enable booking details for all users

### DIFF
--- a/src/routes/agendamento.py
+++ b/src/routes/agendamento.py
@@ -73,9 +73,6 @@ def obter_agendamento_detalhes(id):
     if not agendamento:
         return jsonify({'erro': 'Agendamento não encontrado'}), 404
 
-    if not verificar_admin(user) and agendamento.usuario_id != user.id:
-        return jsonify({'erro': 'Permissão negada'}), 403
-
     dados = agendamento.to_dict()
     dados['usuario_nome'] = agendamento.usuario.nome if agendamento.usuario else None
     return jsonify(dados)

--- a/src/static/js/calendario-salas.js
+++ b/src/static/js/calendario-salas.js
@@ -42,9 +42,7 @@ function inicializarCalendario() {
             return `+${num} mais`;
         },
         eventClick: function(info) {
-            if (isUserAdmin()) {
-                mostrarDetalhesOcupacao(info.event.extendedProps);
-            }
+            mostrarDetalhesOcupacao(info.event.extendedProps);
         },
         dateClick: function(info) {
             mostrarResumoDia(info.dateStr);


### PR DESCRIPTION
## Summary
- allow any logged user to access `/agendamentos/<id>/detalhes`
- permit viewing of room booking details regardless of role

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68757a9dead08323b770c267ed0604dc