### PR TITLE
Fix Flask run configuration

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -135,4 +135,6 @@ def create_app():
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    debug = os.getenv('FLASK_DEBUG', '0').lower() in ('1', 'true', 't', 'yes')
+    port = int(os.getenv('PORT', '5000'))
+    app.run(debug=debug, host='127.0.0.1', port=port)


### PR DESCRIPTION
## Summary
- secure the flask runtime by controlling debug mode via `FLASK_DEBUG`
- bind to `127.0.0.1` in development

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b2e3258083238f73d5fc058a7c11