### PR TITLE
Fix migrations path for Flask-Migrate

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ from src.routes.user import user_bp
 from src.routes.rateio import rateio_bp
 from src.models.recurso import Recurso
 
-migrate = Migrate()
+migrate = Migrate(directory=os.path.join(os.path.dirname(__file__), '..', 'migrations'))
 
 def create_admin(app):
     """Cria o usuário administrador padrão de forma idempotente."""


### PR DESCRIPTION
## Summary
- ensure Flask-Migrate looks for migrations directory outside of `src`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ee0af6c0832384daa0a77cf9f348