### PR TITLE
Fix delete button for rateio configs

### DIFF
--- a/src/static/js/rateio-config.js
+++ b/src/static/js/rateio-config.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             configs.forEach(config => {
                 const tr = document.createElement('tr');
+                tr.dataset.id = config.id;
                 tr.innerHTML = `
                     <td>${escapeHTML(config.filial)}</td>
                     <td>${escapeHTML(config.uo)}</td>
@@ -96,13 +97,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const btnExcluir = e.target.closest('.btn-excluir');
 
         if (btnEditar) {
-            const id = btnEditar.dataset.id;
+            const id = btnEditar.closest('tr').dataset.id;
             const config = await chamarAPI(`/rateio-configs/${id}`); // Busca os dados mais recentes
             abrirModal(config);
         }
 
         if (btnExcluir) {
-            configParaExcluirId = btnExcluir.dataset.id;
+            configParaExcluirId = btnExcluir.closest('tr').dataset.id;
             document.getElementById('confirmacaoModalBody').textContent = 'Tem certeza que deseja excluir esta configuração? Esta ação não pode ser desfeita.';
             confirmacaoModal.show();
         }

--- a/src/static/rateio-config.html
+++ b/src/static/rateio-config.html
@@ -151,6 +151,10 @@
         </div>
     </div>
 
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/rateio-config.js"></script>


### PR DESCRIPTION
## Summary
- make table rows store the config id and use it when deleting
- add toast container to `rateio-config.html` so alerts show up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f57f79ec83239ccfca552d39f706