### PR TITLE
Implement audit log pages and backend

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,9 @@ from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.user import user_bp
 from src.routes.rateio import rateio_bp
+from src.routes.logs import logs_bp
 from src.models.recurso import Recurso
+import src.services.logging_service  # noqa: F401
 
 MIGRATIONS_DIR = os.path.join(os.path.dirname(__file__), '..', 'migrations')
 migrate = Migrate(directory=MIGRATIONS_DIR)
@@ -116,6 +118,7 @@ def create_app():
     app.register_blueprint(instrutor_bp, url_prefix='/api')
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
     app.register_blueprint(rateio_bp, url_prefix='/api')
+    app.register_blueprint(logs_bp, url_prefix='/api')
 
     @app.route('/')
     def index():

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -6,6 +6,7 @@ db = SQLAlchemy()
 from .refresh_token import RefreshToken  # noqa: E402
 from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
+from .log import Log  # noqa: E402
 from .rateio import RateioConfig, LancamentoRateio  # noqa: E402
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "RefreshToken",
     "Recurso",
     "AuditLog",
+    "Log",
     "RateioConfig",
     "LancamentoRateio",
 ]

--- a/src/models/log.py
+++ b/src/models/log.py
@@ -1,0 +1,35 @@
+from src.models import db
+from datetime import datetime
+from enum import Enum
+
+class LogAcao(Enum):
+    CRIACAO = "Criação"
+    ATUALIZACAO = "Atualização"
+    EXCLUSAO = "Exclusão"
+    LOGIN = "Login"
+
+class Log(db.Model):
+    __tablename__ = 'logs_auditoria'
+
+    id = db.Column(db.Integer, primary_key=True)
+    data_hora = db.Column(db.DateTime, default=datetime.utcnow, nullable=False, index=True)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'), nullable=False)
+    usuario_nome = db.Column(db.String(200), nullable=False)
+    acao = db.Column(db.Enum(LogAcao), nullable=False)
+    modelo_alvo = db.Column(db.String(100), nullable=False, index=True)
+    id_alvo = db.Column(db.Integer)
+    detalhes = db.Column(db.JSON)
+
+    usuario = db.relationship('User', backref='logs')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'data_hora': self.data_hora.isoformat(),
+            'usuario_nome': self.usuario_nome,
+            'acao': self.acao.value,
+            'modelo_alvo': self.modelo_alvo,
+            'id_alvo': self.id_alvo,
+            'detalhes': self.detalhes,
+        }
+

--- a/src/routes/logs.py
+++ b/src/routes/logs.py
@@ -1,0 +1,18 @@
+from flask import Blueprint, request, jsonify
+from src.models.log import Log
+from src.auth import admin_required
+
+logs_bp = Blueprint('logs', __name__)
+
+
+@logs_bp.route('/logs', methods=['GET'])
+@admin_required
+def get_logs():
+    modelo = request.args.get('modelo')
+    if not modelo:
+        return jsonify({'erro': 'O parâmetro "modelo" é obrigatório'}), 400
+
+    query = Log.query.filter_by(modelo_alvo=modelo)
+    logs = query.order_by(Log.data_hora.desc()).limit(200).all()
+    return jsonify([log.to_dict() for log in logs])
+

--- a/src/services/logging_service.py
+++ b/src/services/logging_service.py
@@ -1,0 +1,56 @@
+from flask import g
+from sqlalchemy import event
+from src.models import db
+from src.models.log import Log, LogAcao
+
+
+def registrar_log(acao, instance, detalhes=None):
+    user = getattr(g, 'current_user', None)
+    if not user:
+        return
+
+    log_entry = Log(
+        usuario_id=user.id,
+        usuario_nome=user.nome,
+        acao=acao,
+        modelo_alvo=instance.__class__.__name__,
+        id_alvo=getattr(instance, 'id', None),
+        detalhes=detalhes or {},
+    )
+    db.session.add(log_entry)
+
+
+@event.listens_for(db.session, 'before_flush')
+def before_flush(session, flush_context, instances):
+    session.info['objetos_antigos'] = {}
+    for obj in session.dirty:
+        if hasattr(obj, 'id') and obj.id is not None:
+            session.info['objetos_antigos'][obj] = db.session.get(obj.__class__, obj.id)
+
+
+@event.listens_for(db.session, 'after_flush')
+def after_flush(session, flush_context):
+    for instance in session.new:
+        if isinstance(instance, Log):
+            continue
+        registrar_log(LogAcao.CRIACAO, instance)
+
+    for instance in session.dirty:
+        if isinstance(instance, Log):
+            continue
+        antigo = session.info.get('objetos_antigos', {}).get(instance)
+        if not antigo:
+            continue
+        mudancas = {}
+        for attr in db.inspect(instance).attrs.keys():
+            valor_antigo = getattr(antigo, attr, None)
+            valor_novo = getattr(instance, attr, None)
+            if valor_antigo != valor_novo:
+                mudancas[attr] = {'de': str(valor_antigo), 'para': str(valor_novo)}
+        if mudancas:
+            registrar_log(LogAcao.ATUALIZACAO, instance, detalhes=mudancas)
+
+    for instance in session.deleted:
+        if isinstance(instance, Log):
+            continue
+        registrar_log(LogAcao.EXCLUSAO, instance)

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -48,6 +48,11 @@
                                     <i class="bi bi-person me-2"></i> Meu Perfil
                                 </a>
                             </li>
+                            <li>
+                                <a class="dropdown-item" href="/logs.html?modelo=Agendamento&titulo=Agenda de Laboratórios">
+                                    <i class="bi bi-body-text me-2"></i> Logs de Auditoria
+                                </a>
+                            </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="#" id="btnLogout">
@@ -81,6 +86,9 @@
                         </a>
                         <a class="nav-link" href="/perfil.html">
                             <i class="bi bi-person"></i> Meu Perfil
+                        </a>
+                        <a class="nav-link" href="/logs.html?modelo=Agendamento&titulo=Agenda de Laboratórios">
+                            <i class="bi bi-body-text"></i> Logs de Auditoria
                         </a>
                     </div>
                 </div>

--- a/src/static/js/logs.js
+++ b/src/static/js/logs.js
@@ -1,0 +1,60 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const params = new URLSearchParams(window.location.search);
+    const modelo = params.get('modelo');
+    const titulo = params.get('titulo') || 'Auditoria';
+
+    if (!modelo) {
+        document.getElementById('logsTableBody').innerHTML = '<tr><td colspan="4">Erro: Modelo de log não especificado.</td></tr>';
+        return;
+    }
+
+    document.getElementById('logPageTitle').textContent = `Logs de ${titulo}`;
+
+    async function carregarLogs() {
+        try {
+            const logs = await chamarAPI(`/logs?modelo=${modelo}`);
+            const tableBody = document.getElementById('logsTableBody');
+            tableBody.innerHTML = '';
+
+            logs.forEach(log => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${new Date(log.data_hora).toLocaleString('pt-BR')}</td>
+                    <td>${escapeHTML(log.usuario_nome)}</td>
+                    <td><span class="badge ${getBadgeClass(log.acao)}">${escapeHTML(log.acao)}</span></td>
+                    <td>${formatarDetalhes(log)}</td>
+                `;
+                tableBody.appendChild(tr);
+            });
+        } catch (error) {
+            exibirAlerta(`Erro ao carregar logs: ${error.message}`, 'danger');
+        }
+    }
+
+    function formatarDetalhes(log) {
+        if (log.acao === 'Criação' || log.acao === 'Exclusão') {
+            return `Registo ${log.modelo_alvo} (ID: ${log.id_alvo}) foi ${log.acao === 'Criação' ? 'criado' : 'excluído'}.`;
+        }
+        if (log.acao === 'Atualização') {
+            let html = '<ul>';
+            for (const [chave, valores] of Object.entries(log.detalhes)) {
+                html += `<li><strong>${chave}:</strong> de "<em>${escapeHTML(valores.de)}</em>" para "<em>${escapeHTML(valores.para)}</em>"</li>`;
+            }
+            html += '</ul>';
+            return html;
+        }
+        return JSON.stringify(log.detalhes);
+    }
+
+    function getBadgeClass(acao) {
+        switch(acao) {
+            case 'Criação': return 'bg-success';
+            case 'Atualização': return 'bg-warning text-dark';
+            case 'Exclusão': return 'bg-danger';
+            default: return 'bg-secondary';
+        }
+    }
+
+    carregarLogs();
+});
+

--- a/src/static/logs.html
+++ b/src/static/logs.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Logs de Auditoria</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+    <main class="col-lg-9 col-md-12">
+        <div class="page-header">
+            <h2 id="logPageTitle" class="mb-0">Logs de Auditoria</h2>
+        </div>
+        <div class="card mt-4">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover">
+                        <thead>
+                            <tr>
+                                <th>Data/Hora</th>
+                                <th>Utilizador</th>
+                                <th>Ação</th>
+                                <th>Detalhes da Alteração</th>
+                            </tr>
+                        </thead>
+                        <tbody id="logsTableBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </main>
+    <script src="/js/app.js"></script>
+    <script src="/js/logs.js"></script>
+</body>
+</html>

--- a/src/static/rateio-lancamentos.html
+++ b/src/static/rateio-lancamentos.html
@@ -41,6 +41,11 @@
                                     <i class="bi bi-person me-2"></i>Meu Perfil
                                 </a>
                             </li>
+                            <li>
+                                <a class="dropdown-item" href="/logs.html?modelo=RateioConfig&titulo=Controle de Rateio">
+                                    <i class="bi bi-body-text me-2"></i> Logs de Auditoria
+                                </a>
+                            </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="#" onclick="realizarLogout()">
@@ -63,6 +68,9 @@
                         <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
                         <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
                         <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                        <a class="nav-link" href="/logs.html?modelo=RateioConfig&titulo=Controle de Rateio">
+                            <i class="bi bi-body-text"></i> Logs de Auditoria
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- create new Log model and SQLAlchemy enum
- capture DB modifications with logging service
- expose `/logs` route for admins
- add frontend pages to view logs
- link to log pages from agendas and rateio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c03a5f5c8323ba8d7e183211d8da