### PR TITLE
Add logs page for lab scheduling

### DIFF
--- a/src/models/log_agendamento.py
+++ b/src/models/log_agendamento.py
@@ -1,0 +1,29 @@
+from datetime import datetime, date
+from src.models import db
+
+class LogAgendamento(db.Model):
+    """Registro de ações realizadas em agendamentos."""
+
+    __tablename__ = 'logs_agendamentos'
+
+    id = db.Column(db.Integer, primary_key=True)
+    usuario = db.Column(db.String(100))
+    tipo_acao = db.Column(db.String(20))
+    laboratorio = db.Column(db.String(50))
+    turno = db.Column(db.String(20))
+    data_agendamento = db.Column(db.Date)
+    dados_antes = db.Column(db.JSON)
+    dados_depois = db.Column(db.JSON)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __init__(self, usuario: str, tipo_acao: str, laboratorio: str | None,
+                 turno: str | None, data_agendamento: date | None,
+                 dados_antes: dict | None, dados_depois: dict | None):
+        self.usuario = usuario
+        self.tipo_acao = tipo_acao
+        self.laboratorio = laboratorio
+        self.turno = turno
+        self.data_agendamento = data_agendamento
+        self.dados_antes = dados_antes
+        self.dados_depois = dados_depois
+

--- a/src/static/js/logs-agenda.js
+++ b/src/static/js/logs-agenda.js
@@ -1,0 +1,57 @@
+function formatarDataHora(dataISO) {
+    if (!dataISO) return '';
+    const data = new Date(dataISO);
+    return data.toLocaleString('pt-BR');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    verificarAutenticacao();
+    verificarPermissaoAdmin();
+
+    const tabelaBody = document.querySelector('#tabelaLogs tbody');
+
+    async function carregarLogs() {
+        const params = new URLSearchParams();
+        const usuario = document.getElementById('filtroUsuario').value.trim();
+        const data = document.getElementById('filtroData').value;
+        const tipo = document.getElementById('filtroTipo').value;
+        if (usuario) params.append('usuario', usuario);
+        if (data) params.append('data', data);
+        if (tipo) params.append('tipo', tipo);
+        const logs = await chamarAPI(`/logs-agenda?${params.toString()}`, 'GET');
+        atualizarTabela(logs);
+    }
+
+    function atualizarTabela(logs) {
+        tabelaBody.innerHTML = '';
+        if (!logs || logs.length === 0) {
+            tabelaBody.innerHTML = '<tr><td colspan="6" class="text-center">Nenhum registro encontrado.</td></tr>';
+            return;
+        }
+        logs.forEach(l => {
+            const row = `<tr>
+                <td>${escapeHTML(formatarDataHora(l.timestamp))}</td>
+                <td>${escapeHTML(l.tipo_acao)}</td>
+                <td>${escapeHTML(l.usuario)}</td>
+                <td>${escapeHTML(l.laboratorio || '')}</td>
+                <td>${escapeHTML(l.turno || '')}</td>
+                <td>${l.data_agendamento ? escapeHTML(formatarData(l.data_agendamento)) : ''}</td>
+            </tr>`;
+            tabelaBody.insertAdjacentHTML('beforeend', row);
+        });
+    }
+
+    document.getElementById('btnAplicarFiltros').addEventListener('click', carregarLogs);
+    document.getElementById('btnLimparFiltros').addEventListener('click', () => {
+        document.getElementById('filtroUsuario').value = '';
+        document.getElementById('filtroData').value = '';
+        document.getElementById('filtroTipo').value = '';
+        carregarLogs();
+    });
+
+    document.getElementById('btnExportarCsv').addEventListener('click', () => {
+        exportarDados('/logs-agenda/export', 'csv', 'logs_agenda');
+    });
+
+    carregarLogs();
+});

--- a/src/static/logs-agenda.html
+++ b/src/static/logs-agenda.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logs de Agendamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Agenda de Laboratórios">Agenda de Laboratórios</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2 me-1"></i> Dashboard</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/calendario.html"><i class="bi bi-calendar3 me-1"></i> Calendário</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/laboratorios-turmas.html"><i class="bi bi-building me-1"></i> Laboratórios e Turmas</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle me-1"></i> Novo Agendamento</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link active" href="/logs-agenda.html"><i class="bi bi-journal-text me-1"></i> Logs</a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-person-circle me-1"></i>
+                            <span id="userName">Usuário</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                            <li>
+                                <a class="dropdown-item" href="/perfil.html">
+                                    <i class="bi bi-person me-2"></i> Meu Perfil
+                                </a>
+                            </li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <a class="dropdown-item" href="#" id="btnLogout">
+                                    <i class="bi bi-box-arrow-right me-2"></i> Sair
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+<div class="container-fluid py-4">
+    <div class="row">
+        <div class="col-lg-3 d-none d-lg-block">
+            <div class="sidebar rounded shadow-sm">
+                <h5 class="mb-3">Menu Principal</h5>
+                <div class="nav flex-column">
+                    <a class="nav-link" href="/index.html"><i class="bi bi-speedometer2"></i> Dashboard</a>
+                    <a class="nav-link" href="/calendario.html"><i class="bi bi-calendar3"></i> Calendário</a>
+                    <a class="nav-link admin-only" href="/laboratorios-turmas.html"><i class="bi bi-building"></i> Laboratórios e Turmas</a>
+                    <a class="nav-link" href="/novo-agendamento.html"><i class="bi bi-plus-circle"></i> Novo Agendamento</a>
+                    <a class="nav-link active admin-only" href="/logs-agenda.html"><i class="bi bi-journal-text"></i> Logs</a>
+                    <a class="nav-link" href="/perfil.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                </div>
+            </div>
+        </div>
+        <main class="col-lg-9 col-md-12">
+            <div class="page-header">
+                <h2 class="mb-0">LOGS DE AGENDAMENTOS</h2>
+                <button id="btnExportarCsv" class="btn btn-outline-primary"><i class="bi bi-download me-1"></i>Exportar CSV</button>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-4">
+                            <label for="filtroUsuario" class="form-label">Usuário</label>
+                            <input type="text" id="filtroUsuario" class="form-control">
+                        </div>
+                        <div class="col-md-4">
+                            <label for="filtroData" class="form-label">Data da Ação</label>
+                            <input type="date" id="filtroData" class="form-control">
+                        </div>
+                        <div class="col-md-4">
+                            <label for="filtroTipo" class="form-label">Tipo de Ação</label>
+                            <select id="filtroTipo" class="form-select">
+                                <option value="">Todos</option>
+                                <option value="create">Criado</option>
+                                <option value="update">Editado</option>
+                                <option value="delete">Excluído</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row mt-3">
+                        <div class="col-12">
+                            <button type="button" class="btn btn-primary me-2" id="btnAplicarFiltros"><i class="bi bi-search me-1"></i>Filtrar</button>
+                            <button type="button" class="btn btn-outline-secondary" id="btnLimparFiltros"><i class="bi bi-x-circle me-1"></i>Limpar</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>HISTÓRICO DE LOGS</h5>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0" id="tabelaLogs">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>DATA/HORA</th>
+                                    <th>AÇÃO</th>
+                                    <th>USUÁRIO</th>
+                                    <th>LAB.</th>
+                                    <th>TURNO</th>
+                                    <th>DATA AGEND.</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
+<script src="/js/app.js"></script>
+<script src="/js/logs-agenda.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create model `LogAgendamento` for storing scheduling logs
- log create, update and delete actions to new table
- expose `/logs-agenda` and CSV export endpoints
- add admin-only Logs page with filters and export button
- include JS to fetch and display logs

## Testing
- `flake8`
- `bandit -r src -ll`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d193c4bc8323b45245fff61f52b3