### PR TITLE
Add rateio logs page and logging backend

### DIFF
--- a/migrations/versions/dcae188d3b1b_add_log_lancamento_rateio.py
+++ b/migrations/versions/dcae188d3b1b_add_log_lancamento_rateio.py
@@ -1,0 +1,31 @@
+"""Cria tabela de logs de lancamentos de rateio"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'dcae188d3b1b'
+down_revision = '4b18c0688af2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'log_lancamentos_rateio_instrutor',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('timestamp', sa.DateTime, nullable=True),
+        sa.Column('acao', sa.String(length=20), nullable=True),
+        sa.Column('usuario', sa.String(length=100), nullable=True),
+        sa.Column('instrutor', sa.String(length=100), nullable=True),
+        sa.Column('filial', sa.String(length=100), nullable=True),
+        sa.Column('uo', sa.String(length=100), nullable=True),
+        sa.Column('cr', sa.String(length=100), nullable=True),
+        sa.Column('classe_valor', sa.String(length=100), nullable=True),
+        sa.Column('percentual', sa.Float, nullable=True),
+        sa.Column('observacao', sa.Text, nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('log_lancamentos_rateio_instrutor')

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -7,6 +7,7 @@ from .refresh_token import RefreshToken  # noqa: E402
 from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
 from .rateio import RateioConfig, LancamentoRateio  # noqa: E402
+from .log_rateio import LogLancamentoRateio  # noqa: E402
 
 __all__ = [
     "db",
@@ -15,4 +16,5 @@ __all__ = [
     "AuditLog",
     "RateioConfig",
     "LancamentoRateio",
+    "LogLancamentoRateio",
 ]

--- a/src/models/log_rateio.py
+++ b/src/models/log_rateio.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from src.models import db
+
+class LogLancamentoRateio(db.Model):
+    """Histórico das alterações nos lançamentos de rateio dos instrutores."""
+
+    __tablename__ = 'log_lancamentos_rateio_instrutor'
+
+    id = db.Column(db.Integer, primary_key=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    acao = db.Column(db.String(20))
+    usuario = db.Column(db.String(100))
+    instrutor = db.Column(db.String(100))
+    filial = db.Column(db.String(100))
+    uo = db.Column(db.String(100))
+    cr = db.Column(db.String(100))
+    classe_valor = db.Column(db.String(100))
+    percentual = db.Column(db.Float)
+    observacao = db.Column(db.Text)

--- a/src/routes/rateio.py
+++ b/src/routes/rateio.py
@@ -1,13 +1,39 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, make_response
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy import func
+from datetime import datetime
 from src.models import db
 from src.models.rateio import RateioConfig, LancamentoRateio
+from src.models.instrutor import Instrutor
+from src.models.log_rateio import LogLancamentoRateio
 from src.auth import admin_required
 from src.utils.error_handler import handle_internal_error
+import csv
+from io import StringIO
 from src.schemas import RateioConfigCreateSchema, LancamentoRateioSchema
 from pydantic import ValidationError
 
 rateio_bp = Blueprint('rateio', __name__)
+
+
+def registrar_log_rateio(user, acao, instrutor_nome, config, percentual, observacao=None):
+    """Registra log das alterações de lançamentos de rateio."""
+    try:
+        log = LogLancamentoRateio(
+            usuario=user.nome if user else 'Sistema',
+            acao=acao,
+            instrutor=instrutor_nome,
+            filial=config.filial if config else None,
+            uo=config.uo if config else None,
+            cr=config.cr if config else None,
+            classe_valor=config.classe_valor if config else None,
+            percentual=percentual,
+            observacao=observacao,
+        )
+        db.session.add(log)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
 
 
 @rateio_bp.route('/rateio-configs', methods=['GET'])
@@ -139,11 +165,29 @@ def salvar_lancamentos():
         return jsonify({'erro': f'O percentual total ({total_percentual}%) não pode exceder 100%.'}), 400
 
     try:
-        LancamentoRateio.query.filter_by(instrutor_id=payload.instrutor_id, ano=payload.ano, mes=payload.mes).delete()
+        instrutor = db.session.get(Instrutor, payload.instrutor_id)
+        existentes = LancamentoRateio.query.filter_by(
+            instrutor_id=payload.instrutor_id, ano=payload.ano, mes=payload.mes
+        ).all()
+        mapa_existentes = {l.rateio_config_id: l for l in existentes}
+        novos_ids = {item.rateio_config_id for item in payload.lancamentos if item.percentual > 0}
 
-        novos = []
+        # Remover registros que não estarão mais presentes
+        for l in list(existentes):
+            if l.rateio_config_id not in novos_ids:
+                registrar_log_rateio(instrutor, 'delete', instrutor.nome if instrutor else '', l.rateio_config, l.percentual)
+                db.session.delete(l)
+
         for item in payload.lancamentos:
-            if item.percentual > 0:
+            if item.percentual <= 0:
+                continue
+            existente = mapa_existentes.get(item.rateio_config_id)
+            config = existente.rateio_config if existente else db.session.get(RateioConfig, item.rateio_config_id)
+            if existente:
+                if existente.percentual != item.percentual:
+                    existente.percentual = item.percentual
+                    registrar_log_rateio(instrutor, 'update', instrutor.nome if instrutor else '', config, item.percentual)
+            else:
                 novo = LancamentoRateio(
                     instrutor_id=payload.instrutor_id,
                     ano=payload.ano,
@@ -151,10 +195,80 @@ def salvar_lancamentos():
                     rateio_config_id=item.rateio_config_id,
                     percentual=item.percentual,
                 )
-                novos.append(novo)
-        db.session.add_all(novos)
+                db.session.add(novo)
+                registrar_log_rateio(instrutor, 'create', instrutor.nome if instrutor else '', config, item.percentual)
+
         db.session.commit()
         return jsonify({'mensagem': 'Lançamentos salvos com sucesso!'}), 201
     except Exception as e:  # pragma: no cover - segurança
         db.session.rollback()
         return handle_internal_error(e)
+
+
+@rateio_bp.route('/logs-rateio', methods=['GET'])
+@admin_required
+def listar_logs_rateio():
+    """Lista logs de lançamentos de rateio."""
+    query = LogLancamentoRateio.query
+    usuario = request.args.get('usuario')
+    instrutor = request.args.get('instrutor')
+    tipo = request.args.get('tipo')
+    data_acao = request.args.get('data')
+
+    if usuario:
+        query = query.filter(LogLancamentoRateio.usuario.ilike(f'%{usuario}%'))
+    if instrutor:
+        query = query.filter(LogLancamentoRateio.instrutor.ilike(f'%{instrutor}%'))
+    if tipo:
+        query = query.filter(LogLancamentoRateio.acao == tipo)
+    if data_acao:
+        try:
+            dia = datetime.strptime(data_acao, '%Y-%m-%d').date()
+            query = query.filter(func.date(LogLancamentoRateio.timestamp) == dia)
+        except ValueError:
+            return jsonify({'erro': 'Formato de data inválido'}), 400
+
+    logs = query.order_by(LogLancamentoRateio.timestamp.desc()).all()
+    return jsonify([
+        {
+            'id': l.id,
+            'timestamp': l.timestamp.isoformat() if l.timestamp else None,
+            'acao': l.acao,
+            'usuario': l.usuario,
+            'instrutor': l.instrutor,
+            'filial': l.filial,
+            'uo': l.uo,
+            'cr': l.cr,
+            'classe_valor': l.classe_valor,
+            'percentual': l.percentual,
+            'observacao': l.observacao,
+        }
+        for l in logs
+    ])
+
+
+@rateio_bp.route('/logs-rateio/export', methods=['GET'])
+@admin_required
+def exportar_logs_rateio():
+    """Exporta logs de lançamentos de rateio em CSV."""
+    logs = LogLancamentoRateio.query.order_by(LogLancamentoRateio.timestamp.desc()).all()
+    si = StringIO()
+    writer = csv.writer(si)
+    writer.writerow(['Data/Hora', 'Ação', 'Usuário', 'Instrutor', 'Filial', 'UO', 'CR', 'Classe de Valor', 'Percentual', 'Observações'])
+    for l in logs:
+        writer.writerow([
+            l.timestamp.isoformat() if l.timestamp else '',
+            l.acao,
+            l.usuario,
+            l.instrutor,
+            l.filial,
+            l.uo,
+            l.cr,
+            l.classe_valor,
+            l.percentual,
+            l.observacao or '',
+        ])
+    output = make_response(si.getvalue())
+    output.headers['Content-Disposition'] = 'attachment; filename=logs_rateio.csv'
+    output.headers['Content-Type'] = 'text/csv'
+    return output

--- a/src/static/js/logs-rateio.js
+++ b/src/static/js/logs-rateio.js
@@ -1,0 +1,65 @@
+function formatarDataHora(dataISO) {
+    if (!dataISO) return '';
+    const entrada = dataISO.endsWith('Z') || dataISO.includes('+') ? dataISO : `${dataISO}Z`;
+    const data = new Date(entrada);
+    return data.toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    verificarAutenticacao();
+    verificarPermissaoAdmin();
+
+    const tabelaBody = document.querySelector('#tabelaLogs tbody');
+
+    async function carregarLogs() {
+        const params = new URLSearchParams();
+        const usuario = document.getElementById('filtroUsuario').value.trim();
+        const instrutor = document.getElementById('filtroInstrutor').value.trim();
+        const data = document.getElementById('filtroData').value;
+        const tipo = document.getElementById('filtroTipo').value;
+        if (usuario) params.append('usuario', usuario);
+        if (instrutor) params.append('instrutor', instrutor);
+        if (data) params.append('data', data);
+        if (tipo) params.append('tipo', tipo);
+        const logs = await chamarAPI(`/logs-rateio?${params.toString()}`, 'GET');
+        atualizarTabela(logs);
+    }
+
+    function atualizarTabela(logs) {
+        tabelaBody.innerHTML = '';
+        if (!logs || logs.length === 0) {
+            tabelaBody.innerHTML = '<tr><td colspan="10" class="text-center">Nenhum registro encontrado.</td></tr>';
+            return;
+        }
+        logs.forEach(l => {
+            const row = `<tr>
+                <td>${escapeHTML(formatarDataHora(l.timestamp))}</td>
+                <td>${escapeHTML(l.acao)}</td>
+                <td>${escapeHTML(l.usuario)}</td>
+                <td>${escapeHTML(l.instrutor)}</td>
+                <td>${escapeHTML(l.filial)}</td>
+                <td>${escapeHTML(l.uo)}</td>
+                <td>${escapeHTML(l.cr)}</td>
+                <td>${escapeHTML(l.classe_valor)}</td>
+                <td>${l.percentual != null ? escapeHTML(l.percentual.toFixed(2) + '%') : ''}</td>
+                <td>${escapeHTML(l.observacao || '')}</td>
+            </tr>`;
+            tabelaBody.insertAdjacentHTML('beforeend', row);
+        });
+    }
+
+    document.getElementById('btnAplicarFiltros').addEventListener('click', carregarLogs);
+    document.getElementById('btnLimparFiltros').addEventListener('click', () => {
+        document.getElementById('filtroUsuario').value = '';
+        document.getElementById('filtroInstrutor').value = '';
+        document.getElementById('filtroData').value = '';
+        document.getElementById('filtroTipo').value = '';
+        carregarLogs();
+    });
+
+    document.getElementById('btnExportarCsv').addEventListener('click', () => {
+        exportarDados('/logs-rateio/export', 'csv', 'logs_rateio');
+    });
+
+    carregarLogs();
+});

--- a/src/static/logs-rateio.html
+++ b/src/static/logs-rateio.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logs de Rateio</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Controle de Rateio">Controle de Rateio</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin me-1"></i> Lançamentos</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear-fill me-1"></i> Configurações</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/rateio-instrutores.html"><i class="bi bi-person-badge me-1"></i> Instrutores</a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-person-circle me-1"></i>
+                            <span id="userName">Usuário</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                            <li>
+                                <a class="dropdown-item" href="/perfil-rateio.html">
+                                    <i class="bi bi-person me-2"></i>Meu Perfil
+                                </a>
+                            </li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <a class="dropdown-item" href="#" onclick="realizarLogout()">
+                                    <i class="bi bi-box-arrow-right me-2"></i>Sair
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+<div class="container-fluid py-4">
+    <div class="row">
+        <div class="col-lg-3 d-none d-lg-block">
+            <div class="sidebar rounded shadow-sm">
+                <h5 class="mb-3">Menu Principal</h5>
+                <div class="nav flex-column">
+                    <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
+                    <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
+                    <a class="nav-link" href="/rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
+                    <a class="nav-link active" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
+                    <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                </div>
+            </div>
+        </div>
+        <main class="col-lg-9 col-md-12">
+            <div class="page-header">
+                <h2 class="mb-0">LOGS DE RATEIO</h2>
+                <button id="btnExportarCsv" class="btn btn-outline-primary"><i class="bi bi-download me-1"></i>Exportar CSV</button>
+            </div>
+
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-3">
+                            <label for="filtroUsuario" class="form-label">Usuário</label>
+                            <input type="text" id="filtroUsuario" class="form-control">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="filtroInstrutor" class="form-label">Instrutor</label>
+                            <input type="text" id="filtroInstrutor" class="form-control">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="filtroData" class="form-label">Data da Ação</label>
+                            <input type="date" id="filtroData" class="form-control">
+                        </div>
+                        <div class="col-md-3">
+                            <label for="filtroTipo" class="form-label">Tipo de Ação</label>
+                            <select id="filtroTipo" class="form-select">
+                                <option value="">Todos</option>
+                                <option value="create">Create</option>
+                                <option value="update">Update</option>
+                                <option value="delete">Delete</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row mt-3">
+                        <div class="col-12">
+                            <button type="button" class="btn btn-primary me-2" id="btnAplicarFiltros"><i class="bi bi-search me-1"></i>Filtrar</button>
+                            <button type="button" class="btn btn-outline-secondary" id="btnLimparFiltros"><i class="bi bi-x-circle me-1"></i>Limpar</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>HISTÓRICO DE LOGS</h5>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-hover mb-0" id="tabelaLogs">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>DATA/HORA</th>
+                                    <th>AÇÃO</th>
+                                    <th>USUÁRIO</th>
+                                    <th>INSTRUTOR</th>
+                                    <th>FILIAL</th>
+                                    <th>UO</th>
+                                    <th>CR</th>
+                                    <th>CLASSE DE VALOR</th>
+                                    <th>PERCENTUAL</th>
+                                    <th>OBSERVAÇÕES</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
+<script src="/js/app.js"></script>
+<script src="/js/logs-rateio.js"></script>
+</body>
+</html>

--- a/src/static/perfil-rateio.html
+++ b/src/static/perfil-rateio.html
@@ -67,8 +67,9 @@
                         <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
                         <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
+                        <a class="nav-link" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
                         <a class="nav-link active" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
-                    </div>
+                </div>
                 </div>
             </div>
             

--- a/src/static/rateio-config.html
+++ b/src/static/rateio-config.html
@@ -61,9 +61,10 @@
                     <div class="nav flex-column">
                         <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link active" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
-                        <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                        <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
-                    </div>
+                    <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
+                    <a class="nav-link" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
+                    <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                </div>
                 </div>
             </div>
             <main class="col-lg-9 col-md-12">

--- a/src/static/rateio-instrutores.html
+++ b/src/static/rateio-instrutores.html
@@ -67,8 +67,9 @@
                         <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
                         <a class="nav-link active" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
+                        <a class="nav-link" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
                         <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
-                    </div>
+                </div>
                 </div>
             </div>
 

--- a/src/static/rateio-lancamentos.html
+++ b/src/static/rateio-lancamentos.html
@@ -61,9 +61,10 @@
                     <div class="nav flex-column">
                         <a class="nav-link active" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
-                        <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                        <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
-                    </div>
+                    <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
+                    <a class="nav-link" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
+                    <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                </div>
                 </div>
             </div>
             <main class="col-lg-9 col-md-12">


### PR DESCRIPTION
## Summary
- add model and migrations for logging rateio launches
- include CRUD log recording in rateio routes
- expose `/logs-rateio` and CSV export endpoint
- create `logs-rateio.html` and JS for listing logs
- add Logs option to rateio sidebar navigation

## Testing
- `pip install -r requirements.txt`
- `pip install pydantic==2.5.3 email-validator==2.2.0 openpyxl==3.1.2 reportlab==4.0.8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ea97da98832392943e5f34380fb2