### PR TITLE
Remove incorrect menu link and fix rateio logs path

### DIFF
--- a/src/static/logs-rateio.html
+++ b/src/static/logs-rateio.html
@@ -63,7 +63,7 @@
                     <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                     <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
                     <a class="nav-link" href="/rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                    <a class="nav-link active" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
+                    <a class="nav-link active" href="/logs-rateio.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
                     <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
                 </div>
             </div>

--- a/src/static/perfil-rateio.html
+++ b/src/static/perfil-rateio.html
@@ -67,7 +67,7 @@
                         <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
                         <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                        <a class="nav-link" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
+                        <a class="nav-link" href="/logs-rateio.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
                         <a class="nav-link active" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
                 </div>
                 </div>

--- a/src/static/rateio-config.html
+++ b/src/static/rateio-config.html
@@ -62,7 +62,7 @@
                         <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link active" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
                     <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                    <a class="nav-link" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
+                    <a class="nav-link" href="/logs-rateio.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
                     <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
                 </div>
                 </div>

--- a/src/static/rateio-instrutores.html
+++ b/src/static/rateio-instrutores.html
@@ -67,7 +67,7 @@
                         <a class="nav-link" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
                         <a class="nav-link active" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                        <a class="nav-link" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
+                        <a class="nav-link" href="/logs-rateio.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
                         <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
                 </div>
                 </div>

--- a/src/static/rateio-lancamentos.html
+++ b/src/static/rateio-lancamentos.html
@@ -62,7 +62,7 @@
                         <a class="nav-link active" href="/rateio-lancamentos.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio-config.html"><i class="bi bi-gear"></i> Configurações</a>
                     <a class="nav-link" href="./rateio-instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                    <a class="nav-link" href="/logs-rateio.html"><i class="bi bi-journal-text"></i> Logs</a>
+                    <a class="nav-link" href="/logs-rateio.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
                     <a class="nav-link" href="/perfil-rateio.html"><i class="bi bi-person"></i> Meu Perfil</a>
                 </div>
                 </div>


### PR DESCRIPTION
## Summary
- update logs link to include `modelo=LancamentoRateio` across rateio pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f9f3e4b08323933522ca332c4128