### PR TITLE
Standardize rateio pages

### DIFF
--- a/src/static/logs-rateio.html
+++ b/src/static/logs-rateio.html
@@ -145,5 +145,8 @@
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
 <script src="/js/app.js"></script>
 <script src="/js/logs-rateio.js"></script>
+<div aria-live="polite" aria-atomic="true" class="position-relative">
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+</div>
 </body>
 </html>

--- a/src/static/perfil-rateio.html
+++ b/src/static/perfil-rateio.html
@@ -74,8 +74,10 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4">Meu Perfil</h2>
-                
+                <div class="page-header">
+                    <h2 class="mb-0">Meu Perfil</h2>
+                </div>
+
                 <div id="alertContainer"></div>
                 
                 <div class="row">

--- a/src/static/rateio-config.html
+++ b/src/static/rateio-config.html
@@ -75,6 +75,9 @@
                     </button>
                 </div>
                 <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE CONFIGURAÇÕES</h5>
+                    </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
                             <table class="table table-striped table-hover">

--- a/src/static/rateio-lancamentos.html
+++ b/src/static/rateio-lancamentos.html
@@ -73,6 +73,9 @@
                 </div>
 
                 <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                    </div>
                     <div class="card-body">
                         <div class="row">
                             <div class="col-md-6 mb-3">
@@ -139,5 +142,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/rateio-lancamentos.js"></script>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adjust HTML structure on rateio pages to follow instrutores layout
- add missing toast containers for consistent feedback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780af8372c8323aa267654c84397aa