### PR TITLE
Padroniza interface do módulo de rateio

### DIFF
--- a/src/static/logs-rateio.html
+++ b/src/static/logs-rateio.html
@@ -70,11 +70,11 @@
         </div>
         <main class="col-lg-9 col-md-12">
             <div class="page-header">
-                <h2 class="mb-0">LOGS DE RATEIO</h2>
+                <h2 class="mb-0">Logs de Rateio</h2>
                 <button id="btnExportarCsv" class="btn btn-outline-primary"><i class="bi bi-download me-1"></i>Exportar CSV</button>
             </div>
 
-            <div class="card mb-4">
+            <div class="card mt-4">
                 <div class="card-header">
                     <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
                 </div>
@@ -111,7 +111,7 @@
                 </div>
             </div>
 
-            <div class="card">
+            <div class="card mt-4">
                 <div class="card-header">
                     <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>HISTÓRICO DE LOGS</h5>
                 </div>

--- a/src/static/perfil-rateio.html
+++ b/src/static/perfil-rateio.html
@@ -74,12 +74,16 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4">Meu Perfil</h2>
-                
-                <div id="alertContainer"></div>
-                
-                <div class="row">
-                    <div class="col-md-8">
+                <div class="page-header">
+                    <h2 class="mb-0">Meu Perfil</h2>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-body">
+                        <div id="alertContainer"></div>
+
+                        <div class="row">
+                            <div class="col-md-5">
                         <div class="card">
                             <div class="card-header">
                                 <h5 class="card-title mb-0">Informações Pessoais</h5>
@@ -110,7 +114,7 @@
                         </div>
                     </div>
                     
-                    <div class="col-md-4">
+                    <div class="col-md-7">
                         <div class="card mb-4">
                             <div class="card-header">
                                 <h5 class="card-title mb-0">Alterar Senha</h5>
@@ -154,6 +158,8 @@
                                 </div>
                             </div>
                         </div>
+                    </div>
+                </div>
                     </div>
                 </div>
             </main>

--- a/src/static/rateio-config.html
+++ b/src/static/rateio-config.html
@@ -68,7 +68,7 @@
                 </div>
             </div>
             <main class="col-lg-9 col-md-12">
-                <div class="page-header d-flex justify-content-between align-items-center">
+                <div class="page-header">
                     <h2 class="mb-0">Configurações de Rateio</h2>
                     <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#configModal">
                         <i class="bi bi-plus-circle me-2"></i>NOVA CONFIGURAÇÃO
@@ -77,7 +77,7 @@
                 <div class="card mt-4">
                     <div class="card-body p-0">
                         <div class="table-responsive">
-                            <table class="table table-striped table-hover">
+                            <table class="table table-striped table-hover mb-0">
                                 <thead>
                                     <tr>
                                         <th>Filial</th>

--- a/src/static/rateio-lancamentos.html
+++ b/src/static/rateio-lancamentos.html
@@ -72,7 +72,7 @@
                     <h2 class="mb-0">Lançamento de Rateio</h2>
                 </div>
 
-                <div class="card mb-4">
+                <div class="card mt-4">
                     <div class="card-body">
                         <div class="row">
                             <div class="col-md-6 mb-3">


### PR DESCRIPTION
## Summary
- harmonize `rateio-lancamentos.html` card spacing
- normalize header and table layout in `rateio-config.html`
- aplicar cabeçalho e card geral em `perfil-rateio.html`
- ajustar cabeçalho e cards de `logs-rateio.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781d881b90832383400d021fbb7f8a