### PR TITLE
Add training agenda module

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -116,6 +116,8 @@ def create_app():
     app.register_blueprint(instrutor_bp, url_prefix='/api')
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
     app.register_blueprint(rateio_bp, url_prefix='/api')
+    from src.routes.treinamento import treinamento_bp
+    app.register_blueprint(treinamento_bp, url_prefix='/api')
 
     @app.route('/')
     def index():

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -8,6 +8,9 @@ from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
 from .rateio import RateioConfig, LancamentoRateio  # noqa: E402
 from .log_rateio import LogLancamentoRateio  # noqa: E402
+from .treinamento import Treinamento, treinamento_instrutores  # noqa: E402
+from .turma import TurmaTreinamento  # noqa: E402
+from .participacao import Inscricao, Presenca  # noqa: E402
 
 __all__ = [
     "db",
@@ -17,4 +20,9 @@ __all__ = [
     "RateioConfig",
     "LancamentoRateio",
     "LogLancamentoRateio",
+    "Treinamento",
+    "treinamento_instrutores",
+    "TurmaTreinamento",
+    "Inscricao",
+    "Presenca",
 ]

--- a/src/models/participacao.py
+++ b/src/models/participacao.py
@@ -1,0 +1,34 @@
+from src.models import db
+
+class Inscricao(db.Model):
+    __tablename__ = 'inscricoes'
+    id = db.Column(db.Integer, primary_key=True)
+    turma_id = db.Column(db.Integer, db.ForeignKey('turmas_treinamento.id'), nullable=False)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'), nullable=False)
+
+    turma = db.relationship('TurmaTreinamento', backref='inscricoes')
+    usuario = db.relationship('User', backref='inscricoes_treinamentos')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'turma_id': self.turma_id,
+            'usuario_id': self.usuario_id,
+        }
+
+class Presenca(db.Model):
+    __tablename__ = 'presencas'
+    id = db.Column(db.Integer, primary_key=True)
+    inscricao_id = db.Column(db.Integer, db.ForeignKey('inscricoes.id'), nullable=False)
+    data = db.Column(db.Date, nullable=False)
+    presente = db.Column(db.Boolean, default=False, nullable=False)
+
+    inscricao = db.relationship('Inscricao', backref='lista_presenca')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'inscricao_id': self.inscricao_id,
+            'data': self.data.isoformat() if self.data else None,
+            'presente': self.presente,
+        }

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -1,0 +1,28 @@
+from src.models import db
+
+# Tabela de associação para ligar instrutores qualificados a um treinamento
+treinamento_instrutores = db.Table(
+    'treinamento_instrutores',
+    db.Column('treinamento_id', db.Integer, db.ForeignKey('treinamentos.id'), primary_key=True),
+    db.Column('instrutor_id', db.Integer, db.ForeignKey('instrutores.id'), primary_key=True),
+)
+
+class Treinamento(db.Model):
+    __tablename__ = 'treinamentos'
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(200), nullable=False, unique=True)
+    codigo = db.Column(db.String(50), nullable=True, unique=True)
+    carga_horaria = db.Column(db.Integer, nullable=False)
+
+    instrutores_qualificados = db.relationship('Instrutor', secondary=treinamento_instrutores, lazy='dynamic')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'nome': self.nome,
+            'codigo': self.codigo,
+            'carga_horaria': self.carga_horaria,
+        }
+
+    def __repr__(self) -> str:
+        return f'<Treinamento {self.nome}>'

--- a/src/models/turma.py
+++ b/src/models/turma.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from src.models import db
+
+class TurmaTreinamento(db.Model):
+    __tablename__ = 'turmas_treinamento'
+    id = db.Column(db.Integer, primary_key=True)
+    treinamento_id = db.Column(db.Integer, db.ForeignKey('treinamentos.id'), nullable=False)
+    data_inicio = db.Column(db.DateTime, nullable=False)
+    data_fim = db.Column(db.DateTime, nullable=False)
+    status = db.Column(db.String(50), default='A realizar', nullable=False)
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+    data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    treinamento = db.relationship('Treinamento', backref='turmas')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'treinamento_id': self.treinamento_id,
+            'treinamento': self.treinamento.to_dict() if self.treinamento else None,
+            'data_inicio': self.data_inicio.isoformat() if self.data_inicio else None,
+            'data_fim': self.data_fim.isoformat() if self.data_fim else None,
+            'status': self.status,
+        }
+
+    def __repr__(self) -> str:
+        return f'<TurmaTreinamento {self.id}>'

--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -1,0 +1,303 @@
+"""Rotas para gerenciamento de treinamentos e turmas."""
+from datetime import datetime, timedelta
+from flask import Blueprint, request, jsonify
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy import func
+
+from src.models import db
+from src.models.treinamento import Treinamento
+from src.models.turma import TurmaTreinamento
+from src.models.participacao import Inscricao, Presenca
+from src.routes.user import verificar_autenticacao, verificar_admin
+from src.utils.error_handler import handle_internal_error
+
+
+treinamento_bp = Blueprint('treinamento', __name__)
+
+
+@treinamento_bp.route('/treinamentos/catalogo', methods=['GET'])
+def catalogo_treinamentos():
+    """Retorna o catálogo de treinamentos."""
+    treinamentos = Treinamento.query.order_by(Treinamento.nome).all()
+    return jsonify([t.to_dict() for t in treinamentos])
+
+
+@treinamento_bp.route('/turmas/<int:id>/inscrever', methods=['POST'])
+def inscrever(id):
+    """Inscreve o usuário logado em uma turma."""
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    turma = db.session.get(TurmaTreinamento, id)
+    if not turma:
+        return jsonify({'erro': 'Turma não encontrada'}), 404
+
+    if Inscricao.query.filter_by(turma_id=id, usuario_id=user.id).first():
+        return jsonify({'erro': 'Usuário já inscrito'}), 400
+
+    try:
+        insc = Inscricao(turma_id=id, usuario_id=user.id)
+        db.session.add(insc)
+        db.session.commit()
+        return jsonify(insc.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/meus-treinamentos', methods=['GET'])
+def meus_treinamentos():
+    """Lista as turmas em que o usuário está inscrito."""
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    inscricoes = Inscricao.query.filter_by(usuario_id=user.id).all()
+    return jsonify([i.turma.to_dict() for i in inscricoes])
+
+
+# ----- Rotas Admin -----
+
+
+def _verifica_admin(request):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return None, jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return None, jsonify({'erro': 'Permissão negada'}), 403
+    return user, None, None
+
+
+@treinamento_bp.route('/admin/treinamentos', methods=['GET', 'POST'])
+def admin_treinamentos():
+    user, resp, code = _verifica_admin(request)
+    if resp:
+        return resp, code
+
+    if request.method == 'GET':
+        treinamentos = Treinamento.query.order_by(Treinamento.nome).all()
+        return jsonify([t.to_dict() for t in treinamentos])
+
+    data = request.json or {}
+    nome = (data.get('nome') or '').strip()
+    codigo = data.get('codigo')
+    carga_horaria = data.get('carga_horaria')
+
+    if not nome or carga_horaria is None:
+        return jsonify({'erro': 'Dados incompletos'}), 400
+
+    try:
+        novo = Treinamento(nome=nome, codigo=codigo, carga_horaria=carga_horaria)
+        db.session.add(novo)
+        db.session.commit()
+        return jsonify(novo.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/admin/treinamentos/<int:id>', methods=['PUT', 'DELETE'])
+def admin_treinamento_id(id):
+    user, resp, code = _verifica_admin(request)
+    if resp:
+        return resp, code
+
+    treinamento = db.session.get(Treinamento, id)
+    if not treinamento:
+        return jsonify({'erro': 'Treinamento não encontrado'}), 404
+
+    if request.method == 'DELETE':
+        try:
+            db.session.delete(treinamento)
+            db.session.commit()
+            return jsonify({'mensagem': 'Treinamento removido'})
+        except SQLAlchemyError as e:
+            db.session.rollback()
+            return handle_internal_error(e)
+
+    data = request.json or {}
+    treinamento.nome = (data.get('nome') or treinamento.nome).strip()
+    treinamento.codigo = data.get('codigo', treinamento.codigo)
+    treinamento.carga_horaria = data.get('carga_horaria', treinamento.carga_horaria)
+    try:
+        db.session.commit()
+        return jsonify(treinamento.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/admin/turmas', methods=['GET', 'POST'])
+def admin_turmas():
+    user, resp, code = _verifica_admin(request)
+    if resp:
+        return resp, code
+
+    if request.method == 'GET':
+        turmas = TurmaTreinamento.query.order_by(TurmaTreinamento.data_inicio).all()
+        return jsonify([t.to_dict() for t in turmas])
+
+    data = request.json or {}
+    treinamento_id = data.get('treinamento_id')
+    data_inicio = data.get('data_inicio')
+    data_fim = data.get('data_fim')
+    status = data.get('status') or 'A realizar'
+
+    if not all([treinamento_id, data_inicio, data_fim]):
+        return jsonify({'erro': 'Dados incompletos'}), 400
+
+    try:
+        inicio = datetime.fromisoformat(data_inicio)
+        fim = datetime.fromisoformat(data_fim)
+    except ValueError:
+        return jsonify({'erro': 'Datas inválidas'}), 400
+
+    try:
+        turma = TurmaTreinamento(
+            treinamento_id=treinamento_id,
+            data_inicio=inicio,
+            data_fim=fim,
+            status=status,
+        )
+        db.session.add(turma)
+        db.session.commit()
+        return jsonify(turma.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/admin/turmas/<int:id>', methods=['PUT', 'DELETE'])
+def admin_turma_id(id):
+    user, resp, code = _verifica_admin(request)
+    if resp:
+        return resp, code
+
+    turma = db.session.get(TurmaTreinamento, id)
+    if not turma:
+        return jsonify({'erro': 'Turma não encontrada'}), 404
+
+    if request.method == 'DELETE':
+        try:
+            db.session.delete(turma)
+            db.session.commit()
+            return jsonify({'mensagem': 'Turma removida'})
+        except SQLAlchemyError as e:
+            db.session.rollback()
+            return handle_internal_error(e)
+
+    data = request.json or {}
+    if 'treinamento_id' in data:
+        turma.treinamento_id = data['treinamento_id']
+    if 'data_inicio' in data:
+        try:
+            turma.data_inicio = datetime.fromisoformat(data['data_inicio'])
+        except ValueError:
+            return jsonify({'erro': 'Data início inválida'}), 400
+    if 'data_fim' in data:
+        try:
+            turma.data_fim = datetime.fromisoformat(data['data_fim'])
+        except ValueError:
+            return jsonify({'erro': 'Data fim inválida'}), 400
+    if 'status' in data:
+        turma.status = data['status']
+
+    try:
+        db.session.commit()
+        return jsonify(turma.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/admin/turmas/<int:id>/participantes', methods=['GET'])
+def participantes_turma(id):
+    user, resp, code = _verifica_admin(request)
+    if resp:
+        return resp, code
+
+    turma = db.session.get(TurmaTreinamento, id)
+    if not turma:
+        return jsonify({'erro': 'Turma não encontrada'}), 404
+
+    inscritos = [i.usuario.to_dict() for i in turma.inscricoes]
+    return jsonify(inscritos)
+
+
+@treinamento_bp.route('/admin/presenca', methods=['POST'])
+def registrar_presenca():
+    user, resp, code = _verifica_admin(request)
+    if resp:
+        return resp, code
+
+    data = request.json or {}
+    inscricao_id = data.get('inscricao_id')
+    data_presenca = data.get('data')
+    presente = bool(data.get('presente'))
+
+    if not all([inscricao_id, data_presenca]):
+        return jsonify({'erro': 'Dados incompletos'}), 400
+
+    inscricao = db.session.get(Inscricao, inscricao_id)
+    if not inscricao:
+        return jsonify({'erro': 'Inscrição não encontrada'}), 404
+
+    try:
+        dia = datetime.fromisoformat(data_presenca).date()
+    except ValueError:
+        return jsonify({'erro': 'Data inválida'}), 400
+
+    try:
+        presenca = Presenca(
+            inscricao_id=inscricao_id,
+            data=dia,
+            presente=presente,
+        )
+        db.session.add(presenca)
+        db.session.commit()
+        return jsonify(presenca.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/admin/dashboard/treinamentos', methods=['GET'])
+def dashboard_treinamentos():
+    user, resp, code = _verifica_admin(request)
+    if resp:
+        return resp, code
+
+    em_andamento = TurmaTreinamento.query.filter(TurmaTreinamento.status == 'Em andamento').count()
+
+    now = datetime.utcnow()
+    inicio_mes = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if inicio_mes.month == 12:
+        proximo_mes = inicio_mes.replace(year=inicio_mes.year + 1, month=1)
+    else:
+        proximo_mes = inicio_mes.replace(month=inicio_mes.month + 1)
+
+    participantes_mes = (
+        db.session.query(func.count(Inscricao.id))
+        .join(TurmaTreinamento, Inscricao.turma_id == TurmaTreinamento.id)
+        .filter(TurmaTreinamento.data_inicio >= inicio_mes, TurmaTreinamento.data_inicio < proximo_mes)
+        .scalar()
+    )
+
+    mais_procurados = (
+        db.session.query(Treinamento.nome, func.count(Inscricao.id).label('total'))
+        .join(TurmaTreinamento, TurmaTreinamento.treinamento_id == Treinamento.id)
+        .join(Inscricao, Inscricao.turma_id == TurmaTreinamento.id)
+        .group_by(Treinamento.id)
+        .order_by(func.count(Inscricao.id).desc())
+        .limit(5)
+        .all()
+    )
+
+    return jsonify({
+        'em_andamento': em_andamento,
+        'participantes_mes': participantes_mes or 0,
+        'mais_procurados': [
+            {'treinamento': nome, 'inscritos': total} for nome, total in mais_procurados
+        ],
+    })

--- a/src/static/catalogo-admin.html
+++ b/src/static/catalogo-admin.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Catálogo de Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/selecao-sistema.html">Conecta SENAI</a>
+    </div>
+</nav>
+<div class="container">
+    <h1 class="mb-3">Catálogo de Treinamentos</h1>
+    <div id="lista-catalogo" class="table-responsive"></div>
+</div>
+<script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/dashboard-treinamentos.html
+++ b/src/static/dashboard-treinamentos.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard de Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/selecao-sistema.html">Conecta SENAI</a>
+    </div>
+</nav>
+<div class="container">
+    <h1 class="mb-3">Dashboard de Treinamentos</h1>
+    <div id="cards-dashboard" class="row"></div>
+</div>
+<script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/meus-treinamentos.html
+++ b/src/static/meus-treinamentos.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meus Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/index.html">Conecta SENAI</a>
+    </div>
+</nav>
+<div class="container">
+    <h1 class="mb-3">Meus Treinamentos</h1>
+    <div id="minhas-turmas" class="row"></div>
+</div>
+<script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/portal-treinamentos.html
+++ b/src/static/portal-treinamentos.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Portal de Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/index.html">Conecta SENAI</a>
+    </div>
+</nav>
+<div class="container">
+    <h1 class="mb-3">Treinamentos Disponíveis</h1>
+    <div id="lista-treinamentos" class="row"></div>
+</div>
+<script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/turma-detalhe.html
+++ b/src/static/turma-detalhe.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Detalhe da Turma</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/selecao-sistema.html">Conecta SENAI</a>
+    </div>
+</nav>
+<div class="container">
+    <h1 class="mb-3">Detalhe da Turma</h1>
+    <div id="detalhe-turma"></div>
+</div>
+<script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/turmas-admin.html
+++ b/src/static/turmas-admin.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Turmas de Treinamento</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-primary mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/selecao-sistema.html">Conecta SENAI</a>
+    </div>
+</nav>
+<div class="container">
+    <h1 class="mb-3">Turmas de Treinamento</h1>
+    <div id="lista-turmas" class="table-responsive"></div>
+</div>
+<script src="/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce Treinamento, TurmaTreinamento, Inscricao and Presenca models
- expose catalog and enrollment API routes
- add admin dashboard and CRUD endpoints
- register new blueprint in the Flask app
- create basic HTML pages for training management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878337fcf988323a456a2df3fbc7f93