### PR TITLE
Add training module skeleton

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from src.routes.notificacao import notificacao_bp
 from src.routes.ocupacao import ocupacao_bp
 from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
+from src.routes.treinamento import treinamento_bp
 from src.routes.user import user_bp
 from src.routes.rateio import rateio_bp
 from src.models.recurso import Recurso
@@ -112,6 +113,7 @@ def create_app():
     app.register_blueprint(notificacao_bp, url_prefix='/api')
     app.register_blueprint(laboratorio_bp, url_prefix='/api')
     app.register_blueprint(turma_bp, url_prefix='/api')
+    app.register_blueprint(treinamento_bp, url_prefix='/api')
     app.register_blueprint(sala_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
     app.register_blueprint(ocupacao_bp, url_prefix='/api')

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -8,6 +8,10 @@ from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
 from .rateio import RateioConfig, LancamentoRateio  # noqa: E402
 from .log_rateio import LogLancamentoRateio  # noqa: E402
+from .treinamento import Treinamento  # noqa: E402
+from .turma import TurmaTreinamento  # noqa: E402
+from .inscricao import Inscricao  # noqa: E402
+from .presenca import Presenca  # noqa: E402
 
 __all__ = [
     "db",
@@ -17,4 +21,8 @@ __all__ = [
     "RateioConfig",
     "LancamentoRateio",
     "LogLancamentoRateio",
+    "Treinamento",
+    "TurmaTreinamento",
+    "Inscricao",
+    "Presenca",
 ]

--- a/src/models/inscricao.py
+++ b/src/models/inscricao.py
@@ -1,0 +1,28 @@
+"""Modelo de inscrição de usuários em turmas."""
+from datetime import datetime
+from src.models import db
+
+
+class Inscricao(db.Model):
+    """Representa a inscrição de um usuário em uma turma."""
+    __tablename__ = 'inscricoes'
+
+    id = db.Column(db.Integer, primary_key=True)
+    turma_id = db.Column(db.Integer, db.ForeignKey('turmas_treinamentos.id'), nullable=False)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'), nullable=False)
+    status = db.Column(db.String(20), default='inscrito')
+    data_inscricao = db.Column(db.DateTime, default=datetime.utcnow)
+
+    presencas = db.relationship('Presenca', backref='inscricao', lazy=True, cascade='all, delete-orphan')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'turma_id': self.turma_id,
+            'usuario_id': self.usuario_id,
+            'status': self.status,
+            'data_inscricao': self.data_inscricao.isoformat() if self.data_inscricao else None,
+        }
+
+    def __repr__(self):
+        return f'<Inscricao usuario={self.usuario_id} turma={self.turma_id}>'

--- a/src/models/presenca.py
+++ b/src/models/presenca.py
@@ -1,0 +1,24 @@
+"""Modelo de registro de presença nas aulas."""
+from datetime import date
+from src.models import db
+
+
+class Presenca(db.Model):
+    """Registra a presença de um inscrito em determinada data."""
+    __tablename__ = 'presencas'
+
+    id = db.Column(db.Integer, primary_key=True)
+    inscricao_id = db.Column(db.Integer, db.ForeignKey('inscricoes.id'), nullable=False)
+    data = db.Column(db.Date, nullable=False)
+    presente = db.Column(db.Boolean, default=False)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'inscricao_id': self.inscricao_id,
+            'data': self.data.isoformat() if self.data else None,
+            'presente': self.presente,
+        }
+
+    def __repr__(self):
+        return f'<Presenca inscricao={self.inscricao_id} data={self.data}>'

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -1,0 +1,34 @@
+"""Modelo de treinamento."""
+from datetime import datetime
+from src.models import db
+
+
+class Treinamento(db.Model):
+    """Representa um treinamento oferecido."""
+    __tablename__ = 'treinamentos'
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(100), nullable=False)
+    codigo = db.Column(db.String(50), nullable=False, unique=True)
+    descricao = db.Column(db.Text)
+    carga_horaria = db.Column(db.Integer)
+    status = db.Column(db.String(20), default='ativo')
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+    data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    turmas = db.relationship('TurmaTreinamento', backref='treinamento', lazy=True, cascade='all, delete-orphan')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'nome': self.nome,
+            'codigo': self.codigo,
+            'descricao': self.descricao,
+            'carga_horaria': self.carga_horaria,
+            'status': self.status,
+            'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
+            'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None,
+        }
+
+    def __repr__(self):
+        return f'<Treinamento {self.codigo}>'

--- a/src/models/turma.py
+++ b/src/models/turma.py
@@ -1,0 +1,36 @@
+"""Modelo de turma vinculada a um treinamento."""
+from datetime import datetime, date
+from src.models import db
+
+
+class TurmaTreinamento(db.Model):
+    """Turma de um treinamento."""
+    __tablename__ = 'turmas_treinamentos'
+
+    id = db.Column(db.Integer, primary_key=True)
+    treinamento_id = db.Column(db.Integer, db.ForeignKey('treinamentos.id'), nullable=False)
+    nome = db.Column(db.String(100))
+    data_inicio = db.Column(db.Date)
+    data_fim = db.Column(db.Date)
+    vagas = db.Column(db.Integer)
+    status = db.Column(db.String(20), default='aberta')
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+    data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    inscricoes = db.relationship('Inscricao', backref='turma', lazy=True, cascade='all, delete-orphan')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'treinamento_id': self.treinamento_id,
+            'nome': self.nome,
+            'data_inicio': self.data_inicio.isoformat() if self.data_inicio else None,
+            'data_fim': self.data_fim.isoformat() if self.data_fim else None,
+            'vagas': self.vagas,
+            'status': self.status,
+            'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
+            'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None,
+        }
+
+    def __repr__(self):
+        return f'<TurmaTreinamento {self.id} do treinamento {self.treinamento_id}>'

--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -1,0 +1,236 @@
+"""Rotas para gerenciamento de treinamentos e turmas."""
+from flask import Blueprint, request, jsonify
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.models import db, Treinamento, TurmaTreinamento, Inscricao, Presenca
+from src.routes.user import verificar_autenticacao, verificar_admin
+from src.utils.error_handler import handle_internal_error
+
+
+treinamento_bp = Blueprint('treinamento', __name__)
+
+
+# ---- Treinamentos ---------------------------------------------------------
+
+@treinamento_bp.route('/treinamentos', methods=['GET'])
+def listar_treinamentos():
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    treins = Treinamento.query.all()
+    return jsonify([t.to_dict() for t in treins])
+
+
+@treinamento_bp.route('/treinamentos/<int:id>', methods=['GET'])
+def obter_treinamento(id):
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    treino = db.session.get(Treinamento, id)
+    if not treino:
+        return jsonify({'erro': 'Treinamento não encontrado'}), 404
+    return jsonify(treino.to_dict())
+
+
+@treinamento_bp.route('/treinamentos', methods=['POST'])
+def criar_treinamento():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    data = request.json or {}
+    try:
+        novo = Treinamento(
+            nome=data.get('nome'),
+            codigo=data.get('codigo'),
+            descricao=data.get('descricao'),
+            carga_horaria=data.get('carga_horaria'),
+            status=data.get('status', 'ativo'),
+        )
+        db.session.add(novo)
+        db.session.commit()
+        return jsonify(novo.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/treinamentos/<int:id>', methods=['PUT'])
+def atualizar_treinamento(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    treino = db.session.get(Treinamento, id)
+    if not treino:
+        return jsonify({'erro': 'Treinamento não encontrado'}), 404
+    data = request.json or {}
+    treino.nome = data.get('nome', treino.nome)
+    treino.codigo = data.get('codigo', treino.codigo)
+    treino.descricao = data.get('descricao', treino.descricao)
+    treino.carga_horaria = data.get('carga_horaria', treino.carga_horaria)
+    treino.status = data.get('status', treino.status)
+    try:
+        db.session.commit()
+        return jsonify(treino.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/treinamentos/<int:id>', methods=['DELETE'])
+def remover_treinamento(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    treino = db.session.get(Treinamento, id)
+    if not treino:
+        return jsonify({'erro': 'Treinamento não encontrado'}), 404
+    try:
+        db.session.delete(treino)
+        db.session.commit()
+        return jsonify({'mensagem': 'Treinamento removido'})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+# ---- Turmas ---------------------------------------------------------------
+
+@treinamento_bp.route('/turmas', methods=['GET'])
+def listar_turmas():
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    turmas = TurmaTreinamento.query.all()
+    return jsonify([t.to_dict() for t in turmas])
+
+
+@treinamento_bp.route('/turmas/<int:id>', methods=['GET'])
+def obter_turma(id):
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    turma = db.session.get(TurmaTreinamento, id)
+    if not turma:
+        return jsonify({'erro': 'Turma não encontrada'}), 404
+    return jsonify(turma.to_dict())
+
+
+@treinamento_bp.route('/turmas', methods=['POST'])
+def criar_turma():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    data = request.json or {}
+    try:
+        nova = TurmaTreinamento(
+            treinamento_id=data.get('treinamento_id'),
+            nome=data.get('nome'),
+            data_inicio=data.get('data_inicio'),
+            data_fim=data.get('data_fim'),
+            vagas=data.get('vagas'),
+            status=data.get('status', 'aberta'),
+        )
+        db.session.add(nova)
+        db.session.commit()
+        return jsonify(nova.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/turmas/<int:id>', methods=['PUT'])
+def atualizar_turma(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    turma = db.session.get(TurmaTreinamento, id)
+    if not turma:
+        return jsonify({'erro': 'Turma não encontrada'}), 404
+    data = request.json or {}
+    turma.nome = data.get('nome', turma.nome)
+    turma.data_inicio = data.get('data_inicio', turma.data_inicio)
+    turma.data_fim = data.get('data_fim', turma.data_fim)
+    turma.vagas = data.get('vagas', turma.vagas)
+    turma.status = data.get('status', turma.status)
+    try:
+        db.session.commit()
+        return jsonify(turma.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/turmas/<int:id>', methods=['DELETE'])
+def remover_turma(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    if not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    turma = db.session.get(TurmaTreinamento, id)
+    if not turma:
+        return jsonify({'erro': 'Turma não encontrada'}), 404
+    try:
+        db.session.delete(turma)
+        db.session.commit()
+        return jsonify({'mensagem': 'Turma removida'})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+# ---- Inscricoes e Presencas ----------------------------------------------
+
+@treinamento_bp.route('/inscricoes', methods=['POST'])
+def inscrever_usuario():
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    data = request.json or {}
+    try:
+        nova = Inscricao(
+            turma_id=data.get('turma_id'),
+            usuario_id=user.id,
+        )
+        db.session.add(nova)
+        db.session.commit()
+        return jsonify(nova.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route('/inscricoes/<int:id>/presencas', methods=['POST'])
+def registrar_presenca(id):
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+    inscricao = db.session.get(Inscricao, id)
+    if not inscricao:
+        return jsonify({'erro': 'Inscrição não encontrada'}), 404
+    if inscricao.usuario_id != user.id and not verificar_admin(user):
+        return jsonify({'erro': 'Permissão negada'}), 403
+    data = request.json or {}
+    try:
+        pres = Presenca(
+            inscricao_id=id,
+            data=data.get('data'),
+            presente=data.get('presente', True),
+        )
+        db.session.add(pres)
+        db.session.commit()
+        return jsonify(pres.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+

--- a/src/static/catalogo-admin.html
+++ b/src/static/catalogo-admin.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Catálogo de Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Agenda de Treinamentos">Agenda de Treinamentos</span>
+            </a>
+        </div>
+    </nav>
+
+    <div class="container-fluid">
+        <div class="row">
+            <main class="col-12">
+                <div class="page-header">
+                    <h2 class="mb-0">Catálogo de Treinamentos</h2>
+                    <button class="btn btn-primary" onclick="novaEntrada()">
+                        <i class="bi bi-plus-circle me-2"></i>NOVO TREINAMENTO
+                    </button>
+                </div>
+
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-3 align-items-end">
+                            <div class="col-md-4">
+                                <label for="filtroNome" class="form-label">Nome</label>
+                                <input type="text" class="form-control" id="filtroNome" placeholder="Nome do treinamento">
+                            </div>
+                            <div class="col-md-3">
+                                <label for="filtroStatus" class="form-label">Status</label>
+                                <select id="filtroStatus" class="form-select">
+                                    <option value="">Todos</option>
+                                    <option value="ativo">Ativo</option>
+                                    <option value="inativo">Inativo</option>
+                                </select>
+                            </div>
+                            <div class="col-md-5 text-end">
+                                <button id="btnAplicarFiltros" type="button" class="btn btn-primary me-2">
+                                    <i class="bi bi-search me-1"></i>Filtrar
+                                </button>
+                                <button id="btnLimparFiltros" type="button" class="btn btn-outline-secondary">
+                                    <i class="bi bi-x-circle me-1"></i>Limpar
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE TREINAMENTOS</h5>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th scope="col">NOME</th>
+                                        <th scope="col">CÓDIGO</th>
+                                        <th scope="col">CARGA HORÁRIA</th>
+                                        <th scope="col">STATUS</th>
+                                        <th scope="col" class="text-end">AÇÕES</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="tabelaCatalogo">
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/catalogo-admin.js"></script>
+</body>
+</html>

--- a/src/static/dashboard-treinamentos.html
+++ b/src/static/dashboard-treinamentos.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard - Agenda de Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Agenda de Treinamentos">Agenda de Treinamentos</span>
+            </a>
+        </div>
+    </nav>
+
+    <div class="container-fluid">
+        <div class="row">
+            <main class="col-12">
+                <div class="page-header">
+                    <h2 class="mb-0">Dashboard - Agenda de Treinamentos</h2>
+                    <button class="btn btn-primary" onclick="window.location.href='/turmas-admin.html'">
+                        <i class="bi bi-plus-circle me-2"></i>NOVA TURMA
+                    </button>
+                </div>
+
+                <div class="row mb-4">
+                    <div class="col-lg-3 col-md-6 mb-4">
+                        <div class="card kpi-card">
+                            <div class="card-body">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <h6 class="kpi-title text-uppercase">Treinamentos em Andamento</h6>
+                                        <h2 class="kpi-number" id="kpiAndamento">-</h2>
+                                    </div>
+                                    <i class="bi bi-graph-up-arrow kpi-icon"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-6 mb-4">
+                        <div class="card kpi-card">
+                            <div class="card-body">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <h6 class="kpi-title text-uppercase">Participantes no Mês</h6>
+                                        <h2 class="kpi-number" id="kpiParticipantesMes">-</h2>
+                                    </div>
+                                    <i class="bi bi-people kpi-icon"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-6 mb-4">
+                        <div class="card kpi-card">
+                            <div class="card-body">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <h6 class="kpi-title text-uppercase">Taxa de Ocupação</h6>
+                                        <h2 class="kpi-number" id="kpiOcupacao">-</h2>
+                                    </div>
+                                    <i class="bi bi-bar-chart-line kpi-icon"></i>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-4">
+                        <div class="card h-100">
+                            <div class="card-header">
+                                <h5 class="card-title mb-0">Treinamentos Mais Procurados</h5>
+                            </div>
+                            <div class="card-body">
+                                <canvas id="graficoMaisProcurados" height="200"></canvas>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6 mb-4">
+                        <div class="card h-100">
+                            <div class="card-header">
+                                <h5 class="card-title mb-0">Próximas Turmas a Iniciar</h5>
+                            </div>
+                            <div class="card-body">
+                                <div id="listaProximasTurmas"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/dashboard-treinamentos.js"></script>
+</body>
+</html>

--- a/src/static/meus-treinamentos.html
+++ b/src/static/meus-treinamentos.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meus Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="/selecao-sistema.html">Agenda de Treinamentos</a>
+        </div>
+    </nav>
+
+    <div class="container py-4">
+        <div class="page-header">
+            <h2 class="mb-0">Meus Treinamentos</h2>
+        </div>
+
+        <div class="accordion mt-4" id="accordionTreinamentos">
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/meus-treinamentos.js"></script>
+</body>
+</html>

--- a/src/static/portal-treinamentos.html
+++ b/src/static/portal-treinamentos.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Portal de Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="#">Portal de Treinamentos</a>
+        </div>
+    </nav>
+
+    <div class="container py-4">
+        <h2 class="mb-4 text-center">Treinamentos Disponíveis</h2>
+        <div class="row row-cols-1 row-cols-md-3 g-4" id="grelhaTreinamentos">
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/portal-treinamentos.js"></script>
+</body>
+</html>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -122,6 +122,21 @@
                     </div>
                 </div>
             </div>
+
+            <div class="col-md-5 mb-4">
+                <div class="card sistema-card h-100" onclick="window.location.href='/dashboard-treinamentos.html'">
+                    <div class="card-body text-center p-5">
+                        <div class="sistema-icon">
+                            <i class="bi bi-calendar-check"></i>
+                        </div>
+                        <h3 class="card-title">AGENDA DE TREINAMENTOS</h3>
+                        <p class="card-text">Módulo para gestão de catálogo de cursos, turmas, inscrições e participantes.</p>
+                        <div class="mt-4">
+                            <span class="badge bg-warning text-dark">Em Desenvolvimento</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     

--- a/src/static/turma-detalhe.html
+++ b/src/static/turma-detalhe.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Detalhes da Turma</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Agenda de Treinamentos">Agenda de Treinamentos</span>
+            </a>
+        </div>
+    </nav>
+
+    <div class="container py-4">
+        <div class="page-header">
+            <h2 id="tituloTurma">Detalhes da Turma</h2>
+        </div>
+
+        <div class="card mt-4">
+            <div class="card-body">
+                <ul class="nav nav-tabs" id="tabsTurma" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="tab-participantes" data-bs-toggle="tab" data-bs-target="#participantes" type="button" role="tab">Participantes</button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="tab-presencas" data-bs-toggle="tab" data-bs-target="#presencas" type="button" role="tab">Lista de Presença</button>
+                    </li>
+                </ul>
+                <div class="tab-content mt-3" id="conteudoTurma">
+                    <div class="tab-pane fade show active" id="participantes" role="tabpanel">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>Aluno</th>
+                                    <th>Email</th>
+                                </tr>
+                            </thead>
+                            <tbody id="listaParticipantes"></tbody>
+                        </table>
+                    </div>
+                    <div class="tab-pane fade" id="presencas" role="tabpanel">
+                        <table class="table table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>Data</th>
+                                    <th>Presente</th>
+                                </tr>
+                            </thead>
+                            <tbody id="listaPresencas"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/turma-detalhe.js"></script>
+</body>
+</html>

--- a/src/static/turmas-admin.html
+++ b/src/static/turmas-admin.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestão de Turmas</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Agenda de Treinamentos">Agenda de Treinamentos</span>
+            </a>
+        </div>
+    </nav>
+
+    <div class="container-fluid">
+        <div class="row">
+            <main class="col-12">
+                <div class="page-header">
+                    <h2 class="mb-0">Gestão de Turmas</h2>
+                    <button class="btn btn-primary" onclick="criarTurma()">
+                        <i class="bi bi-plus-circle me-2"></i>CRIAR TURMA
+                    </button>
+                </div>
+
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-3 align-items-end">
+                            <div class="col-md-4">
+                                <label for="filtroTreinamento" class="form-label">Treinamento</label>
+                                <input type="text" class="form-control" id="filtroTreinamento" placeholder="Nome do treinamento">
+                            </div>
+                            <div class="col-md-3">
+                                <label for="filtroStatus" class="form-label">Status</label>
+                                <select id="filtroStatus" class="form-select">
+                                    <option value="">Todos</option>
+                                    <option value="aberta">Aberta</option>
+                                    <option value="concluida">Concluída</option>
+                                </select>
+                            </div>
+                            <div class="col-md-5 text-end">
+                                <button id="btnAplicarFiltros" type="button" class="btn btn-primary me-2">
+                                    <i class="bi bi-search me-1"></i>Filtrar
+                                </button>
+                                <button id="btnLimparFiltros" type="button" class="btn btn-outline-secondary">
+                                    <i class="bi bi-x-circle me-1"></i>Limpar
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE TURMAS</h5>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-hover mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th scope="col">TREINAMENTO</th>
+                                        <th scope="col">DATAS</th>
+                                        <th scope="col">STATUS</th>
+                                        <th scope="col" class="text-end">AÇÕES</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="tabelaTurmas">
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/turmas-admin.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add card for Agenda de Treinamentos
- introduce models for training management
- register new blueprint and routes
- create admin and portal pages for trainings

## Testing
- `pytest -q`
- `flask --app src.main db migrate -m "treinamentos" && flask --app src.main db upgrade` *(fails: duplicate column name)*

------
https://chatgpt.com/codex/tasks/task_e_68783a23eda08323b57b98a17574323d