### PR TITLE
Fix training module card link

### DIFF
--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -64,18 +64,16 @@
             </div>
 
             <div class="col-md-5 mb-4 admin-only">
-                <div class="card sistema-card h-100" onclick="window.location.href="/agenda-treinamentos.html"">
-                    <div class="card-body text-center p-5">
-                        <div class="sistema-icon">
-                            <i class="fas fa-chalkboard-teacher"></i>
-                        </div>
-                        <h3 class="card-title">Agenda de Treinamentos</h3>
-                        <p class="card-text">Módulo para programação e gestão de treinamentos por área técnica.</p>
-                        <div class="mt-4">
+                <a href="pages/agenda-treinamentos.html" class="text-decoration-none text-dark">
+                    <div class="card h-100">
+                        <div class="card-body text-center">
+                            <div class="icon"><i class="fas fa-chalkboard-teacher"></i></div>
+                            <h5 class="card-title">AGENDA DE TREINAMENTOS</h5>
+                            <p>Módulo para programação e gestão de treinamentos por área técnica.</p>
                             <span class="badge bg-success">Disponível</span>
                         </div>
                     </div>
-                </div>
+                </a>
             </div>
 
             <div class="col-md-5 mb-4">


### PR DESCRIPTION
## Summary
- add anchor link for Agenda de Treinamentos card so card is clickable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687938cf256c8323a4743e177e305e81