### PR TITLE
Fix training agenda page redirect

### DIFF
--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -64,7 +64,7 @@
             </div>
 
             <div class="col-md-5 mb-4 admin-only">
-                <div class="card sistema-card h-100" onclick="window.location.href="/agenda-treinamentos.html"">
+                <div class="card sistema-card h-100" onclick="window.location.href='/agenda-treinamentos.html'">
                     <div class="card-body text-center p-5">
                         <div class="sistema-icon">
                             <i class="fas fa-chalkboard-teacher"></i>


### PR DESCRIPTION
## Summary
- fix the onclick handler for the agenda de treinamentos card

## Testing
- `flake8 --max-line-length=120 --exit-zero`
- `bandit -r src -ll`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793de322dc8323b7780c3dd7624d1e