### PR TITLE
Add training module backend and frontend integration

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.user import user_bp
 from src.routes.rateio import rateio_bp
+from src.routes.treinamento import treinamento_bp
 from src.models.recurso import Recurso
 
 MIGRATIONS_DIR = os.path.join(os.path.dirname(__file__), '..', 'migrations')
@@ -116,6 +117,7 @@ def create_app():
     app.register_blueprint(instrutor_bp, url_prefix='/api')
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
     app.register_blueprint(rateio_bp, url_prefix='/api')
+    app.register_blueprint(treinamento_bp, url_prefix='/api')
 
     @app.route('/')
     def index():

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -8,6 +8,7 @@ from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
 from .rateio import RateioConfig, LancamentoRateio  # noqa: E402
 from .log_rateio import LogLancamentoRateio  # noqa: E402
+from .treinamento import Treinamento, TurmaTreinamento, MaterialDidatico, Inscricao, ListaPresenca  # noqa: E402
 
 __all__ = [
     "db",
@@ -17,4 +18,9 @@ __all__ = [
     "RateioConfig",
     "LancamentoRateio",
     "LogLancamentoRateio",
+    "Treinamento",
+    "TurmaTreinamento",
+    "MaterialDidatico",
+    "Inscricao",
+    "ListaPresenca",
 ]

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -1,0 +1,100 @@
+from src.models import db
+from datetime import datetime
+
+# Tabela de associação entre Turma e Instrutor (Muitos para Muitos)
+turma_instrutores = db.Table(
+    'turma_instrutores',
+    db.Column('turma_id', db.Integer, db.ForeignKey('treinamento_turmas.id'), primary_key=True),
+    db.Column('instrutor_id', db.Integer, db.ForeignKey('instrutores.id'), primary_key=True)
+)
+
+
+class Treinamento(db.Model):
+    """Modelo para o catálogo de treinamentos."""
+
+    __tablename__ = 'treinamentos'
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(200), nullable=False, unique=True)
+    codigo = db.Column(db.String(50), unique=True, nullable=True)
+    carga_horaria = db.Column(db.Integer, nullable=False)
+    data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
+
+    materiais = db.relationship('MaterialDidatico', backref='treinamento', lazy=True, cascade='all, delete-orphan')
+    turmas = db.relationship('TurmaTreinamento', backref='treinamento', lazy=True)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'nome': self.nome,
+            'codigo': self.codigo,
+            'carga_horaria': self.carga_horaria,
+            'materiais': [m.to_dict() for m in self.materiais],
+        }
+
+
+class TurmaTreinamento(db.Model):
+    """Modelo para as turmas de um treinamento."""
+
+    __tablename__ = 'treinamento_turmas'
+    id = db.Column(db.Integer, primary_key=True)
+    treinamento_id = db.Column(db.Integer, db.ForeignKey('treinamentos.id'), nullable=False)
+    data_inicio = db.Column(db.Date, nullable=False)
+    data_fim = db.Column(db.Date, nullable=False)
+    status = db.Column(db.String(50), default='A realizar')  # 'A realizar', 'Em andamento', 'Concluída', 'Cancelada'
+
+    instrutores = db.relationship(
+        'Instrutor',
+        secondary=turma_instrutores,
+        lazy='subquery',
+        backref=db.backref('turmas_treinamento', lazy=True),
+    )
+
+    inscricoes = db.relationship('Inscricao', backref='turma', lazy=True, cascade='all, delete-orphan')
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'treinamento_id': self.treinamento_id,
+            'treinamento_nome': self.treinamento.nome if self.treinamento else None,
+            'data_inicio': self.data_inicio.isoformat(),
+            'data_fim': self.data_fim.isoformat(),
+            'status': self.status,
+            'instrutores': [i.to_dict() for i in self.instrutores],
+            'participantes': [i.usuario.to_dict() for i in self.inscricoes],
+        }
+
+
+class MaterialDidatico(db.Model):
+    """Modelo para materiais didáticos."""
+
+    __tablename__ = 'treinamento_materiais'
+    id = db.Column(db.Integer, primary_key=True)
+    treinamento_id = db.Column(db.Integer, db.ForeignKey('treinamentos.id'), nullable=False)
+    descricao = db.Column(db.String(255), nullable=False)
+    url = db.Column(db.String(500), nullable=True)
+
+    def to_dict(self):
+        return {'id': self.id, 'descricao': self.descricao, 'url': self.url}
+
+
+class Inscricao(db.Model):
+    """Modelo para inscrição de um usuário em uma turma."""
+
+    __tablename__ = 'treinamento_inscricoes'
+    id = db.Column(db.Integer, primary_key=True)
+    turma_id = db.Column(db.Integer, db.ForeignKey('treinamento_turmas.id'), nullable=False)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'), nullable=False)
+    data_inscricao = db.Column(db.DateTime, default=datetime.utcnow)
+
+    usuario = db.relationship('User', backref='inscricoes_treinamento')
+    presencas = db.relationship('ListaPresenca', backref='inscricao', lazy=True, cascade='all, delete-orphan')
+
+
+class ListaPresenca(db.Model):
+    """Modelo para a lista de presença."""
+
+    __tablename__ = 'treinamento_presenca'
+    id = db.Column(db.Integer, primary_key=True)
+    inscricao_id = db.Column(db.Integer, db.ForeignKey('treinamento_inscricoes.id'), nullable=False)
+    data_aula = db.Column(db.Date, nullable=False)
+    presente = db.Column(db.Boolean, default=False)

--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -1,0 +1,49 @@
+from flask import Blueprint, request, jsonify, g
+from src.models import db
+from src.models.treinamento import Treinamento, TurmaTreinamento, Inscricao, MaterialDidatico
+from src.models.instrutor import Instrutor
+from src.models.user import User
+from src.auth import admin_required, login_required
+from datetime import datetime
+
+
+treinamento_bp = Blueprint('treinamento', __name__)
+
+
+@treinamento_bp.route('/treinamentos', methods=['GET'])
+@login_required
+def listar_treinamentos():
+    treinamentos = Treinamento.query.order_by(Treinamento.nome).all()
+    return jsonify([t.to_dict() for t in treinamentos])
+
+
+@treinamento_bp.route('/turmas_disponiveis', methods=['GET'])
+@login_required
+def listar_turmas_disponiveis():
+    turmas = TurmaTreinamento.query.filter(TurmaTreinamento.status.in_(['A realizar', 'Em andamento'])).all()
+    return jsonify([t.to_dict() for t in turmas])
+
+
+@treinamento_bp.route('/turmas/inscrever', methods=['POST'])
+@login_required
+def inscrever_em_turma():
+    user = g.current_user
+    data = request.get_json()
+    turma_id = data.get('turma_id') if data else None
+
+    if not turma_id:
+        return jsonify({"erro": "ID da turma é obrigatório"}), 400
+
+    turma = TurmaTreinamento.query.get(turma_id)
+    if not turma:
+        return jsonify({"erro": "Turma não encontrada"}), 404
+
+    ja_inscrito = Inscricao.query.filter_by(turma_id=turma_id, usuario_id=user.id).first()
+    if ja_inscrito:
+        return jsonify({"erro": "Você já está inscrito nesta turma"}), 409
+
+    nova_inscricao = Inscricao(turma_id=turma_id, usuario_id=user.id)
+    db.session.add(nova_inscricao)
+    db.session.commit()
+
+    return jsonify({"mensagem": "Inscrição realizada com sucesso!"}), 201

--- a/src/static/js/portal-treinamentos.js
+++ b/src/static/js/portal-treinamentos.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // Garante que o usuário está autenticado
+    if (!verificarAutenticacao()) return;
+
+    const usuario = getUsuarioLogado();
+    if (usuario) {
+        document.getElementById('userName').textContent = usuario.nome;
+        if (isAdmin()) {
+            document.querySelectorAll('.admin-only').forEach(el => {
+                el.style.display = 'list-item';
+            });
+        }
+    }
+
+    carregarTurmasDisponiveis();
+});
+
+async function carregarTurmasDisponiveis() {
+    const container = document.getElementById('lista-treinamentos');
+    if (!container) return;
+
+    container.innerHTML = `<div class="text-center"><div class="spinner-border text-primary"></div></div>`;
+
+    try {
+        const turmas = await chamarAPI('/turmas_disponiveis');
+        if (!turmas || turmas.length === 0) {
+            container.innerHTML = '<p class="text-muted text-center">Nenhum treinamento disponível no momento.</p>';
+            return;
+        }
+
+        let html = '';
+        turmas.forEach(turma => {
+            const instrutores = turma.instrutores.map(i => i.nome).join(', ') || 'A definir';
+            html += `
+                <div class="col-md-6 col-lg-4 mb-4">
+                    <div class="card h-100 shadow-sm">
+                        <div class="card-body d-flex flex-column">
+                            <h5 class="card-title">${escapeHTML(turma.treinamento_nome)}</h5>
+                            <p class="card-text text-muted">
+                                <i class="bi bi-calendar-event"></i> Início em: ${formatarData(turma.data_inicio)} <br>
+                                <i class="bi bi-person-badge"></i> Instrutor(es): ${escapeHTML(instrutores)}
+                            </p>
+                            <button class="btn btn-primary mt-auto" onclick="inscreverNaTurma(${turma.id})">
+                                <i class="bi bi-check-circle-fill me-2"></i>Inscrever-se
+                            </button>
+                        </div>
+                    </div>
+                </div>`;
+        });
+        container.innerHTML = html;
+    } catch (error) {
+        container.innerHTML = `<p class="text-danger text-center">Erro ao carregar treinamentos: ${escapeHTML(error.message)}</p>`;
+    }
+}
+
+async function inscreverNaTurma(turmaId) {
+    try {
+        await chamarAPI('/turmas/inscrever', 'POST', { turma_id: turmaId });
+        exibirAlerta('Inscrição realizada com sucesso!', 'success');
+    } catch (error) {
+        exibirAlerta(error.message, 'danger');
+    }
+}

--- a/src/static/treinamentos/portal.html
+++ b/src/static/treinamentos/portal.html
@@ -62,7 +62,7 @@
 
             <main class="col-lg-9 col-md-12">
                 <h2 class="mb-4">Treinamentos Disponíveis</h2>
-                <div class="row" id="cardsTreinamentos">
+                <div class="row" id="lista-treinamentos">
                     <div class="col-md-6 col-lg-4 mb-4">
                         <div class="card h-100">
                             <div class="card-body">
@@ -90,6 +90,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="/js/portal-treinamentos.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             if (!isUserAdmin()) {


### PR DESCRIPTION
## Summary
- implement training-related models
- register training models in model package
- create new training API routes
- register training blueprint
- add frontend JS for training portal
- hook JS in portal page

## Testing
- `pytest -q`
- `flake8 --max-line-length=120 --exit-zero`
- `bandit -r src -ll`


------
https://chatgpt.com/codex/tasks/task_e_687982b2ed148323bfc75a4ef1a43efd