### PR TITLE
Add admin and user training endpoints

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ from src.routes.user import user_bp
 from src.routes.rateio import rateio_bp
 from src.routes.treinamento import treinamento_bp
 from src.routes.treinamento_admin import admin_treinamento_bp
+from src.routes.treinamento_user import user_treinamento_bp
 from src.models.recurso import Recurso
 
 MIGRATIONS_DIR = os.path.join(os.path.dirname(__file__), '..', 'migrations')
@@ -119,7 +120,8 @@ def create_app():
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
     app.register_blueprint(rateio_bp, url_prefix='/api')
     app.register_blueprint(treinamento_bp, url_prefix='/api')
-    app.register_blueprint(admin_treinamento_bp, url_prefix='/api')
+    app.register_blueprint(admin_treinamento_bp, url_prefix='/api/admin')
+    app.register_blueprint(user_treinamento_bp, url_prefix='/api/user')
 
     @app.route('/')
     def index():

--- a/src/routes/treinamento_user.py
+++ b/src/routes/treinamento_user.py
@@ -1,0 +1,1 @@
+from .treinamento import treinamento_bp as user_treinamento_bp

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -2,10 +2,12 @@ from .sala import SalaCreateSchema, SalaUpdateSchema
 from .instrutor import InstrutorCreateSchema, InstrutorUpdateSchema
 from .ocupacao import OcupacaoCreateSchema, OcupacaoUpdateSchema
 from .rateio import RateioConfigCreateSchema, LancamentoRateioSchema
+from .treinamento import TreinamentoCreateSchema
 
 __all__ = [
     'SalaCreateSchema', 'SalaUpdateSchema',
     'InstrutorCreateSchema', 'InstrutorUpdateSchema',
     'OcupacaoCreateSchema', 'OcupacaoUpdateSchema',
     'RateioConfigCreateSchema', 'LancamentoRateioSchema',
+    'TreinamentoCreateSchema',
 ]

--- a/src/schemas/treinamento.py
+++ b/src/schemas/treinamento.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+class MaterialDidaticoSchema(BaseModel):
+    descricao: Optional[str] = 'Material Principal'
+    url: str
+
+class TreinamentoCreateSchema(BaseModel):
+    nome: str
+    codigo: Optional[str] = None
+    carga_horaria: int = Field(gt=0)
+    max_alunos: int = Field(gt=0)
+    materiais: Optional[List[MaterialDidaticoSchema]] = None


### PR DESCRIPTION
## Summary
- implement training admin blueprint
- alias training user blueprint
- update schema exports and create TreinamentoCreateSchema
- register new blueprints with url prefixes in `create_app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2e38fae083239c585fae45aad8cd