### PR TITLE
Fix blueprint registration issue

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -121,7 +121,11 @@ def create_app():
     app.register_blueprint(rateio_bp, url_prefix='/api')
     app.register_blueprint(treinamento_bp, url_prefix='/api')
     app.register_blueprint(admin_treinamento_bp, url_prefix='/api/admin')
-    app.register_blueprint(user_treinamento_bp, url_prefix='/api/user')
+    app.register_blueprint(
+        user_treinamento_bp,
+        url_prefix='/api/user',
+        name='treinamento_user',
+    )
 
     @app.route('/')
     def index():


### PR DESCRIPTION
## Summary
- allow registering treinamento routes twice by providing a custom name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a334251f083238ba7fd849a1ec0ec