### PR TITLE
Fix Novo Treinamento button visibility

### DIFF
--- a/src/static/treinamentos/catalogo-treinamentos.html
+++ b/src/static/treinamentos/catalogo-treinamentos.html
@@ -61,6 +61,9 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h2 class="mb-0">Catálogo de Treinamentos</h2>
+                    <button id="btn-novo-treinamento" class="btn btn-primary">
+                        <i class="bi bi-plus-circle me-2"></i>NOVO TREINAMENTO
+                    </button>
                 </div>
 
                 <div id="alertContainer"></div>


### PR DESCRIPTION
## Summary
- restore page header structure on catalogo-treinamentos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc87943188323b244921ae6b48bc8