### PR TITLE
Fix duplicate table migration

### DIFF
--- a/migrations/versions/dcae188d3b1b_add_log_lancamento_rateio.py
+++ b/migrations/versions/dcae188d3b1b_add_log_lancamento_rateio.py
@@ -24,6 +24,7 @@ def upgrade():
         sa.Column('classe_valor', sa.String(length=100), nullable=True),
         sa.Column('percentual', sa.Float, nullable=True),
         sa.Column('observacao', sa.Text, nullable=True),
+        checkfirst=True,
     )
 
 


### PR DESCRIPTION
## Summary
- avoid duplicate table creation by adding `checkfirst=True` to table creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cda4d12c48323a4e3d68f64cecd35