### PR TITLE
Implement training catalog endpoints

### DIFF
--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -15,19 +15,43 @@ class Treinamento(db.Model):
     codigo = db.Column(db.String(50), unique=True, nullable=True)
     carga_horaria = db.Column(db.Integer, nullable=False)
     max_alunos = db.Column(db.Integer, nullable=False, default=20)
+    materiais = db.Column(db.Text, nullable=True)
     data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
 
-    materiais = db.relationship('MaterialDidatico', backref='treinamento', lazy='dynamic', cascade='all, delete-orphan')
-    turmas = db.relationship('TurmaTreinamento', backref='treinamento', lazy='dynamic', cascade='all, delete-orphan')
+    materiais_didaticos = db.relationship(
+        'MaterialDidatico',
+        backref='treinamento',
+        lazy='dynamic',
+        cascade='all, delete-orphan'
+    )
+    turmas = db.relationship(
+        'TurmaTreinamento',
+        backref='treinamento',
+        lazy='dynamic',
+        cascade='all, delete-orphan'
+    )
 
-    def to_dict_full(self):
+    def to_dict(self):
+        """Retorna representacao simples do treinamento."""
         return {
             'id': self.id,
             'nome': self.nome,
             'codigo': self.codigo,
             'carga_horaria': self.carga_horaria,
             'max_alunos': self.max_alunos,
-            'materiais': [m.to_dict() for m in self.materiais]
+            'materiais': self.materiais,
+        }
+
+    def to_dict_full(self):
+        """Inclui materiais didáticos relacionados."""
+        return {
+            'id': self.id,
+            'nome': self.nome,
+            'codigo': self.codigo,
+            'carga_horaria': self.carga_horaria,
+            'max_alunos': self.max_alunos,
+            'materiais': self.materiais,
+            'materiais_didaticos': [m.to_dict() for m in self.materiais_didaticos],
         }
 
 class TurmaTreinamento(db.Model):

--- a/src/routes/treinamento_admin.py
+++ b/src/routes/treinamento_admin.py
@@ -37,7 +37,13 @@ def criar_treinamento():
     if dados.get('materiais'):
         for mat in dados['materiais']:
             if mat.get('url'):
-                db.session.add(MaterialDidatico(descricao=mat.get('descricao', 'Material'), url=mat['url'], treinamento=novo_treinamento))
+                db.session.add(
+                    MaterialDidatico(
+                        descricao=mat.get('descricao', 'Material'),
+                        url=mat['url'],
+                        treinamento=novo_treinamento,
+                    )
+                )
 
     db.session.commit()
     return jsonify(novo_treinamento.to_dict_full()), 201
@@ -57,7 +63,13 @@ def atualizar_treinamento(id):
     if dados.get('materiais'):
         for mat in dados['materiais']:
             if mat.get('url'):
-                db.session.add(MaterialDidatico(descricao=mat.get('descricao', 'Material'), url=mat['url'], treinamento_id=id))
+                db.session.add(
+                    MaterialDidatico(
+                        descricao=mat.get('descricao', 'Material'),
+                        url=mat['url'],
+                        treinamento_id=id,
+                    )
+                )
 
     db.session.commit()
     return jsonify(treinamento.to_dict_full())

--- a/src/static/js/treinamentos/catalogo.js
+++ b/src/static/js/treinamentos/catalogo.js
@@ -49,7 +49,7 @@ function abrirModal(data={}) {
   document.getElementById('codigo').value = data.codigo || '';
   document.getElementById('carga_horaria').value = data.carga_horaria || '';
   document.getElementById('max_alunos').value = data.max_alunos || 20;
-  document.getElementById('materiais').value = (data.materiais||[]).map(m=>m.url).join('\n');
+  document.getElementById('materiais').value = (data.materiais_didaticos||[]).map(m=>m.url).join('\n');
   modal.show();
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from src.routes.sala import sala_bp
 from src.routes.turma import turma_bp
 from src.routes.agendamento import agendamento_bp
 from src.routes.instrutor import instrutor_bp
+from src.routes.treinamento import treinamento_bp
 
 @pytest.fixture
 def app():
@@ -34,6 +35,7 @@ def app():
     app.register_blueprint(turma_bp, url_prefix='/api')
     app.register_blueprint(agendamento_bp, url_prefix='/api')
     app.register_blueprint(instrutor_bp, url_prefix='/api')
+    app.register_blueprint(treinamento_bp, url_prefix='/api')
 
     with app.app_context():
         db.create_all()

--- a/tests/test_treinamento_routes.py
+++ b/tests/test_treinamento_routes.py
@@ -1,0 +1,37 @@
+import pytest
+
+
+def test_criar_e_listar_treinamento(client, login_admin):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.post('/api/treinamentos', json={
+        'nome': 'Python Basico',
+        'codigo': 'PY001',
+        'carga_horaria': 20,
+        'max_alunos': 30,
+        'materiais': 'Apostila'
+    }, headers=headers)
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data['nome'] == 'Python Basico'
+
+    resp = client.get('/api/treinamentos')
+    assert resp.status_code == 200
+    lista = resp.get_json()
+    assert any(t['nome'] == 'Python Basico' for t in lista)
+
+
+def test_criar_treinamento_dados_invalidos(client, login_admin):
+    token, _ = login_admin(client)
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.post('/api/treinamentos', json={'nome': 'Invalido'}, headers=headers)
+    assert resp.status_code == 400
+
+
+def test_criar_treinamento_nao_admin(client, non_admin_auth_headers):
+    resp = client.post('/api/treinamentos', json={
+        'nome': 'X',
+        'carga_horaria': 10,
+        'max_alunos': 5
+    }, headers=non_admin_auth_headers)
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add `materiais` column and new helper methods to Treinamento model
- expose training list/creation endpoints
- adjust admin routes and JS to use renamed `materiais_didaticos`
- register training blueprint in tests and add route tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ce432cb088323b3d5bdf29a653312