### PR TITLE
Fix API endpoint for trainings catalog

### DIFF
--- a/src/static/js/treinamentos/catalogo.js
+++ b/src/static/js/treinamentos/catalogo.js
@@ -9,7 +9,7 @@ async function carregarTreinamentos() {
   const tbody = document.getElementById('tabela-catalogo');
   tbody.innerHTML = '<tr><td colspan="5">Carregando...</td></tr>';
   try {
-    const dados = await chamarAPI('/user/treinamentos');
+    const dados = await chamarAPI('/admin/treinamentos');
     tbody.innerHTML = '';
     if (!Array.isArray(dados) || !dados.length) {
       tbody.innerHTML = '<tr><td colspan="5" class="text-center">Nenhum treinamento cadastrado.</td></tr>';


### PR DESCRIPTION
## Summary
- point trainings catalog to the administrative endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf1ac79f88323b46625572d8f10c0