### PR TITLE
Remove migrations from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local /usr/local
 COPY ./src ./src
-COPY ./migrations ./migrations
+# Migrations are created at runtime; ensure directory exists
+RUN mkdir -p /app/migrations
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Todas as variáveis disponíveis estão listadas em `.env.example`.
    Um servidor Redis precisa estar ativo no endereço definido em `REDIS_URL` para que a limitação de requisições e a revogação de tokens funcionem corretamente.
 
 3. Execute as migrações do banco para criar as tabelas necessárias ou
-   atualizar o esquema após mudanças no código:
+   atualizar o esquema após mudanças no código. O diretório `migrations`
+   será criado automaticamente caso ainda não exista:
 
    ```bash
    flask --app src.main db upgrade
@@ -66,6 +67,9 @@ Uma alternativa é rodar a aplicação em um container Docker. Para construir a 
 docker build -t agenda-senai .
 ```
 
+As migrações não são mais distribuídas no repositório. O diretório será criado
+automaticamente quando a aplicação rodar o comando de upgrade.
+
 Em seguida, inicie o container usando as variáveis definidas em um arquivo `.env`:
 
    ```bash
@@ -80,7 +84,8 @@ A aplicação ficará disponível em [http://localhost:8000](http://localhost:80
 - `src/routes/` - Blueprints com as rotas REST de cada recurso.
 - `src/models/` - Definições das tabelas e regras de negócios.
 - `src/static/` - Arquivos estáticos de frontend (HTML, CSS e JavaScript).
-- `migrations/` - Migrações do banco de dados gerenciadas pelo Flask-Migrate.
+- `migrations/` - Criado automaticamente em tempo de execução para armazenar as
+  migrações do banco de dados.
 - `tests/` - Casos de teste automatizados.
 
 ## Principais Endpoints da API


### PR DESCRIPTION
## Summary
- delete the step that copied migrations into the image
- create the migrations directory during build
- document that migrations are generated at runtime

## Testing
- `pytest -q`
- `docker build -t agenda-senai .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687cf7c292fc8323aacaf1ecf40f708d