### PR TITLE
Add extra user profile fields

### DIFF
--- a/src/models/user.py
+++ b/src/models/user.py
@@ -15,6 +15,9 @@ class User(db.Model):
         tipo (str): Tipo de usuário ('comum' ou 'admin')
         data_criacao (datetime): Data de criação do registro
         data_atualizacao (datetime): Data da última atualização do registro
+        data_nascimento (date): Data de nascimento do usuário (opcional)
+        cpf (str): CPF do usuário (opcional)
+        empresa (str): Empresa do usuário (opcional)
     """
     __tablename__ = 'usuarios'
     
@@ -25,7 +28,14 @@ class User(db.Model):
     senha_hash = db.Column(db.String(256), nullable=False)
     tipo = db.Column(db.String(20), nullable=False, default='comum')
     data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
-    data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    data_atualizacao = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    # Novos campos opcionais
+    data_nascimento = db.Column(db.Date, nullable=True)
+    cpf = db.Column(db.String(14), unique=True, nullable=True)
+    empresa = db.Column(db.String(100), nullable=True)
     
     # Relacionamento com agendamentos
     agendamentos = db.relationship('Agendamento', backref='usuario', lazy=True)
@@ -92,6 +102,9 @@ class User(db.Model):
             'username': self.username,
             'email': self.email,
             'tipo': self.tipo,
+            'data_nascimento': self.data_nascimento.isoformat() if self.data_nascimento else None,
+            'cpf': self.cpf,
+            'empresa': self.empresa,
             'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
             'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None
         }

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -271,6 +271,25 @@ def atualizar_usuario(id):
             return jsonify({"erro": "Email já cadastrado para outro usuário"}), 400
         usuario.email = data["email"]
 
+    if "cpf" in data:
+        cpf_valor = data["cpf"] or None
+        if cpf_valor:
+            cpf_existente = User.query.filter_by(cpf=cpf_valor).first()
+            if cpf_existente and cpf_existente.id != id:
+                return jsonify({"erro": "CPF já cadastrado para outro usuário"}), 400
+        usuario.cpf = cpf_valor
+
+    if "empresa" in data:
+        usuario.empresa = data["empresa"] or None
+
+    if "data_nascimento" in data and data["data_nascimento"]:
+        try:
+            usuario.data_nascimento = datetime.strptime(data["data_nascimento"], "%Y-%m-%d").date()
+        except (ValueError, TypeError):
+            usuario.data_nascimento = None
+    elif "data_nascimento" in data and not data["data_nascimento"]:
+        usuario.data_nascimento = None
+
     # Apenas administradores podem alterar o tipo de usuário
     if "tipo" in data and verificar_admin(user):
         if data["tipo"] not in ["comum", "admin"]:

--- a/src/static/admin/admin-perfil.html
+++ b/src/static/admin/admin-perfil.html
@@ -91,8 +91,23 @@
                                         <label for="email" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="email" name="email" required>
                                     </div>
-                                    
-                                    
+
+                                    <div class="row">
+                                        <div class="col-md-6 mb-3">
+                                            <label for="data_nascimento" class="form-label">Data de Nascimento</label>
+                                            <input type="date" class="form-control" id="data_nascimento" name="data_nascimento">
+                                        </div>
+                                        <div class="col-md-6 mb-3">
+                                            <label for="cpf" class="form-label">CPF</label>
+                                            <input type="text" class="form-control" id="cpf" name="cpf" placeholder="000.000.000-00">
+                                        </div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="empresa" class="form-label">Empresa</label>
+                                        <input type="text" class="form-control" id="empresa" name="empresa">
+                                    </div>
+
                                     <div class="mb-3">
                                         <label for="tipo" class="form-label">Tipo de Usuário</label>
                                         <input type="text" class="form-control" id="tipo" name="tipo" readonly>
@@ -183,13 +198,19 @@
                 
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
+                const data_nascimento = document.getElementById('data_nascimento').value;
+                const cpf = document.getElementById('cpf').value;
+                const empresa = document.getElementById('empresa').value;
                 
                 try {
                     const usuario = getUsuarioLogado();
                     
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
                         nome,
-                        email
+                        email,
+                        data_nascimento,
+                        cpf,
+                        empresa
                     });
                     
                     // Atualiza os dados no localStorage
@@ -250,6 +271,9 @@
                 document.getElementById('nome').value = dadosUsuario.nome;
                 document.getElementById('email').value = dadosUsuario.email;
                 document.getElementById('tipo').value = dadosUsuario.tipo === 'admin' ? 'Administrador' : 'Comum';
+                document.getElementById('data_nascimento').value = dadosUsuario.data_nascimento || '';
+                document.getElementById('cpf').value = dadosUsuario.cpf || '';
+                document.getElementById('empresa').value = dadosUsuario.empresa || '';
                 
                 // Atualiza os dados no localStorage
                 localStorage.setItem('usuario', JSON.stringify(dadosUsuario));

--- a/src/static/laboratorios/laboratorios-perfil.html
+++ b/src/static/laboratorios/laboratorios-perfil.html
@@ -114,8 +114,23 @@
                                         <label for="email" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="email" name="email" required>
                                     </div>
-                                    
-                                    
+
+                                    <div class="row">
+                                        <div class="col-md-6 mb-3">
+                                            <label for="data_nascimento" class="form-label">Data de Nascimento</label>
+                                            <input type="date" class="form-control" id="data_nascimento" name="data_nascimento">
+                                        </div>
+                                        <div class="col-md-6 mb-3">
+                                            <label for="cpf" class="form-label">CPF</label>
+                                            <input type="text" class="form-control" id="cpf" name="cpf" placeholder="000.000.000-00">
+                                        </div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="empresa" class="form-label">Empresa</label>
+                                        <input type="text" class="form-control" id="empresa" name="empresa">
+                                    </div>
+
                                     <div class="mb-3">
                                         <label for="tipo" class="form-label">Tipo de Usuário</label>
                                         <input type="text" class="form-control" id="tipo" name="tipo" readonly>
@@ -212,13 +227,19 @@
                 
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
+                const data_nascimento = document.getElementById('data_nascimento').value;
+                const cpf = document.getElementById('cpf').value;
+                const empresa = document.getElementById('empresa').value;
                 
                 try {
                     const usuario = getUsuarioLogado();
                     
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
                         nome,
-                        email
+                        email,
+                        data_nascimento,
+                        cpf,
+                        empresa
                     });
                     
                     // Atualiza os dados no localStorage
@@ -279,6 +300,9 @@
                 document.getElementById('nome').value = dadosUsuario.nome;
                 document.getElementById('email').value = dadosUsuario.email;
                 document.getElementById('tipo').value = dadosUsuario.tipo === 'admin' ? 'Administrador' : 'Comum';
+                document.getElementById('data_nascimento').value = dadosUsuario.data_nascimento || '';
+                document.getElementById('cpf').value = dadosUsuario.cpf || '';
+                document.getElementById('empresa').value = dadosUsuario.empresa || '';
                 
                 // Atualiza os dados no localStorage
                 localStorage.setItem('usuario', JSON.stringify(dadosUsuario));

--- a/src/static/ocupacao/ocupacao-perfil.html
+++ b/src/static/ocupacao/ocupacao-perfil.html
@@ -132,8 +132,23 @@
                                         <label for="email" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="email" name="email" required>
                                     </div>
-                                    
-                                    
+
+                                    <div class="row">
+                                        <div class="col-md-6 mb-3">
+                                            <label for="data_nascimento" class="form-label">Data de Nascimento</label>
+                                            <input type="date" class="form-control" id="data_nascimento" name="data_nascimento">
+                                        </div>
+                                        <div class="col-md-6 mb-3">
+                                            <label for="cpf" class="form-label">CPF</label>
+                                            <input type="text" class="form-control" id="cpf" name="cpf" placeholder="000.000.000-00">
+                                        </div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="empresa" class="form-label">Empresa</label>
+                                        <input type="text" class="form-control" id="empresa" name="empresa">
+                                    </div>
+
                                     <div class="mb-3">
                                         <label for="tipo" class="form-label">Tipo de Usuário</label>
                                         <input type="text" class="form-control" id="tipo" name="tipo" readonly>
@@ -230,13 +245,19 @@
                 
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
+                const data_nascimento = document.getElementById('data_nascimento').value;
+                const cpf = document.getElementById('cpf').value;
+                const empresa = document.getElementById('empresa').value;
                 
                 try {
                     const usuario = getUsuarioLogado();
                     
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
                         nome,
-                        email
+                        email,
+                        data_nascimento,
+                        cpf,
+                        empresa
                     });
                     
                     // Atualiza os dados no localStorage
@@ -297,6 +318,9 @@
                 document.getElementById('nome').value = dadosUsuario.nome;
                 document.getElementById('email').value = dadosUsuario.email;
                 document.getElementById('tipo').value = dadosUsuario.tipo === 'admin' ? 'Administrador' : 'Comum';
+                document.getElementById('data_nascimento').value = dadosUsuario.data_nascimento || '';
+                document.getElementById('cpf').value = dadosUsuario.cpf || '';
+                document.getElementById('empresa').value = dadosUsuario.empresa || '';
                 
                 // Atualiza os dados no localStorage
                 localStorage.setItem('usuario', JSON.stringify(dadosUsuario));

--- a/src/static/rateio/rateio-perfil.html
+++ b/src/static/rateio/rateio-perfil.html
@@ -99,8 +99,23 @@
                                         <label for="email" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="email" name="email" required>
                                     </div>
-                                    
-                                    
+
+                                    <div class="row">
+                                        <div class="col-md-6 mb-3">
+                                            <label for="data_nascimento" class="form-label">Data de Nascimento</label>
+                                            <input type="date" class="form-control" id="data_nascimento" name="data_nascimento">
+                                        </div>
+                                        <div class="col-md-6 mb-3">
+                                            <label for="cpf" class="form-label">CPF</label>
+                                            <input type="text" class="form-control" id="cpf" name="cpf" placeholder="000.000.000-00">
+                                        </div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="empresa" class="form-label">Empresa</label>
+                                        <input type="text" class="form-control" id="empresa" name="empresa">
+                                    </div>
+
                                     <div class="mb-3">
                                         <label for="tipo" class="form-label">Tipo de Usuário</label>
                                         <input type="text" class="form-control" id="tipo" name="tipo" readonly>
@@ -199,13 +214,19 @@
                 
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
+                const data_nascimento = document.getElementById('data_nascimento').value;
+                const cpf = document.getElementById('cpf').value;
+                const empresa = document.getElementById('empresa').value;
                 
                 try {
                     const usuario = getUsuarioLogado();
                     
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
                         nome,
-                        email
+                        email,
+                        data_nascimento,
+                        cpf,
+                        empresa
                     });
                     
                     // Atualiza os dados no localStorage
@@ -266,6 +287,9 @@
                 document.getElementById('nome').value = dadosUsuario.nome;
                 document.getElementById('email').value = dadosUsuario.email;
                 document.getElementById('tipo').value = dadosUsuario.tipo === 'admin' ? 'Administrador' : 'Comum';
+                document.getElementById('data_nascimento').value = dadosUsuario.data_nascimento || '';
+                document.getElementById('cpf').value = dadosUsuario.cpf || '';
+                document.getElementById('empresa').value = dadosUsuario.empresa || '';
                 
                 // Atualiza os dados no localStorage
                 localStorage.setItem('usuario', JSON.stringify(dadosUsuario));

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -267,3 +267,35 @@ def test_root_admin_can_downgrade_admin(client, login_admin):
     )
     assert resp_downgrade.status_code == 200
     assert resp_downgrade.get_json()['tipo'] == 'comum'
+
+
+def test_atualizar_usuario_novos_campos(client):
+    resp = client.post(
+        '/api/usuarios',
+        json={'nome': 'Novo', 'email': 'novo2@example.com', 'senha': 'Senha@123'},
+        environ_base={'REMOTE_ADDR': '1.1.1.16'}
+    )
+    assert resp.status_code == 201
+    user_id = resp.get_json()['id']
+
+    resp_login = client.post('/api/login', json={'email': 'novo2@example.com', 'senha': 'Senha@123'})
+    assert resp_login.status_code == 200
+    token = resp_login.get_json()['token']
+    headers = {'Authorization': f'Bearer {token}'}
+
+    resp_put = client.put(
+        f'/api/usuarios/{user_id}',
+        json={
+            'nome': 'Novo Nome',
+            'email': 'novo2@example.com',
+            'data_nascimento': '2000-01-02',
+            'cpf': '123.456.789-00',
+            'empresa': 'ACME'
+        },
+        headers=headers,
+    )
+    assert resp_put.status_code == 200
+    data = resp_put.get_json()
+    assert data['cpf'] == '123.456.789-00'
+    assert data['empresa'] == 'ACME'
+    assert data['data_nascimento'] == '2000-01-02'


### PR DESCRIPTION
## Summary
- extend `User` model to support birth date, CPF and company
- allow `/usuarios/<id>` updates to handle those fields
- expose new fields in profile HTML pages and JavaScript
- test updating the additional profile fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cffb7ed188323bab1858148a68b42