### PR TITLE
Add missing Flask-Cors dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "flask-migrate (==4.0.5)",
     "flask-jwt-extended (==4.6.0)"
     ,"requests (==2.31.0)"
+    ,"flask-cors (==4.0.0)"
 ]
 
 [tool.poetry]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ werkzeug==3.1.3
 pymysql==1.1.1
 cryptography==45.0.5
 requests
+Flask-Cors


### PR DESCRIPTION
## Summary
- add Flask-Cors to dependencies

## Testing
- `pip install -r requirements.txt`
- `pip install pydantic==2.5.3`
- `pip install email-validator==2.2.0`
- `pip install openpyxl==3.1.2`
- `pip install reportlab==4.0.8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d04606d048323bc6e66e13b520bb7