### PR TITLE
Handle missing migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,14 @@ Todas as variáveis disponíveis estão listadas em `.env.example`.
    Um servidor Redis precisa estar ativo no endereço definido em `REDIS_URL` para que a limitação de requisições e a revogação de tokens funcionem corretamente.
 
 3. Execute as migrações do banco para criar as tabelas necessárias ou
-   atualizar o esquema após mudanças no código. O diretório `migrations`
-   será criado automaticamente caso ainda não exista:
+   atualizar o esquema após mudanças no código. Caso o diretório
+   `migrations` ainda não exista, inicie-o primeiro:
+
+   ```bash
+   flask --app src.main db init
+   ```
+
+   Em seguida aplique as migrações:
 
    ```bash
    flask --app src.main db upgrade
@@ -67,8 +73,14 @@ Uma alternativa é rodar a aplicação em um container Docker. Para construir a 
 docker build -t agenda-senai .
 ```
 
-As migrações não são mais distribuídas no repositório. O diretório será criado
-automaticamente quando a aplicação rodar o comando de upgrade.
+As migrações não são mais distribuídas no repositório. Se o diretório
+`migrations` não existir, crie-o com:
+
+```bash
+flask --app src.main db init
+```
+
+Em seguida execute o comando de upgrade normalmente.
 
 Em seguida, inicie o container usando as variáveis definidas em um arquivo `.env`:
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ from logging.handlers import RotatingFileHandler
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 from flask_migrate import Migrate, upgrade
+import flask_migrate
 from flask_login import LoginManager, login_user
 
 from src.models import db
@@ -110,6 +111,10 @@ def create_app():
 
         try:
             # Aplica as migrations do banco de dados
+            env_path = os.path.join(migrations_dir, "env.py")
+            if not os.path.exists(env_path):
+                flask_migrate.init(directory=migrations_dir)
+                flask_migrate.migrate(directory=migrations_dir, message="initial")
             upgrade(directory=migrations_dir)
             app.logger.info("Migrations aplicadas com sucesso.")
         except Exception as e:


### PR DESCRIPTION
## Summary
- initialize database migrations if not present
- document running `db init` before `db upgrade`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d13dc5a508323831d8c3d47c85dc9