### PR TITLE
Fix admin password env fallback

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -123,13 +123,13 @@ def create_app():
         # Cria o usuário administrador se não existir
         try:
             admin_email = os.getenv("ADMIN_EMAIL")
-            admin_senha = os.getenv("ADMIN_SENHA")
+            admin_password = os.getenv("ADMIN_PASSWORD") or os.getenv("ADMIN_SENHA")
 
             if admin_email and not User.query.filter_by(email=admin_email).first():
                 admin_user = User(
                     nome="Administrador",
                     email=admin_email,
-                    senha=admin_senha,
+                    senha=admin_password,
                     tipo="admin",
                 )
                 db.session.add(admin_user)


### PR DESCRIPTION
## Summary
- read optional `ADMIN_SENHA` when `ADMIN_PASSWORD` isn't set
- keep README and `.env.example` referencing `ADMIN_PASSWORD`

## Testing
- `pip install -r requirements.txt`
- `pip install pydantic==2.5.3 openpyxl==3.1.2 reportlab==4.0.8`
- `pip install 'email-validator==2.2.0'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d185b7ed483239b66519c3bcd0467