### PR TITLE
Add email-validator to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ cryptography==45.0.5
 requests
 Flask-Cors
 Flask-Login
+email-validator==2.2.0


### PR DESCRIPTION
## Summary
- include `email-validator` to align requirements with `pyproject.toml`

## Testing
- `flake8 --max-line-length=120 --exit-zero`
- `bandit -r src -ll`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d1a56887c8323b01e0872fa2f2e56