### PR TITLE
Fix migrations initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local /usr/local
 COPY ./src ./src
-# Migrations are created at runtime; ensure directory exists
-RUN mkdir -p /app/migrations
 
 EXPOSE 8080
 

--- a/src/main.py
+++ b/src/main.py
@@ -129,8 +129,9 @@ def create_app():
         return app.send_static_file(path)
 
     with app.app_context():
-        if not os.path.exists(MIGRATIONS_DIR):
-            logging.info("Pasta de migrations nao encontrada, inicializando...")
+        env_path = os.path.join(MIGRATIONS_DIR, 'env.py')
+        if not os.path.exists(env_path):
+            logging.info("Inicializando diret\u00f3rio de migrations...")
             try:
                 init(directory=MIGRATIONS_DIR)
                 migrate_cmd(directory=MIGRATIONS_DIR)


### PR DESCRIPTION
## Summary
- avoid pre-creating migrations directory in Dockerfile
- check for `env.py` before initializing migrations directory

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q email-validator==2.2.0`
- `pip install -q openpyxl==3.1.2`
- `pip install -q reportlab==4.0.8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d919dd8cc8323a4c0baa56e92ed3a