### PR TITLE
Fix migrations directory for production

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -21,8 +21,7 @@ from src.routes.rateio import rateio_bp
 from src.models.recurso import Recurso
 import sqlalchemy as sa
 
-MIGRATIONS_DIR = os.path.join(os.path.dirname(__file__), '..', 'migrations')
-migrate = Migrate(directory=MIGRATIONS_DIR)
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 def create_admin(app):
     """Cria o usuário administrador padrão de forma idempotente."""
@@ -85,6 +84,8 @@ def create_app():
     logging.basicConfig(level=logging.INFO)
     app = Flask(__name__, static_url_path='', static_folder='static')
 
+    migrations_dir = os.path.join(project_root, 'migrations')
+
     db_uri = os.getenv("DATABASE_URL", "sqlite:///agenda_laboratorio.db").strip()
     if db_uri.startswith('postgres://'):
         db_uri = db_uri.replace('postgres://', 'postgresql://', 1)
@@ -101,7 +102,7 @@ def create_app():
     app.config['SECRET_KEY'] = secret_key
 
     db.init_app(app)
-    migrate.init_app(app, db)
+    Migrate(app, db, directory=migrations_dir)
     init_redis(app)
     limiter.init_app(app)
 
@@ -129,26 +130,25 @@ def create_app():
         return app.send_static_file(path)
 
     with app.app_context():
-        if not os.path.exists(MIGRATIONS_DIR):
+        if not os.path.exists(migrations_dir):
             logging.info("Pasta de migrations nao encontrada, inicializando...")
             try:
-                init(directory=MIGRATIONS_DIR)
-                migrate_cmd(directory=MIGRATIONS_DIR)
+                init(directory=migrations_dir)
+                migrate_cmd(directory=migrations_dir)
             except Exception as e:  # pragma: no cover - primeira migracao opcional
                 logging.error("Erro ao criar migrations: %s", str(e))
 
-        versions_dir = os.path.join(MIGRATIONS_DIR, 'versions')
+        versions_dir = os.path.join(migrations_dir, 'versions')
         if not os.path.exists(versions_dir) or not os.listdir(versions_dir):
             try:
-                migrate_cmd(directory=MIGRATIONS_DIR)
+                migrate_cmd(directory=migrations_dir)
             except Exception as e:  # pragma: no cover - geracao opcional
                 logging.error("Erro ao gerar migrations: %s", str(e))
 
         try:
-            upgrade(directory=MIGRATIONS_DIR)
+            upgrade(directory=migrations_dir)
         except Exception as e:  # pragma: no cover - migracao opcional
             logging.error("Erro ao aplicar migrations: %s", str(e))
-        db.create_all()
         create_admin(app)
         create_default_recursos(app)
 


### PR DESCRIPTION
## Summary
- ensure absolute migrations path based on project root
- initialize Flask-Migrate with this directory
- rely solely on migrations to manage the DB

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d936e3a5c8323b34fccfa7763427b