### PR TITLE
Add optional user info storage

### DIFF
--- a/src/models/user.py
+++ b/src/models/user.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 from werkzeug.security import generate_password_hash, check_password_hash
 from src.models import db
+from .user_info import UserInfo
 
 class User(db.Model):
     """
@@ -29,6 +30,8 @@ class User(db.Model):
     
     # Relacionamento com agendamentos
     agendamentos = db.relationship('Agendamento', backref='usuario', lazy=True)
+    # Informações opcionais
+    info = db.relationship('UserInfo', uselist=False, back_populates='user', cascade='all, delete-orphan')
     
     def __init__(self, nome, email, senha, tipo='comum', username=None):
         """
@@ -45,6 +48,8 @@ class User(db.Model):
         self.username = username or email.split('@')[0]
         self.set_senha(senha)
         self.tipo = tipo
+        # Cria registro de informações opcionais associado
+        self.info = UserInfo()
     
     def set_senha(self, senha):
         """
@@ -93,7 +98,10 @@ class User(db.Model):
             'email': self.email,
             'tipo': self.tipo,
             'data_criacao': self.data_criacao.isoformat() if self.data_criacao else None,
-            'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None
+            'data_atualizacao': self.data_atualizacao.isoformat() if self.data_atualizacao else None,
+            'cpf': self.info.cpf if self.info else None,
+            'data_nascimento': self.info.data_nascimento.isoformat() if self.info and self.info.data_nascimento else None,
+            'empresa': self.info.empresa if self.info else None,
         }
     
     def __repr__(self):

--- a/src/models/user_info.py
+++ b/src/models/user_info.py
@@ -1,0 +1,21 @@
+from src.models import db
+
+class UserInfo(db.Model):
+    """Informações opcionais adicionais dos usuários."""
+
+    __tablename__ = 'usuarios_info'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('usuarios.id'), nullable=False, unique=True)
+    cpf = db.Column(db.String(14))
+    data_nascimento = db.Column(db.Date)
+    empresa = db.Column(db.String(150))
+
+    user = db.relationship('User', back_populates='info')
+
+    def to_dict(self):
+        return {
+            'cpf': self.cpf,
+            'data_nascimento': self.data_nascimento.isoformat() if self.data_nascimento else None,
+            'empresa': self.empresa,
+        }

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -10,6 +10,7 @@ import jwt
 import uuid
 from src.models import db
 from src.models.user import User
+from src.models.user_info import UserInfo
 from src.models.refresh_token import RefreshToken
 import hashlib
 from src.redis_client import redis_conn
@@ -154,6 +155,9 @@ def criar_usuario():
     nome = dados.get("nome")
     senha = dados.get("senha")
     username = dados.get("username") or email.split('@')[0]
+    cpf = dados.get("cpf")
+    data_nascimento = dados.get("data_nascimento")
+    empresa = dados.get("empresa")
 
     # Validação de dados
     if not all([nome, email, senha]):
@@ -185,6 +189,14 @@ def criar_usuario():
             tipo="comum",
             username=username,
         )
+        if cpf or data_nascimento or empresa:
+            novo_usuario.info.cpf = cpf
+            if data_nascimento:
+                try:
+                    novo_usuario.info.data_nascimento = datetime.strptime(data_nascimento, "%Y-%m-%d").date()
+                except ValueError:
+                    return jsonify({"erro": "Data de nascimento inválida"}), 400
+            novo_usuario.info.empresa = empresa
         db.session.add(novo_usuario)
         db.session.commit()
         return jsonify(novo_usuario.to_dict()), 201
@@ -201,6 +213,9 @@ def registrar_usuario():
     senha = request.form.get("senha")
     username = request.form.get("username") or email.split('@')[0]
     confirmar = request.form.get("confirmarSenha")
+    cpf = request.form.get("cpf")
+    data_nascimento = request.form.get("data_nascimento")
+    empresa = request.form.get("empresa")
 
     if not all([nome, email, senha, confirmar]):
         return jsonify({"erro": "Dados incompletos"}), 400
@@ -229,6 +244,14 @@ def registrar_usuario():
             tipo="comum",
             username=username,
         )
+        if cpf or data_nascimento or empresa:
+            novo_usuario.info.cpf = cpf
+            if data_nascimento:
+                try:
+                    novo_usuario.info.data_nascimento = datetime.strptime(data_nascimento, "%Y-%m-%d").date()
+                except ValueError:
+                    return jsonify({"erro": "Data de nascimento inválida"}), 400
+            novo_usuario.info.empresa = empresa
         db.session.add(novo_usuario)
         db.session.commit()
     except SQLAlchemyError as e:  # pragma: no cover
@@ -270,6 +293,23 @@ def atualizar_usuario(id):
         if email_existente and email_existente.id != id:
             return jsonify({"erro": "Email já cadastrado para outro usuário"}), 400
         usuario.email = data["email"]
+
+    if any(k in data for k in ("cpf", "data_nascimento", "empresa")):
+        if not usuario.info:
+            usuario.info = UserInfo()
+        if "cpf" in data:
+            usuario.info.cpf = data["cpf"] or None
+        if "data_nascimento" in data:
+            valor = data["data_nascimento"]
+            if valor:
+                try:
+                    usuario.info.data_nascimento = datetime.strptime(valor, "%Y-%m-%d").date()
+                except ValueError:
+                    return jsonify({"erro": "Data de nascimento inválida"}), 400
+            else:
+                usuario.info.data_nascimento = None
+        if "empresa" in data:
+            usuario.info.empresa = data["empresa"] or None
 
     # Apenas administradores podem alterar o tipo de usuário
     if "tipo" in data and verificar_admin(user):

--- a/src/static/admin/admin-perfil.html
+++ b/src/static/admin/admin-perfil.html
@@ -91,6 +91,21 @@
                                         <label for="email" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="email" name="email" required>
                                     </div>
+
+                                    <div class="mb-3">
+                                        <label for="cpf" class="form-label">CPF</label>
+                                        <input type="text" class="form-control" id="cpf" name="cpf">
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="dataNascimento" class="form-label">Data de Nascimento</label>
+                                        <input type="date" class="form-control" id="dataNascimento" name="dataNascimento">
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="empresa" class="form-label">Empresa</label>
+                                        <input type="text" class="form-control" id="empresa" name="empresa">
+                                    </div>
                                     
                                     
                                     <div class="mb-3">
@@ -183,18 +198,27 @@
                 
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
+                const cpf = document.getElementById('cpf').value;
+                const dataNascimento = document.getElementById('dataNascimento').value;
+                const empresa = document.getElementById('empresa').value;
                 
                 try {
                     const usuario = getUsuarioLogado();
                     
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
                         nome,
-                        email
+                        email,
+                        cpf,
+                        data_nascimento: dataNascimento,
+                        empresa
                     });
                     
                     // Atualiza os dados no localStorage
                     usuario.nome = nome;
                     usuario.email = email;
+                    usuario.cpf = cpf;
+                    usuario.data_nascimento = dataNascimento || null;
+                    usuario.empresa = empresa;
                     localStorage.setItem('usuario', JSON.stringify(usuario));
                     
                     // Atualiza o nome na navbar
@@ -249,6 +273,9 @@
                 // Preenche o formulário
                 document.getElementById('nome').value = dadosUsuario.nome;
                 document.getElementById('email').value = dadosUsuario.email;
+                document.getElementById('cpf').value = dadosUsuario.cpf || '';
+                document.getElementById('dataNascimento').value = dadosUsuario.data_nascimento ? dadosUsuario.data_nascimento.split('T')[0] : '';
+                document.getElementById('empresa').value = dadosUsuario.empresa || '';
                 document.getElementById('tipo').value = dadosUsuario.tipo === 'admin' ? 'Administrador' : 'Comum';
                 
                 // Atualiza os dados no localStorage

--- a/src/static/laboratorios/laboratorios-perfil.html
+++ b/src/static/laboratorios/laboratorios-perfil.html
@@ -114,6 +114,21 @@
                                         <label for="email" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="email" name="email" required>
                                     </div>
+
+                                    <div class="mb-3">
+                                        <label for="cpf" class="form-label">CPF</label>
+                                        <input type="text" class="form-control" id="cpf" name="cpf">
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="dataNascimento" class="form-label">Data de Nascimento</label>
+                                        <input type="date" class="form-control" id="dataNascimento" name="dataNascimento">
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="empresa" class="form-label">Empresa</label>
+                                        <input type="text" class="form-control" id="empresa" name="empresa">
+                                    </div>
                                     
                                     
                                     <div class="mb-3">
@@ -212,18 +227,27 @@
                 
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
+                const cpf = document.getElementById('cpf').value;
+                const dataNascimento = document.getElementById('dataNascimento').value;
+                const empresa = document.getElementById('empresa').value;
                 
                 try {
                     const usuario = getUsuarioLogado();
                     
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
                         nome,
-                        email
+                        email,
+                        cpf,
+                        data_nascimento: dataNascimento,
+                        empresa
                     });
                     
                     // Atualiza os dados no localStorage
                     usuario.nome = nome;
                     usuario.email = email;
+                    usuario.cpf = cpf;
+                    usuario.data_nascimento = dataNascimento || null;
+                    usuario.empresa = empresa;
                     localStorage.setItem('usuario', JSON.stringify(usuario));
                     
                     // Atualiza o nome na navbar
@@ -278,6 +302,9 @@
                 // Preenche o formulário
                 document.getElementById('nome').value = dadosUsuario.nome;
                 document.getElementById('email').value = dadosUsuario.email;
+                document.getElementById('cpf').value = dadosUsuario.cpf || '';
+                document.getElementById('dataNascimento').value = dadosUsuario.data_nascimento ? dadosUsuario.data_nascimento.split('T')[0] : '';
+                document.getElementById('empresa').value = dadosUsuario.empresa || '';
                 document.getElementById('tipo').value = dadosUsuario.tipo === 'admin' ? 'Administrador' : 'Comum';
                 
                 // Atualiza os dados no localStorage

--- a/src/static/ocupacao/ocupacao-perfil.html
+++ b/src/static/ocupacao/ocupacao-perfil.html
@@ -132,6 +132,21 @@
                                         <label for="email" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="email" name="email" required>
                                     </div>
+
+                                    <div class="mb-3">
+                                        <label for="cpf" class="form-label">CPF</label>
+                                        <input type="text" class="form-control" id="cpf" name="cpf">
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="dataNascimento" class="form-label">Data de Nascimento</label>
+                                        <input type="date" class="form-control" id="dataNascimento" name="dataNascimento">
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="empresa" class="form-label">Empresa</label>
+                                        <input type="text" class="form-control" id="empresa" name="empresa">
+                                    </div>
                                     
                                     
                                     <div class="mb-3">
@@ -230,18 +245,27 @@
                 
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
+                const cpf = document.getElementById('cpf').value;
+                const dataNascimento = document.getElementById('dataNascimento').value;
+                const empresa = document.getElementById('empresa').value;
                 
                 try {
                     const usuario = getUsuarioLogado();
                     
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
                         nome,
-                        email
+                        email,
+                        cpf,
+                        data_nascimento: dataNascimento,
+                        empresa
                     });
                     
                     // Atualiza os dados no localStorage
                     usuario.nome = nome;
                     usuario.email = email;
+                    usuario.cpf = cpf;
+                    usuario.data_nascimento = dataNascimento || null;
+                    usuario.empresa = empresa;
                     localStorage.setItem('usuario', JSON.stringify(usuario));
                     
                     // Atualiza o nome na navbar
@@ -296,6 +320,9 @@
                 // Preenche o formulário
                 document.getElementById('nome').value = dadosUsuario.nome;
                 document.getElementById('email').value = dadosUsuario.email;
+                document.getElementById('cpf').value = dadosUsuario.cpf || '';
+                document.getElementById('dataNascimento').value = dadosUsuario.data_nascimento ? dadosUsuario.data_nascimento.split('T')[0] : '';
+                document.getElementById('empresa').value = dadosUsuario.empresa || '';
                 document.getElementById('tipo').value = dadosUsuario.tipo === 'admin' ? 'Administrador' : 'Comum';
                 
                 // Atualiza os dados no localStorage

--- a/src/static/rateio/rateio-perfil.html
+++ b/src/static/rateio/rateio-perfil.html
@@ -99,6 +99,21 @@
                                         <label for="email" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="email" name="email" required>
                                     </div>
+
+                                    <div class="mb-3">
+                                        <label for="cpf" class="form-label">CPF</label>
+                                        <input type="text" class="form-control" id="cpf" name="cpf">
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="dataNascimento" class="form-label">Data de Nascimento</label>
+                                        <input type="date" class="form-control" id="dataNascimento" name="dataNascimento">
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="empresa" class="form-label">Empresa</label>
+                                        <input type="text" class="form-control" id="empresa" name="empresa">
+                                    </div>
                                     
                                     
                                     <div class="mb-3">
@@ -199,18 +214,27 @@
                 
                 const nome = document.getElementById('nome').value;
                 const email = document.getElementById('email').value;
+                const cpf = document.getElementById('cpf').value;
+                const dataNascimento = document.getElementById('dataNascimento').value;
+                const empresa = document.getElementById('empresa').value;
                 
                 try {
                     const usuario = getUsuarioLogado();
                     
                     await chamarAPI(`/usuarios/${usuario.id}`, 'PUT', {
                         nome,
-                        email
+                        email,
+                        cpf,
+                        data_nascimento: dataNascimento,
+                        empresa
                     });
                     
                     // Atualiza os dados no localStorage
                     usuario.nome = nome;
                     usuario.email = email;
+                    usuario.cpf = cpf;
+                    usuario.data_nascimento = dataNascimento || null;
+                    usuario.empresa = empresa;
                     localStorage.setItem('usuario', JSON.stringify(usuario));
                     
                     // Atualiza o nome na navbar
@@ -265,6 +289,9 @@
                 // Preenche o formulário
                 document.getElementById('nome').value = dadosUsuario.nome;
                 document.getElementById('email').value = dadosUsuario.email;
+                document.getElementById('cpf').value = dadosUsuario.cpf || '';
+                document.getElementById('dataNascimento').value = dadosUsuario.data_nascimento ? dadosUsuario.data_nascimento.split('T')[0] : '';
+                document.getElementById('empresa').value = dadosUsuario.empresa || '';
                 document.getElementById('tipo').value = dadosUsuario.tipo === 'admin' ? 'Administrador' : 'Comum';
                 
                 // Atualiza os dados no localStorage


### PR DESCRIPTION
## Summary
- create new `UserInfo` model to hold optional CPF, birth date and company
- link `UserInfo` with `User` and expose fields in API
- store/update new info via user routes
- add form fields to all profile pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e832ea538832398814913121b9f5e