### PR TITLE
Fix migrations dir in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local /usr/local
 COPY ./src ./src
-# Migrations are created at runtime; ensure directory exists
-RUN mkdir -p /app/migrations
+# Migrations are created at runtime by Flask-Migrate
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- avoid pre-creating the migrations directory in the Docker image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e968647488323b60cdd44d16f5bd6