### PR TITLE
Fix Alembic path in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,10 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local /usr/local
 COPY ./src ./src
 COPY ./migrations ./migrations
+COPY alembic.ini ./
 
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
 
-CMD ["gunicorn", "src.main:app", "--bind", "0.0.0.0:8080"]
+CMD ["bash", "-c", "alembic upgrade head && gunicorn src.main:app --bind 0.0.0.0:8080"]

--- a/alembic.ini
+++ b/alembic.ini
@@ -5,7 +5,7 @@
 # this is typically a path given in POSIX (e.g. forward slashes)
 # format, relative to the token %(here)s which refers to the location of this
 # ini file
-script_location = %(here)s/migrations
+script_location = migrations
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time
@@ -84,7 +84,7 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
-sqlalchemy.url = driver://user:pass@localhost/dbname
+sqlalchemy.url = ${DATABASE_URL}
 
 
 [post_write_hooks]


### PR DESCRIPTION
## Summary
- set `script_location` to migrations
- use `${DATABASE_URL}` in alembic.ini
- copy `alembic.ini` into Docker image
- run migrations before starting gunicorn

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pydantic==2.5.3 email-validator==2.2.0 flask-migrate==4.0.5 redis==5.0.1 flask-limiter==3.12`
- `pip install -q openpyxl==3.1.2 reportlab==4.0.8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea4cf5b2c83239eafd7b7ed2569fc