### PR TITLE
Fix migrations path usage

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -134,19 +134,19 @@ def create_app():
             logging.info("Pasta de migrations nao encontrada, inicializando...")
             try:
                 init(directory=migrations_dir)
-                migrate_cmd(directory=project_root)
+                migrate_cmd(directory=migrations_dir)
             except Exception as e:  # pragma: no cover - primeira migracao opcional
                 logging.error("Erro ao criar migrations: %s", str(e))
 
         versions_dir = os.path.join(migrations_dir, 'versions')
         if not os.path.exists(versions_dir) or not os.listdir(versions_dir):
             try:
-                migrate_cmd(directory=project_root)
+                migrate_cmd(directory=migrations_dir)
             except Exception as e:  # pragma: no cover - geracao opcional
                 logging.error("Erro ao gerar migrations: %s", str(e))
 
         try:
-            upgrade(directory=project_root)
+            upgrade(directory=migrations_dir)
         except Exception as e:  # pragma: no cover - migracao opcional
             logging.error("Erro ao aplicar migrations: %s", str(e))
         create_admin(app)


### PR DESCRIPTION
## Summary
- fix `migrate_cmd` and `upgrade` to reference `migrations_dir`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eacfb2c9c832386ceee6bea0e6412