### PR TITLE
Fix Alembic config path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local /usr/local
 COPY ./src ./src
 COPY ./migrations ./migrations
-COPY alembic.ini ./
+COPY alembic.ini ./migrations/
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- place `alembic.ini` in the migrations directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eaf7a29288323b4609005202456e6