### PR TITLE
Handle missing Redis in startup

### DIFF
--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -28,13 +28,20 @@ def init_redis(app=None):
     if os.getenv("DISABLE_REDIS") == "1":
         client = DummyRedis()
     else:
-        client = Redis.from_url(url)
-        client.ping()
+        try:
+            client = Redis.from_url(url)
+            client.ping()
+        except Exception as e:  # pragma: no cover - fallback quando redis indisponível
+            if app is not None:
+                app.logger.warning("Redis indisponível: %s", str(e))
+            client = DummyRedis()
 
     if app is not None:
         app.redis_conn = client
+    global redis_conn
+    redis_conn = client
     return client
 
 
-redis_conn = init_redis()
+redis_conn = DummyRedis()
 


### PR DESCRIPTION
## Summary
- avoid failing at import when Redis is absent
- log a warning and fall back to a dummy client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb289b3c483238b0bcf51c3d7893a