### PR TITLE
Fix Alembic database URL configuration

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,23 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+from alembic.config import Config
+from alembic import command
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///agenda_laboratorio.db").strip()
+if DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def init_db():
+    """Inicializa o banco de dados e aplica as migracoes."""
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    alembic_cfg = Config(os.path.join(project_root, "alembic.ini"))
+    alembic_cfg.set_main_option("sqlalchemy.url", DATABASE_URL)
+    command.upgrade(alembic_cfg, "head")
+


### PR DESCRIPTION
## Summary
- add new `src/database.py` with `init_db()` that sets Alembic `sqlalchemy.url` from `DATABASE_URL`

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pydantic`
- `pip install -q 'pydantic[email]'`
- `pip install -q openpyxl`
- `pip install -q reportlab`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb79b5fec83238877791b363fddba