### PR TITLE
Implement admin training management

### DIFF
--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -31,8 +31,12 @@ class Treinamento(db.Model):
             "carga_horaria": self.carga_horaria,
             "tem_pratica": self.tem_pratica,
             "links_materiais": self.links_materiais,
-            "data_criacao": self.data_criacao.isoformat() if self.data_criacao else None,
-            "data_atualizacao": self.data_atualizacao.isoformat() if self.data_atualizacao else None,
+            "data_criacao": (
+                self.data_criacao.isoformat() if self.data_criacao else None
+            ),
+            "data_atualizacao": (
+                self.data_atualizacao.isoformat() if self.data_atualizacao else None
+            ),
         }
 
     def __repr__(self):
@@ -45,7 +49,9 @@ class TurmaTreinamento(db.Model):
     __tablename__ = "turmas_treinamento"
 
     id = db.Column(db.Integer, primary_key=True)
-    treinamento_id = db.Column(db.Integer, db.ForeignKey("treinamentos.id"), nullable=False)
+    treinamento_id = db.Column(
+        db.Integer, db.ForeignKey("treinamentos.id"), nullable=False
+    )
     data_inicio = db.Column(db.Date, nullable=False)
     data_termino = db.Column(db.Date, nullable=False)
     data_treinamento_pratico = db.Column(db.Date)
@@ -59,8 +65,14 @@ class TurmaTreinamento(db.Model):
             "id": self.id,
             "treinamento_id": self.treinamento_id,
             "data_inicio": self.data_inicio.isoformat() if self.data_inicio else None,
-            "data_termino": self.data_termino.isoformat() if self.data_termino else None,
-            "data_treinamento_pratico": self.data_treinamento_pratico.isoformat() if self.data_treinamento_pratico else None,
+            "data_termino": (
+                self.data_termino.isoformat() if self.data_termino else None
+            ),
+            "data_treinamento_pratico": (
+                self.data_treinamento_pratico.isoformat()
+                if self.data_treinamento_pratico
+                else None
+            ),
         }
 
     def __repr__(self):
@@ -73,7 +85,8 @@ class InscricaoTreinamento(db.Model):
     __tablename__ = "inscricoes_treinamento"
 
     id = db.Column(db.Integer, primary_key=True)
-    usuario_id = db.Column(db.Integer, db.ForeignKey("usuarios.id"), nullable=False)
+    # Para inscrições manuais é permitido não associar a um usuário do sistema.
+    usuario_id = db.Column(db.Integer, db.ForeignKey("usuarios.id"), nullable=True)
     turma_id = db.Column(
         db.Integer, db.ForeignKey("turmas_treinamento.id"), nullable=False
     )
@@ -95,9 +108,13 @@ class InscricaoTreinamento(db.Model):
             "nome": self.nome,
             "email": self.email,
             "cpf": self.cpf,
-            "data_nascimento": self.data_nascimento.isoformat() if self.data_nascimento else None,
+            "data_nascimento": (
+                self.data_nascimento.isoformat() if self.data_nascimento else None
+            ),
             "empresa": self.empresa,
-            "data_inscricao": self.data_inscricao.isoformat() if self.data_inscricao else None,
+            "data_inscricao": (
+                self.data_inscricao.isoformat() if self.data_inscricao else None
+            ),
         }
 
     def __repr__(self):

--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -1,58 +1,74 @@
 """Rotas para gerenciamento de treinamentos e inscricoes."""
+
 from flask import Blueprint, request, jsonify, g
 from sqlalchemy.exc import SQLAlchemyError
 
 from src.models import db, Treinamento, TurmaTreinamento, InscricaoTreinamento
 from src.utils.error_handler import handle_internal_error
-from src.schemas.treinamento import InscricaoTreinamentoCreateSchema
-from src.auth import login_required
+from src.schemas.treinamento import (
+    InscricaoTreinamentoCreateSchema,
+    TreinamentoCreateSchema,
+    TreinamentoUpdateSchema,
+    TurmaTreinamentoCreateSchema,
+    TurmaTreinamentoUpdateSchema,
+)
+from src.auth import login_required, admin_required
+from pydantic import ValidationError
+from io import StringIO, BytesIO
+import csv
+from flask import send_file, make_response
+from openpyxl import Workbook
 
 
-treinamento_bp = Blueprint('treinamento', __name__)
+treinamento_bp = Blueprint("treinamento", __name__)
 
 
-@treinamento_bp.route('/treinamentos', methods=['GET'])
+@treinamento_bp.route("/treinamentos", methods=["GET"])
 @login_required
 def listar_treinamentos():
     """Lista todas as turmas de treinamento."""
-    turmas = (
-        TurmaTreinamento.query
-        .join(Treinamento)
-        .order_by(Treinamento.nome)
-        .all()
-    )
+    turmas = TurmaTreinamento.query.join(Treinamento).order_by(Treinamento.nome).all()
     dados = []
     for turma in turmas:
-        dados.append({
-            'turma_id': turma.id,
-            'treinamento': turma.treinamento.to_dict(),
-            'data_inicio': turma.data_inicio.isoformat() if turma.data_inicio else None,
-            'data_termino': turma.data_termino.isoformat() if turma.data_termino else None,
-            'data_treinamento_pratico': turma.data_treinamento_pratico.isoformat() if turma.data_treinamento_pratico else None,
-        })
+        dados.append(
+            {
+                "turma_id": turma.id,
+                "treinamento": turma.treinamento.to_dict(),
+                "data_inicio": (
+                    turma.data_inicio.isoformat() if turma.data_inicio else None
+                ),
+                "data_termino": (
+                    turma.data_termino.isoformat() if turma.data_termino else None
+                ),
+                "data_treinamento_pratico": (
+                    turma.data_treinamento_pratico.isoformat()
+                    if turma.data_treinamento_pratico
+                    else None
+                ),
+            }
+        )
     return jsonify(dados)
 
 
-@treinamento_bp.route('/treinamentos/<int:turma_id>/inscricoes', methods=['POST'])
+@treinamento_bp.route("/treinamentos/<int:turma_id>/inscricoes", methods=["POST"])
 @login_required
 def inscrever_usuario(turma_id):
     """Realiza a inscricao do usuario logado em uma turma."""
     turma = db.session.get(TurmaTreinamento, turma_id)
     if not turma:
-        return jsonify({'erro': 'Turma não encontrada'}), 404
+        return jsonify({"erro": "Turma não encontrada"}), 404
 
     existente = InscricaoTreinamento.query.filter_by(
-        usuario_id=g.current_user.id,
-        turma_id=turma_id
+        usuario_id=g.current_user.id, turma_id=turma_id
     ).first()
     if existente:
-        return jsonify({'erro': 'Usuário já inscrito nesta turma'}), 400
+        return jsonify({"erro": "Usuário já inscrito nesta turma"}), 400
 
     data = request.json or {}
     try:
         payload = InscricaoTreinamentoCreateSchema(**data)
     except Exception as e:  # pylint: disable=broad-except
-        return jsonify({'erro': str(e)}), 400
+        return jsonify({"erro": str(e)}), 400
 
     try:
         insc = InscricaoTreinamento(
@@ -72,24 +88,279 @@ def inscrever_usuario(turma_id):
         return handle_internal_error(e)
 
 
-@treinamento_bp.route('/treinamentos/minhas', methods=['GET'])
+@treinamento_bp.route("/treinamentos/minhas", methods=["GET"])
 @login_required
 def listar_meus_cursos():
     """Lista cursos em que o usuario esta inscrito."""
     inscricoes = (
-        InscricaoTreinamento.query
-        .filter_by(usuario_id=g.current_user.id)
+        InscricaoTreinamento.query.filter_by(usuario_id=g.current_user.id)
         .join(TurmaTreinamento)
         .join(Treinamento)
         .all()
     )
     result = []
     for inc in inscricoes:
-        result.append({
-            'id': inc.id,
-            'turma_id': inc.turma_id,
-            'treinamento': inc.turma.treinamento.to_dict(),
-            'data_inicio': inc.turma.data_inicio.isoformat() if inc.turma.data_inicio else None,
-            'data_termino': inc.turma.data_termino.isoformat() if inc.turma.data_termino else None,
-        })
+        result.append(
+            {
+                "id": inc.id,
+                "turma_id": inc.turma_id,
+                "treinamento": inc.turma.treinamento.to_dict(),
+                "data_inicio": (
+                    inc.turma.data_inicio.isoformat() if inc.turma.data_inicio else None
+                ),
+                "data_termino": (
+                    inc.turma.data_termino.isoformat()
+                    if inc.turma.data_termino
+                    else None
+                ),
+            }
+        )
     return jsonify(result)
+
+
+@treinamento_bp.route("/treinamentos/catalogo", methods=["GET"])
+@login_required
+def listar_catalogo_treinamentos():
+    """Lista os treinamentos cadastrados."""
+    treins = Treinamento.query.order_by(Treinamento.nome).all()
+    return jsonify([t.to_dict() for t in treins])
+
+
+@treinamento_bp.route("/treinamentos/catalogo", methods=["POST"])
+@admin_required
+def criar_treinamento():
+    """Cadastra um novo treinamento."""
+    data = request.json or {}
+    try:
+        payload = TreinamentoCreateSchema(**data)
+    except ValidationError as e:
+        return jsonify({"erro": e.errors()}), 400
+    try:
+        novo = Treinamento(
+            nome=payload.nome,
+            codigo=payload.codigo,
+            capacidade_maxima=payload.capacidade_maxima,
+            carga_horaria=payload.carga_horaria,
+            tem_pratica=payload.tem_pratica,
+            links_materiais=payload.links_materiais,
+        )
+        db.session.add(novo)
+        db.session.commit()
+        return jsonify(novo.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route("/treinamentos/catalogo/<int:treinamento_id>", methods=["GET"])
+@login_required
+def obter_treinamento(treinamento_id):
+    """Obtém um treinamento específico."""
+    treino = db.session.get(Treinamento, treinamento_id)
+    if not treino:
+        return jsonify({"erro": "Treinamento não encontrado"}), 404
+    return jsonify(treino.to_dict())
+
+
+@treinamento_bp.route("/treinamentos/catalogo/<int:treinamento_id>", methods=["PUT"])
+@admin_required
+def atualizar_treinamento(treinamento_id):
+    """Atualiza um treinamento existente."""
+    treino = db.session.get(Treinamento, treinamento_id)
+    if not treino:
+        return jsonify({"erro": "Treinamento não encontrado"}), 404
+    data = request.json or {}
+    try:
+        payload = TreinamentoUpdateSchema(**data)
+    except ValidationError as e:
+        return jsonify({"erro": e.errors()}), 400
+
+    if payload.nome is not None:
+        treino.nome = payload.nome
+    if payload.codigo is not None:
+        treino.codigo = payload.codigo
+    if payload.capacidade_maxima is not None:
+        treino.capacidade_maxima = payload.capacidade_maxima
+    if payload.carga_horaria is not None:
+        treino.carga_horaria = payload.carga_horaria
+    if payload.tem_pratica is not None:
+        treino.tem_pratica = payload.tem_pratica
+    if payload.links_materiais is not None:
+        treino.links_materiais = payload.links_materiais
+    try:
+        db.session.commit()
+        return jsonify(treino.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route("/treinamentos/catalogo/<int:treinamento_id>", methods=["DELETE"])
+@admin_required
+def remover_treinamento(treinamento_id):
+    """Exclui um treinamento."""
+    treino = db.session.get(Treinamento, treinamento_id)
+    if not treino:
+        return jsonify({"erro": "Treinamento não encontrado"}), 404
+    try:
+        db.session.delete(treino)
+        db.session.commit()
+        return jsonify({"mensagem": "Treinamento removido com sucesso"})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route("/treinamentos/turmas", methods=["POST"])
+@admin_required
+def criar_turma_treinamento():
+    """Cria uma turma para um treinamento."""
+    data = request.json or {}
+    try:
+        payload = TurmaTreinamentoCreateSchema(**data)
+    except ValidationError as e:
+        return jsonify({"erro": e.errors()}), 400
+
+    if not db.session.get(Treinamento, payload.treinamento_id):
+        return jsonify({"erro": "Treinamento não encontrado"}), 404
+    turma = TurmaTreinamento(
+        treinamento_id=payload.treinamento_id,
+        data_inicio=payload.data_inicio,
+        data_termino=payload.data_termino,
+        data_treinamento_pratico=payload.data_treinamento_pratico,
+    )
+    try:
+        db.session.add(turma)
+        db.session.commit()
+        return jsonify(turma.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route("/treinamentos/turmas/<int:turma_id>", methods=["PUT"])
+@admin_required
+def atualizar_turma_treinamento(turma_id):
+    """Atualiza uma turma."""
+    turma = db.session.get(TurmaTreinamento, turma_id)
+    if not turma:
+        return jsonify({"erro": "Turma não encontrada"}), 404
+    data = request.json or {}
+    try:
+        payload = TurmaTreinamentoUpdateSchema(**data)
+    except ValidationError as e:
+        return jsonify({"erro": e.errors()}), 400
+
+    if payload.treinamento_id is not None:
+        if not db.session.get(Treinamento, payload.treinamento_id):
+            return jsonify({"erro": "Treinamento não encontrado"}), 404
+        turma.treinamento_id = payload.treinamento_id
+    if payload.data_inicio is not None:
+        turma.data_inicio = payload.data_inicio
+    if payload.data_termino is not None:
+        turma.data_termino = payload.data_termino
+    if payload.data_treinamento_pratico is not None:
+        turma.data_treinamento_pratico = payload.data_treinamento_pratico
+    try:
+        db.session.commit()
+        return jsonify(turma.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route("/treinamentos/turmas/<int:turma_id>", methods=["DELETE"])
+@admin_required
+def remover_turma_treinamento(turma_id):
+    """Remove uma turma."""
+    turma = db.session.get(TurmaTreinamento, turma_id)
+    if not turma:
+        return jsonify({"erro": "Turma não encontrada"}), 404
+    try:
+        db.session.delete(turma)
+        db.session.commit()
+        return jsonify({"mensagem": "Turma removida com sucesso"})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route("/treinamentos/turmas/<int:turma_id>/inscricoes", methods=["GET"])
+@admin_required
+def listar_inscricoes(turma_id):
+    """Lista inscrições de uma turma."""
+    turma = db.session.get(TurmaTreinamento, turma_id)
+    if not turma:
+        return jsonify({"erro": "Turma não encontrada"}), 404
+    inscricoes = InscricaoTreinamento.query.filter_by(turma_id=turma_id).all()
+    return jsonify([i.to_dict() for i in inscricoes])
+
+
+@treinamento_bp.route(
+    "/treinamentos/turmas/<int:turma_id>/inscricoes/admin", methods=["POST"]
+)
+@admin_required
+def criar_inscricao_admin(turma_id):
+    """Adiciona manualmente uma inscrição em uma turma."""
+    if not db.session.get(TurmaTreinamento, turma_id):
+        return jsonify({"erro": "Turma não encontrada"}), 404
+    data = request.json or {}
+    try:
+        payload = InscricaoTreinamentoCreateSchema(**data)
+    except ValidationError as e:
+        return jsonify({"erro": e.errors()}), 400
+    insc = InscricaoTreinamento(
+        usuario_id=None,
+        turma_id=turma_id,
+        nome=payload.nome,
+        email=payload.email,
+        cpf=payload.cpf,
+        data_nascimento=payload.data_nascimento,
+        empresa=payload.empresa,
+    )
+    try:
+        db.session.add(insc)
+        db.session.commit()
+        return jsonify(insc.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@treinamento_bp.route(
+    "/treinamentos/turmas/<int:turma_id>/inscricoes/export", methods=["GET"]
+)
+@admin_required
+def exportar_inscricoes(turma_id):
+    """Exporta inscrições de uma turma em CSV ou XLSX."""
+    turma = db.session.get(TurmaTreinamento, turma_id)
+    if not turma:
+        return jsonify({"erro": "Turma não encontrada"}), 404
+    formato = request.args.get("formato", "csv").lower()
+    inscricoes = InscricaoTreinamento.query.filter_by(turma_id=turma_id).all()
+
+    if formato == "xlsx":
+        wb = Workbook()
+        ws = wb.active
+        ws.append(["ID", "Nome", "Email", "CPF"])
+        for i in inscricoes:
+            ws.append([i.id, i.nome, i.email, i.cpf])
+        buf = BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+        return send_file(
+            buf,
+            mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            as_attachment=True,
+            download_name="inscricoes.xlsx",
+        )
+
+    si = StringIO()
+    writer = csv.writer(si)
+    writer.writerow(["ID", "Nome", "Email", "CPF"])
+    for i in inscricoes:
+        writer.writerow([i.id, i.nome, i.email, i.cpf])
+    output = make_response(si.getvalue())
+    output.headers["Content-Disposition"] = "attachment; filename=inscricoes.csv"
+    output.headers["Content-Type"] = "text/csv"
+    return output

--- a/src/schemas/treinamento.py
+++ b/src/schemas/treinamento.py
@@ -1,5 +1,7 @@
+"""Esquemas Pydantic para o módulo de treinamentos."""
+
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 from datetime import date
 
 
@@ -9,3 +11,43 @@ class InscricaoTreinamentoCreateSchema(BaseModel):
     cpf: Optional[str] = None
     data_nascimento: Optional[date] = None
     empresa: Optional[str] = None
+
+
+class TreinamentoCreateSchema(BaseModel):
+    """Schema para cadastro de treinamentos."""
+
+    nome: str
+    codigo: str
+    capacidade_maxima: Optional[int] = None
+    carga_horaria: Optional[int] = None
+    tem_pratica: Optional[bool] = False
+    links_materiais: Optional[List[str]] = None
+
+
+class TreinamentoUpdateSchema(BaseModel):
+    """Schema para atualização parcial de treinamentos."""
+
+    nome: Optional[str] = None
+    codigo: Optional[str] = None
+    capacidade_maxima: Optional[int] = None
+    carga_horaria: Optional[int] = None
+    tem_pratica: Optional[bool] = None
+    links_materiais: Optional[List[str]] = None
+
+
+class TurmaTreinamentoCreateSchema(BaseModel):
+    """Schema para criação de turmas de treinamento."""
+
+    treinamento_id: int
+    data_inicio: date
+    data_termino: date
+    data_treinamento_pratico: Optional[date] = None
+
+
+class TurmaTreinamentoUpdateSchema(BaseModel):
+    """Schema para atualização de turmas de treinamento."""
+
+    treinamento_id: Optional[int] = None
+    data_inicio: Optional[date] = None
+    data_termino: Optional[date] = None
+    data_treinamento_pratico: Optional[date] = None

--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -1,0 +1,168 @@
+// Funções para administração de treinamentos e turmas
+
+async function carregarCatalogo() {
+    try {
+        const lista = await chamarAPI('/treinamentos/catalogo');
+        const tbody = document.getElementById('catalogoTableBody');
+        if (!tbody) return;
+        tbody.innerHTML = '';
+        if (lista.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="6" class="text-center">Nenhum treinamento cadastrado.</td></tr>';
+            return;
+        }
+        for (const t of lista) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${t.id}</td>
+                <td>${escapeHTML(t.nome)}</td>
+                <td>${escapeHTML(t.codigo)}</td>
+                <td>${t.carga_horaria || ''}</td>
+                <td>${t.capacidade_maxima || ''}</td>
+                <td>
+                    <button class="btn btn-sm btn-outline-primary me-1" onclick="editarTreinamento(${t.id})"><i class="bi bi-pencil"></i></button>
+                    <button class="btn btn-sm btn-outline-danger" onclick="excluirTreinamento(${t.id})"><i class="bi bi-trash"></i></button>
+                </td>`;
+            tbody.appendChild(tr);
+        }
+    } catch (e) {
+        exibirAlerta(e.message, 'danger');
+    }
+}
+
+async function salvarTreinamento() {
+    const id = document.getElementById('treinamentoId').value;
+    const body = {
+        nome: document.getElementById('nomeTrein').value,
+        codigo: document.getElementById('codigoTrein').value,
+        capacidade_maxima: parseInt(document.getElementById('capacidadeTrein').value) || null,
+        carga_horaria: parseInt(document.getElementById('cargaTrein').value) || null,
+        tem_pratica: document.getElementById('temPratica').checked,
+        links_materiais: document.getElementById('linksTrein').value ? document.getElementById('linksTrein').value.split('\n') : null
+    };
+    try {
+        if (id) {
+            await chamarAPI(`/treinamentos/catalogo/${id}`, 'PUT', body);
+        } else {
+            await chamarAPI('/treinamentos/catalogo', 'POST', body);
+        }
+        bootstrap.Modal.getInstance(document.getElementById('treinamentoModal')).hide();
+        carregarCatalogo();
+    } catch (e) {
+        exibirAlerta(e.message, 'danger');
+    }
+}
+
+function editarTreinamento(id) {
+    chamarAPI(`/treinamentos/catalogo/${id}`).then(t => {
+        document.getElementById('treinamentoId').value = t.id;
+        document.getElementById('nomeTrein').value = t.nome;
+        document.getElementById('codigoTrein').value = t.codigo;
+        document.getElementById('capacidadeTrein').value = t.capacidade_maxima || '';
+        document.getElementById('cargaTrein').value = t.carga_horaria || '';
+        document.getElementById('temPratica').checked = t.tem_pratica;
+        document.getElementById('linksTrein').value = (t.links_materiais || []).join('\n');
+        new bootstrap.Modal(document.getElementById('treinamentoModal')).show();
+    });
+}
+
+async function excluirTreinamento(id) {
+    if (!confirm('Excluir treinamento?')) return;
+    try {
+        await chamarAPI(`/treinamentos/catalogo/${id}`, 'DELETE');
+        carregarCatalogo();
+    } catch (e) {
+        exibirAlerta(e.message, 'danger');
+    }
+}
+
+async function carregarTurmas() {
+    try {
+        const turmas = await chamarAPI('/treinamentos');
+        const tbody = document.getElementById('turmasTableBody');
+        if (!tbody) return;
+        tbody.innerHTML = '';
+        if (turmas.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="6" class="text-center">Nenhuma turma cadastrada.</td></tr>';
+            return;
+        }
+        for (const t of turmas) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${t.turma_id}</td>
+                <td>${escapeHTML(t.treinamento.nome)}</td>
+                <td>${formatarData(t.data_inicio)}</td>
+                <td>${formatarData(t.data_termino)}</td>
+                <td>
+                    <a class="btn btn-sm btn-outline-secondary me-1" href="/treinamentos/admin-inscricoes.html?turma=${t.turma_id}">Inscrições</a>
+                    <button class="btn btn-sm btn-outline-primary" onclick="editarTurma(${t.turma_id})"><i class="bi bi-pencil"></i></button>
+                </td>`;
+            tbody.appendChild(tr);
+        }
+    } catch (e) {
+        exibirAlerta(e.message, 'danger');
+    }
+}
+
+async function salvarTurma() {
+    const id = document.getElementById('turmaId').value;
+    const body = {
+        treinamento_id: parseInt(document.getElementById('turmaTreinamentoId').value),
+        data_inicio: document.getElementById('dataInicio').value,
+        data_termino: document.getElementById('dataFim').value,
+        data_treinamento_pratico: document.getElementById('dataPratica').value || null
+    };
+    try {
+        if (id) {
+            await chamarAPI(`/treinamentos/turmas/${id}`, 'PUT', body);
+        } else {
+            await chamarAPI('/treinamentos/turmas', 'POST', body);
+        }
+        bootstrap.Modal.getInstance(document.getElementById('turmaModal')).hide();
+        carregarTurmas();
+    } catch (e) {
+        exibirAlerta(e.message, 'danger');
+    }
+}
+
+function editarTurma(id) {
+    chamarAPI(`/treinamentos/turmas/${id}`).then(t => {
+        document.getElementById('turmaId').value = t.id;
+        document.getElementById('turmaTreinamentoId').value = t.treinamento_id;
+        document.getElementById('dataInicio').value = t.data_inicio || '';
+        document.getElementById('dataFim').value = t.data_termino || '';
+        document.getElementById('dataPratica').value = t.data_treinamento_pratico || '';
+        new bootstrap.Modal(document.getElementById('turmaModal')).show();
+    });
+}
+
+async function carregarInscricoes(turmaId) {
+    try {
+        const insc = await chamarAPI(`/treinamentos/turmas/${turmaId}/inscricoes`);
+        const tbody = document.getElementById('inscricoesTableBody');
+        tbody.innerHTML = '';
+        if (insc.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="5" class="text-center">Nenhuma inscrição.</td></tr>';
+            return;
+        }
+        for (const i of insc) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${i.id}</td>
+                <td>${escapeHTML(i.nome)}</td>
+                <td>${escapeHTML(i.email)}</td>
+                <td>${i.cpf || ''}</td>
+            `;
+            tbody.appendChild(tr);
+        }
+    } catch (e) {
+        exibirAlerta(e.message, 'danger');
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    verificarAutenticacao();
+    verificarPermissaoAdmin();
+    if (document.getElementById('catalogoTableBody')) carregarCatalogo();
+    if (document.getElementById('turmasTableBody')) carregarTurmas();
+});
+

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Catálogo de Treinamentos</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/selecao-sistema.html">
+            <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2"> Catálogo de Treinamentos
+        </a>
+        <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="nav-link" href="#" id="btnLogout">Sair</a></li>
+        </ul>
+    </div>
+</nav>
+<div class="container my-4">
+    <div class="d-flex justify-content-between mb-3">
+        <h3>Treinamentos</h3>
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#treinamentoModal">Novo</button>
+    </div>
+    <div id="alertContainer"></div>
+    <table class="table table-striped">
+        <thead>
+            <tr><th>ID</th><th>Nome</th><th>Código</th><th>Carga</th><th>Capacidade</th><th></th></tr>
+        </thead>
+        <tbody id="catalogoTableBody"></tbody>
+    </table>
+</div>
+
+<div class="modal fade" id="treinamentoModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Treinamento</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="treinamentoForm">
+                    <input type="hidden" id="treinamentoId">
+                    <div class="mb-3">
+                        <label class="form-label">Nome</label>
+                        <input type="text" class="form-control" id="nomeTrein" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Código</label>
+                        <input type="text" class="form-control" id="codigoTrein" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Capacidade Máxima</label>
+                        <input type="number" class="form-control" id="capacidadeTrein">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Carga Horária</label>
+                        <input type="number" class="form-control" id="cargaTrein">
+                    </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="temPratica">
+                        <label class="form-check-label" for="temPratica">Possui parte prática</label>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Links para materiais (um por linha)</label>
+                        <textarea class="form-control" id="linksTrein" rows="3"></textarea>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button type="button" class="btn btn-primary" onclick="salvarTreinamento()">Salvar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/app.js"></script>
+<script src="/js/treinamentos-admin.js"></script>
+</body>
+</html>
+

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Inscrições da Turma</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/treinamentos/admin-turmas.html">
+            <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2"> Inscrições
+        </a>
+        <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="nav-link" href="#" id="btnLogout">Sair</a></li>
+        </ul>
+    </div>
+</nav>
+<div class="container my-4">
+    <h3 class="mb-3">Lista de Inscrições</h3>
+    <table class="table table-striped">
+        <thead>
+            <tr><th>ID</th><th>Nome</th><th>Email</th><th>CPF</th></tr>
+        </thead>
+        <tbody id="inscricoesTableBody"></tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/app.js"></script>
+<script src="/js/treinamentos-admin.js"></script>
+<script>
+    const params = new URLSearchParams(window.location.search);
+    const turmaId = params.get('turma');
+    if (turmaId) {
+        document.addEventListener('DOMContentLoaded', () => carregarInscricoes(turmaId));
+    }
+</script>
+</body>
+</html>
+

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Gerenciar Turmas de Treinamento</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/selecao-sistema.html">
+            <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2"> Gerenciar Turmas
+        </a>
+        <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="nav-link" href="#" id="btnLogout">Sair</a></li>
+        </ul>
+    </div>
+</nav>
+<div class="container my-4">
+    <div class="d-flex justify-content-between mb-3">
+        <h3>Turmas</h3>
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#turmaModal">Nova</button>
+    </div>
+    <table class="table table-striped">
+        <thead>
+            <tr><th>ID</th><th>Treinamento</th><th>Início</th><th>Término</th><th></th></tr>
+        </thead>
+        <tbody id="turmasTableBody"></tbody>
+    </table>
+</div>
+
+<div class="modal fade" id="turmaModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Turma</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="turmaForm">
+                    <input type="hidden" id="turmaId">
+                    <div class="mb-3">
+                        <label class="form-label">Treinamento (ID)</label>
+                        <input type="number" class="form-control" id="turmaTreinamentoId" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Data de Início</label>
+                        <input type="date" class="form-control" id="dataInicio" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Data de Término</label>
+                        <input type="date" class="form-control" id="dataFim" required>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Data do treinamento prático</label>
+                        <input type="date" class="form-control" id="dataPratica">
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button type="button" class="btn btn-primary" onclick="salvarTurma()">Salvar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/app.js"></script>
+<script src="/js/treinamentos-admin.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- allow inscriptions without user via nullable usuario_id
- expand training schemas
- add catalog, turma, and inscricao admin routes
- provide admin JS helpers and pages for training management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8e48f8d083238c2c789ec172c52a