### PR TITLE
Add migration for capacidade_maxima column

### DIFF
--- a/migrations/versions/25108d2d85b5_add_capacidade_maxima_column.py
+++ b/migrations/versions/25108d2d85b5_add_capacidade_maxima_column.py
@@ -1,0 +1,26 @@
+"""add capacidade_maxima column to treinamentos
+
+Revision ID: 25108d2d85b5
+Revises: 933546544697
+Create Date: 2025-07-22 12:30:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '25108d2d85b5'
+down_revision: Union[str, Sequence[str], None] = '933546544697'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('treinamentos', sa.Column('capacidade_maxima', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('treinamentos', 'capacidade_maxima')


### PR DESCRIPTION
## Summary
- create Alembic migration to add `capacidade_maxima` to `treinamentos`

## Testing
- `flake8 --max-line-length=120 --exit-zero`
- `bandit -r src -ll`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687fa9364f0483238fdb46a41c755623