### PR TITLE
Automate Alembic migrations

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,37 @@
+name: Auto Migrations
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "src/models/**"
+      - "alembic.ini"
+      - "migrations/env.py"
+  pull_request:
+    paths:
+      - "src/models/**"
+      - "alembic.ini"
+      - "migrations/env.py"
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Run automated migrations
+        run: |
+          ./scripts/auto_migrate.sh "CI auto migration"
+      - name: Check for uncommitted migrations
+        run: |
+          git status --porcelain
+          if [ -n "$(git status --porcelain migrations/versions)" ]; then
+            echo "New migrations detected. Commit them to the repository." && exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -108,3 +108,21 @@ Actions. O workflow `.github/workflows/ci.yml` instala as dependências do
 projeto e executa o `flake8`, o `bandit` e a suíte de testes com `pytest` a
 cada push ou pull request para a branch `main`.
 
+
+## Migrações automáticas
+
+Para evitar divergências entre os modelos do SQLAlchemy e o esquema do banco de dados, o repositório disponibiliza o script `scripts/auto_migrate.sh`. Ele gera e aplica migrations de forma automática.
+
+Execute o script sempre que alterar arquivos em `src/models/`:
+
+```bash
+./scripts/auto_migrate.sh "Mensagem da migration"
+```
+
+Ele realiza três etapas:
+
+1. Garante que o banco esteja atualizado com `flask db upgrade`.
+2. Roda `flask db migrate` com autogeração para criar uma nova migration se mudanças forem detectadas.
+3. Aplica a nova migration com `flask db upgrade`.
+
+Um workflow opcional (`.github/workflows/migrations.yml`) executa o mesmo processo em PRs e falha caso existam migrations não versionadas. Assim, ao abrir um PR, verifique se novas migrations foram geradas e commitadas.

--- a/scripts/auto_migrate.sh
+++ b/scripts/auto_migrate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Automates Alembic migrations based on SQLAlchemy models.
+# Usage: ./scripts/auto_migrate.sh [migration message]
+
+set -euo pipefail
+
+MESSAGE=${1:-"Auto migration $(date +%Y%m%d%H%M)"}
+
+# Ensure database is up to date
+flask --app src.main db upgrade
+
+# Autogenerate a new migration if there are model changes
+flask --app src.main db migrate -m "$MESSAGE" || true
+
+# Apply new migrations (if any)
+flask --app src.main db upgrade


### PR DESCRIPTION
## Summary
- add script to autogenerate and apply Alembic migrations
- document how to run the automation
- add workflow to check migrations on PRs

## Testing
- `flake8 --max-line-length=120 --exit-zero`
- `bandit -r src -ll`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fbb81105883239425fd1103fa91ca