### PR TITLE
Fix missing migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
 
-CMD sh -c "gunicorn -b 0.0.0.0:${PORT:-8080} src.main:create_app"
+CMD sh -c "flask --app src.main db upgrade && gunicorn -b 0.0.0.0:${PORT:-8080} src.main:create_app"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ docker build -t agenda-senai .
 ```
 
 As migrações não são mais distribuídas no repositório. O diretório será criado
-automaticamente quando a aplicação rodar o comando de upgrade.
+automaticamente quando a aplicação rodar o comando de upgrade. O Dockerfile já
+executa `flask db upgrade` antes de iniciar o Gunicorn, garantindo que o banco
+esteja sempre na versão correta.
 
 Em seguida, inicie o container usando as variáveis definidas em um arquivo `.env`:
 


### PR DESCRIPTION
## Summary
- automatically run Flask migrations when the Docker container starts
- mention auto migrations in the Docker instructions

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc33482688323ae86c5e541332917