### PR TITLE
Fix missing tem_pratica column

### DIFF
--- a/migrations/versions/4c1f7c0e92ab_add_tem_pratica_column_to_treinamentos.py
+++ b/migrations/versions/4c1f7c0e92ab_add_tem_pratica_column_to_treinamentos.py
@@ -1,0 +1,28 @@
+"""add tem_pratica column to treinamentos
+
+Revision ID: 4c1f7c0e92ab
+Revises: 25108d2d85b5
+Create Date: 2025-07-22 17:18:27.331963
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4c1f7c0e92ab'
+down_revision: Union[str, Sequence[str], None] = '25108d2d85b5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('treinamentos', sa.Column('tem_pratica', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('treinamentos', 'tem_pratica')


### PR DESCRIPTION
## Summary
- add migration script for `tem_pratica` column in `treinamentos`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc6cc03188323921d0cf35adf9ee5