### PR TITLE
Add migration for missing treinamento columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,32 @@ Ele realiza três etapas:
 3. Aplica a nova migration com `flask db upgrade`.
 
 Um workflow opcional (`.github/workflows/migrations.yml`) executa o mesmo processo em PRs e falha caso existam migrations não versionadas. Assim, ao abrir um PR, verifique se novas migrations foram geradas e commitadas.
+
+### Passo a passo para rodar as migrations
+
+1. Certifique-se de que a variável `DATABASE_URL` está configurada no arquivo `.env`.
+2. Aplique as migrations pendentes executando:
+
+```bash
+flask --app src.main db upgrade
+```
+
+3. Caso tenha alterado algum modelo, gere uma nova migration automática e aplique-a:
+
+```bash
+flask --app src.main db migrate -m "Descricao da mudança"
+flask --app src.main db upgrade
+```
+
+Você também pode usar o script que já realiza essas etapas de uma vez:
+
+```bash
+./scripts/auto_migrate.sh "Descricao da mudança"
+```
+
+### Checklist após alterar modelos
+
+- [ ] Atualize ou crie os arquivos em `src/models/`.
+- [ ] Rode `./scripts/auto_migrate.sh "Descrição"` para gerar e aplicar a migration.
+- [ ] Inclua os arquivos de migration em `migrations/versions/` no commit.
+- [ ] Execute `pytest` para garantir que todos os testes continuam passando.

--- a/migrations/versions/c68944a9fc4a_add_missing_columns_to_treinamentos.py
+++ b/migrations/versions/c68944a9fc4a_add_missing_columns_to_treinamentos.py
@@ -1,0 +1,30 @@
+"""ensure extra columns exist on treinamentos table
+
+Revision ID: c68944a9fc4a
+Revises: da712fed38d7
+Create Date: 2025-08-22 12:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'c68944a9fc4a'
+down_revision: Union[str, Sequence[str], None] = 'da712fed38d7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE treinamentos ADD COLUMN IF NOT EXISTS tem_pratica BOOLEAN")
+    op.execute("ALTER TABLE treinamentos ADD COLUMN IF NOT EXISTS links_materiais JSONB")
+    op.execute("ALTER TABLE treinamentos ADD COLUMN IF NOT EXISTS data_criacao TIMESTAMP")
+    op.execute("ALTER TABLE treinamentos ADD COLUMN IF NOT EXISTS data_atualizacao TIMESTAMP")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE treinamentos DROP COLUMN IF EXISTS data_atualizacao")
+    op.execute("ALTER TABLE treinamentos DROP COLUMN IF EXISTS data_criacao")
+    op.execute("ALTER TABLE treinamentos DROP COLUMN IF EXISTS links_materiais")
+    op.execute("ALTER TABLE treinamentos DROP COLUMN IF EXISTS tem_pratica")
+


### PR DESCRIPTION
## Summary
- ensure `tem_pratica`, `links_materiais`, `data_criacao` and `data_atualizacao` columns exist
- document how to run and generate migrations and provide checklist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd461178c832397ee545e197af8a7