### PR TITLE
Fix DB field name mismatch

### DIFF
--- a/migrations/versions/67c822ca4b6e_rename_data_fim_column.py
+++ b/migrations/versions/67c822ca4b6e_rename_data_fim_column.py
@@ -1,0 +1,24 @@
+"""rename data_termino column to data_fim
+
+Revision ID: 67c822ca4b6e
+Revises: 9f1c4e5a4b6a
+Create Date: 2025-08-22 12:45:00
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '67c822ca4b6e'
+down_revision: Union[str, Sequence[str], None] = '9f1c4e5a4b6a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('turmas_treinamento') as batch_op:
+        batch_op.alter_column('data_termino', new_column_name='data_fim')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('turmas_treinamento') as batch_op:
+        batch_op.alter_column('data_fim', new_column_name='data_termino')

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -55,7 +55,7 @@ class TurmaTreinamento(db.Model):
         db.Integer, db.ForeignKey("treinamentos.id"), nullable=False
     )
     data_inicio = db.Column(db.Date, nullable=False)
-    data_termino = db.Column(db.Date, nullable=False)
+    data_termino = db.Column("data_fim", db.Date, nullable=False)
     data_treinamento_pratico = db.Column(db.Date)
 
     treinamento = db.relationship(


### PR DESCRIPTION
## Summary
- map `TurmaTreinamento.data_termino` to column `data_fim`
- add migration to rename the column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff51525ac83239c41f9379c7a6aa2