### PR TITLE
Fix missing status field for training classes

### DIFF
--- a/migrations/versions/47aff0d3be81_add_status_column_to_turma_treinamento.py
+++ b/migrations/versions/47aff0d3be81_add_status_column_to_turma_treinamento.py
@@ -1,0 +1,22 @@
+"""add status column to turmas_treinamento
+
+Revision ID: 47aff0d3be81
+Revises: 67c822ca4b6e
+Create Date: 2025-08-22 13:00:00
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '47aff0d3be81'
+down_revision: Union[str, Sequence[str], None] = '67c822ca4b6e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE turmas_treinamento ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'aberta'")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE turmas_treinamento DROP COLUMN IF EXISTS status")

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -57,6 +57,7 @@ class TurmaTreinamento(db.Model):
     data_inicio = db.Column(db.Date, nullable=False)
     data_termino = db.Column("data_fim", db.Date, nullable=False)
     data_treinamento_pratico = db.Column(db.Date)
+    status = db.Column(db.String(20), nullable=False, default="aberta")
 
     treinamento = db.relationship(
         "Treinamento", back_populates="turmas"
@@ -73,6 +74,7 @@ class TurmaTreinamento(db.Model):
             "data_inicio": self.data_inicio.strftime("%Y-%m-%d"),
             "data_termino": self.data_termino.strftime("%Y-%m-%d"),
             "data_treinamento_pratico": self.data_treinamento_pratico.strftime("%Y-%m-%d") if self.data_treinamento_pratico else None,
+            "status": self.status,
             "inscritos": self.inscricoes.count(),
         }
 

--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -228,6 +228,7 @@ def criar_turma_treinamento():
         data_inicio=payload.data_inicio,
         data_termino=payload.data_termino,
         data_treinamento_pratico=payload.data_treinamento_pratico,
+        status=payload.status or "aberta",
     )
     try:
         db.session.add(turma)
@@ -261,6 +262,8 @@ def atualizar_turma_treinamento(turma_id):
         turma.data_termino = payload.data_termino
     if payload.data_treinamento_pratico is not None:
         turma.data_treinamento_pratico = payload.data_treinamento_pratico
+    if payload.status is not None:
+        turma.status = payload.status
     try:
         db.session.commit()
         return jsonify(turma.to_dict())

--- a/src/schemas/treinamento.py
+++ b/src/schemas/treinamento.py
@@ -42,6 +42,7 @@ class TurmaTreinamentoCreateSchema(BaseModel):
     data_inicio: date
     data_termino: date
     data_treinamento_pratico: Optional[date] = None
+    status: Optional[str] = "aberta"
 
 
 class TurmaTreinamentoUpdateSchema(BaseModel):
@@ -51,3 +52,4 @@ class TurmaTreinamentoUpdateSchema(BaseModel):
     data_inicio: Optional[date] = None
     data_termino: Optional[date] = None
     data_treinamento_pratico: Optional[date] = None
+    status: Optional[str] = None


### PR DESCRIPTION
## Summary
- add new status column to TurmaTreinamento model
- expose status in training API schemas and routes
- create Alembic migration to ensure status column exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffe851f20832385b976bdfacd7b1c