### PR TITLE
Reset modals for new training/turma

### DIFF
--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -109,6 +109,16 @@ function editarTreinamento(id) {
     });
 }
 
+function limparFormularioTreinamento() {
+    document.getElementById('treinamentoForm').reset();
+    document.getElementById('treinamentoId').value = '';
+}
+
+function novoTreinamento() {
+    limparFormularioTreinamento();
+    new bootstrap.Modal(document.getElementById('treinamentoModal')).show();
+}
+
 async function excluirTreinamento(id) {
     if (!confirm('Excluir treinamento?')) return;
     try {
@@ -177,6 +187,18 @@ async function editarTurma(id) {
     document.getElementById('dataFim').value = t.data_termino || '';
     document.getElementById('dataPratica').value = t.data_treinamento_pratico || '';
     atualizarCampoPratica();
+    new bootstrap.Modal(document.getElementById('turmaModal')).show();
+}
+
+function limparFormularioTurma() {
+    document.getElementById('turmaForm').reset();
+    document.getElementById('turmaId').value = '';
+    atualizarCampoPratica();
+}
+
+function novaTurma() {
+    limparFormularioTurma();
+    carregarTreinamentosSelect();
     new bootstrap.Modal(document.getElementById('turmaModal')).show();
 }
 

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -65,7 +65,7 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h2 class="mb-0">Gerenciar Catálogo de Treinamentos</h2>
-                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#treinamentoModal"><i class="bi bi-plus-circle me-2"></i>NOVO TREINAMENTO</button>
+                    <button class="btn btn-primary" onclick="novoTreinamento()"><i class="bi bi-plus-circle me-2"></i>NOVO TREINAMENTO</button>
                 </div>
                 
                 <div id="alertContainer" class="mt-3"></div>

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -65,7 +65,7 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h2 class="mb-0">Gerenciar Turmas</h2>
-                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#turmaModal"><i class="bi bi-plus-circle me-2"></i>NOVA TURMA</button>
+                    <button class="btn btn-primary" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>NOVA TURMA</button>
                 </div>
                 
                 <div id="alertContainer" class="mt-3"></div>


### PR DESCRIPTION
## Summary
- clear training modal when creating a new catalog entry
- clear turma modal when creating a new class
- update new buttons to call the reset functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801408ca908323a21c20190a992ffe