### PR TITLE
Add company column and export for training inscriptions

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -345,9 +345,11 @@ def exportar_inscricoes(turma_id):
     if formato == "xlsx":
         wb = Workbook()
         ws = wb.active
-        ws.append(["ID", "Nome", "Email", "CPF"])
+        # Cabeçalho da planilha
+        ws.append(["ID", "Nome", "Email", "CPF", "Empresa"])
+        # Adiciona as inscrições
         for i in inscricoes:
-            ws.append([i.id, i.nome, i.email, i.cpf])
+            ws.append([i.id, i.nome, i.email, i.cpf, i.empresa])
         buf = BytesIO()
         wb.save(buf)
         buf.seek(0)
@@ -360,9 +362,9 @@ def exportar_inscricoes(turma_id):
 
     si = StringIO()
     writer = csv.writer(si)
-    writer.writerow(["ID", "Nome", "Email", "CPF"])
+    writer.writerow(["ID", "Nome", "Email", "CPF", "Empresa"])
     for i in inscricoes:
-        writer.writerow([i.id, i.nome, i.email, i.cpf])
+        writer.writerow([i.id, i.nome, i.email, i.cpf, i.empresa])
     output = make_response(si.getvalue())
     output.headers["Content-Disposition"] = "attachment; filename=inscricoes.csv"
     output.headers["Content-Type"] = "text/csv"

--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -208,7 +208,8 @@ async function carregarInscricoes(turmaId) {
         const tbody = document.getElementById('inscricoesTableBody');
         tbody.innerHTML = '';
         if (insc.length === 0) {
-            tbody.innerHTML = '<tr><td colspan="5" class="text-center">Nenhuma inscrição.</td></tr>';
+            // Mensagem quando não existem inscrições na turma
+            tbody.innerHTML = '<tr><td colspan="6" class="text-center">Nenhuma inscrição.</td></tr>';
             return;
         }
         for (const i of insc) {
@@ -218,6 +219,7 @@ async function carregarInscricoes(turmaId) {
                 <td>${escapeHTML(i.nome)}</td>
                 <td>${escapeHTML(i.email)}</td>
                 <td>${i.cpf || ''}</td>
+                <td>${escapeHTML(i.empresa || '')}</td>
             `;
             tbody.appendChild(tr);
         }
@@ -236,6 +238,18 @@ document.addEventListener('DOMContentLoaded', () => {
     if (document.getElementById('turmaTreinamentoId')) {
         carregarTreinamentosSelect().then(atualizarCampoPratica);
         document.getElementById('turmaTreinamentoId').addEventListener('change', atualizarCampoPratica);
+    }
+
+    // Botão de exportação da lista de inscrições
+    const btnExportar = document.getElementById('btnExportarInscricoes');
+    if (btnExportar) {
+        const params = new URLSearchParams(window.location.search);
+        const turmaId = params.get('turma');
+        btnExportar.addEventListener('click', () => {
+            if (turmaId) {
+                exportarDados(`/treinamentos/turmas/${turmaId}/inscricoes/export`, 'xlsx', 'inscricoes');
+            }
+        });
     }
 });
 

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -68,13 +68,23 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h2 class="mb-0">Lista de Inscrições</h2>
+                    <!-- Botão de exportação alinhado à direita -->
+                    <button id="btnExportarInscricoes" class="btn btn-outline-primary">
+                        <i class="bi bi-download me-1"></i>Exportar Inscrições
+                    </button>
                 </div>
                 <div class="card mt-4">
                     <div class="card-body p-0">
                         <div class="table-responsive">
                             <table class="table table-striped table-hover">
                                 <thead>
-                                    <tr><th>ID</th><th>Nome</th><th>Email</th><th>CPF</th></tr>
+                                    <tr>
+                                        <th>ID</th>
+                                        <th>Nome</th>
+                                        <th>Email</th>
+                                        <th>CPF</th>
+                                        <th>Empresa</th>
+                                    </tr>
                                 </thead>
                                 <tbody id="inscricoesTableBody"></tbody>
                             </table>


### PR DESCRIPTION
## Summary
- show Empresa column in admin Inscrições list
- enable exporting of inscrições in XLSX format
- include company field in API export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68801ec45db48323a3482e86b7972db4