### PR TITLE
Add company column & XLSX export to admin inscriptions

### DIFF
--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -208,7 +208,7 @@ async function carregarInscricoes(turmaId) {
         const tbody = document.getElementById('inscricoesTableBody');
         tbody.innerHTML = '';
         if (insc.length === 0) {
-            tbody.innerHTML = '<tr><td colspan="5" class="text-center">Nenhuma inscrição.</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="6" class="text-center">Nenhuma inscrição.</td></tr>';
             return;
         }
         for (const i of insc) {
@@ -218,12 +218,36 @@ async function carregarInscricoes(turmaId) {
                 <td>${escapeHTML(i.nome)}</td>
                 <td>${escapeHTML(i.email)}</td>
                 <td>${i.cpf || ''}</td>
+                <td>${escapeHTML(i.empresa || '')}</td>
             `;
             tbody.appendChild(tr);
         }
     } catch (e) {
         exibirAlerta(e.message, 'danger');
     }
+}
+
+// Exporta a lista de inscrições da tabela para um arquivo XLSX
+function exportarInscricoesXLSX() {
+    const linhas = [
+        ['ID', 'Nome', 'Email', 'CPF', 'Empresa'],
+        ...Array.from(document.querySelectorAll('#inscricoesTableBody tr')).map(tr =>
+            Array.from(tr.children).map(td => td.textContent.trim())
+        )
+    ];
+    const ws = XLSX.utils.aoa_to_sheet(linhas);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Inscricoes');
+    const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    const blob = new Blob([wbout], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'inscricoes.xlsx';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -236,6 +260,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (document.getElementById('turmaTreinamentoId')) {
         carregarTreinamentosSelect().then(atualizarCampoPratica);
         document.getElementById('turmaTreinamentoId').addEventListener('change', atualizarCampoPratica);
+    }
+
+    const btnExportar = document.getElementById('btnExportarInscricoes');
+    if (btnExportar) {
+        btnExportar.addEventListener('click', exportarInscricoesXLSX);
     }
 });
 

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -71,10 +71,13 @@
                 </div>
                 <div class="card mt-4">
                     <div class="card-body p-0">
+                        <div class="d-flex justify-content-end p-3">
+                            <button id="btnExportarInscricoes" class="btn btn-sm btn-outline-secondary">Exportar Inscrições</button>
+                        </div>
                         <div class="table-responsive">
                             <table class="table table-striped table-hover">
                                 <thead>
-                                    <tr><th>ID</th><th>Nome</th><th>Email</th><th>CPF</th></tr>
+                                    <tr><th>ID</th><th>Nome</th><th>Email</th><th>CPF</th><th>Empresa</th></tr>
                                 </thead>
                                 <tbody id="inscricoesTableBody"></tbody>
                             </table>
@@ -84,8 +87,9 @@
             </main>
         </div>
     </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="/js/app.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+    <script src="/js/app.js"></script>
 <script src="/js/treinamentos-admin.js"></script>
 <script>
     const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- display `empresa` in admin inscriptions table
- add an export button to download inscriptions as XLSX
- implement client-side XLSX export using SheetJS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688022a20658832392d55d11fd1eabe8