### PR TITLE
Add conteudo programatico field

### DIFF
--- a/migrations/versions/2a3b24d0e5e5_add_conteudo_programatico_column.py
+++ b/migrations/versions/2a3b24d0e5e5_add_conteudo_programatico_column.py
@@ -1,0 +1,22 @@
+"""add conteudo_programatico column to treinamentos
+
+Revision ID: add_conteudo_programatico
+Revises: 9f1c4e5a4b6a
+Create Date: 2025-09-01 00:00:00
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'add_conteudo_programatico'
+down_revision: Union[str, Sequence[str], None] = '9f1c4e5a4b6a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('treinamentos', sa.Column('conteudo_programatico', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('treinamentos', 'conteudo_programatico')

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -20,6 +20,8 @@ class Treinamento(db.Model):
     carga_horaria = db.Column(db.Integer)
     tem_pratica = db.Column(db.Boolean, default=False)
     links_materiais = db.Column(db.JSON)
+    # Novo campo para descrever o conteudo programatico do treinamento
+    conteudo_programatico = db.Column(db.Text)
 
     data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
     data_atualizacao = db.Column(
@@ -39,6 +41,7 @@ class Treinamento(db.Model):
             "carga_horaria": self.carga_horaria,
             "tem_pratica": self.tem_pratica,
             "links_materiais": self.links_materiais or [],
+            "conteudo_programatico": self.conteudo_programatico,
         }
 
     def __repr__(self):

--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -143,6 +143,8 @@ def criar_treinamento():
             carga_horaria=payload.carga_horaria,
             tem_pratica=payload.tem_pratica,
             links_materiais=payload.links_materiais,
+            # Inclui conteudo programatico se enviado
+            conteudo_programatico=payload.conteudo_programatico,
         )
         db.session.add(novo)
         db.session.commit()
@@ -187,6 +189,8 @@ def atualizar_treinamento(treinamento_id):
         treino.tem_pratica = payload.tem_pratica
     if payload.links_materiais is not None:
         treino.links_materiais = payload.links_materiais
+    if payload.conteudo_programatico is not None:
+        treino.conteudo_programatico = payload.conteudo_programatico
     try:
         db.session.commit()
         return jsonify(treino.to_dict())

--- a/src/schemas/treinamento.py
+++ b/src/schemas/treinamento.py
@@ -22,6 +22,7 @@ class TreinamentoCreateSchema(BaseModel):
     carga_horaria: Optional[int] = None
     tem_pratica: Optional[bool] = False
     links_materiais: Optional[List[str]] = None
+    conteudo_programatico: Optional[str] = None
 
 
 class TreinamentoUpdateSchema(BaseModel):
@@ -33,6 +34,7 @@ class TreinamentoUpdateSchema(BaseModel):
     carga_horaria: Optional[int] = None
     tem_pratica: Optional[bool] = None
     links_materiais: Optional[List[str]] = None
+    conteudo_programatico: Optional[str] = None
 
 
 class TurmaTreinamentoCreateSchema(BaseModel):

--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -81,7 +81,9 @@ async function salvarTreinamento() {
         capacidade_maxima: parseInt(document.getElementById('capacidadeTrein').value) || null,
         carga_horaria: parseInt(document.getElementById('cargaTrein').value) || null,
         tem_pratica: document.getElementById('temPratica').checked,
-        links_materiais: document.getElementById('linksTrein').value ? document.getElementById('linksTrein').value.split('\n') : null
+        links_materiais: document.getElementById('linksTrein').value ? document.getElementById('linksTrein').value.split('\n') : null,
+        // Novo campo de conteudo programatico
+        conteudo_programatico: document.getElementById('conteudoTrein').value || null
     };
     try {
         if (id) {
@@ -105,6 +107,8 @@ function editarTreinamento(id) {
         document.getElementById('cargaTrein').value = t.carga_horaria || '';
         document.getElementById('temPratica').checked = t.tem_pratica;
         document.getElementById('linksTrein').value = (t.links_materiais || []).join('\n');
+        // Preenche conteudo programatico
+        document.getElementById('conteudoTrein').value = t.conteudo_programatico || '';
         new bootstrap.Modal(document.getElementById('treinamentoModal')).show();
     });
 }

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -120,6 +120,11 @@
                             <label class="form-label">Links para materiais (um por linha)</label>
                             <textarea class="form-control" id="linksTrein" rows="3"></textarea>
                         </div>
+                        <!-- Novo campo de Conteúdo Programático -->
+                        <div class="mb-3">
+                            <label class="form-label">Conteúdo Programático</label>
+                            <textarea class="form-control" id="conteudoTrein" rows="3"></textarea>
+                        </div>
                     </form>
                 </div>
                 <div class="modal-footer">

--- a/tests/test_treinamento_routes.py
+++ b/tests/test_treinamento_routes.py
@@ -1,0 +1,34 @@
+import jwt
+from datetime import datetime, timedelta
+from src.models.user import User
+
+
+def admin_headers(app):
+    with app.app_context():
+        user = User.query.filter_by(email='admin@example.com').first()
+        token = jwt.encode({
+            'user_id': user.id,
+            'nome': user.nome,
+            'perfil': user.tipo,
+            'exp': datetime.utcnow() + timedelta(hours=1)
+        }, app.config['SECRET_KEY'], algorithm='HS256')
+        return {'Authorization': f'Bearer {token}'}
+
+
+def test_criar_e_atualizar_treinamento(client, app):
+    headers = admin_headers(app)
+    resp = client.post('/api/treinamentos/catalogo', json={
+        'nome': 'Trein',
+        'codigo': 'T1',
+        'conteudo_programatico': 'Intro'
+    }, headers=headers)
+    assert resp.status_code == 201
+    treino_id = resp.get_json()['id']
+    assert resp.get_json()['conteudo_programatico'] == 'Intro'
+
+    resp_up = client.put(f'/api/treinamentos/catalogo/{treino_id}', json={
+        'conteudo_programatico': 'Avancado'
+    }, headers=headers)
+    assert resp_up.status_code == 200
+    assert resp_up.get_json()['conteudo_programatico'] == 'Avancado'
+


### PR DESCRIPTION
## Summary
- allow training descriptions via a new `conteudo_programatico` column
- expose the field through API and admin UI
- adjust admin catalog modal and JS
- add Alembic migration
- test training creation/update with the new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688028ee2b0c832386d3ee52e55483d4