### PR TITLE
Add conteudo_programatico field to training model

### DIFF
--- a/migrations/versions/add_conteudo_programatico_to_treinamento.py
+++ b/migrations/versions/add_conteudo_programatico_to_treinamento.py
@@ -1,0 +1,27 @@
+"""add conteudo_programatico column to treinamentos
+
+Revision ID: 5e78c8e1a7b9
+Revises: 47aff0d3be81
+Create Date: 2025-08-23 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '5e78c8e1a7b9'
+down_revision: Union[str, Sequence[str], None] = '47aff0d3be81'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('treinamentos', sa.Column('conteudo_programatico', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('treinamentos', 'conteudo_programatico')

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -20,6 +20,7 @@ class Treinamento(db.Model):
     carga_horaria = db.Column(db.Integer)
     tem_pratica = db.Column(db.Boolean, default=False)
     links_materiais = db.Column(db.JSON)
+    conteudo_programatico = db.Column(db.Text, nullable=True)
 
     data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
     data_atualizacao = db.Column(
@@ -39,6 +40,7 @@ class Treinamento(db.Model):
             "carga_horaria": self.carga_horaria,
             "tem_pratica": self.tem_pratica,
             "links_materiais": self.links_materiais or [],
+            "conteudo_programatico": self.conteudo_programatico,
         }
 
     def __repr__(self):

--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -143,6 +143,7 @@ def criar_treinamento():
             carga_horaria=payload.carga_horaria,
             tem_pratica=payload.tem_pratica,
             links_materiais=payload.links_materiais,
+            conteudo_programatico=payload.conteudo_programatico,
         )
         db.session.add(novo)
         db.session.commit()
@@ -187,6 +188,8 @@ def atualizar_treinamento(treinamento_id):
         treino.tem_pratica = payload.tem_pratica
     if payload.links_materiais is not None:
         treino.links_materiais = payload.links_materiais
+    if payload.conteudo_programatico is not None:
+        treino.conteudo_programatico = payload.conteudo_programatico
     try:
         db.session.commit()
         return jsonify(treino.to_dict())

--- a/src/schemas/treinamento.py
+++ b/src/schemas/treinamento.py
@@ -22,6 +22,7 @@ class TreinamentoCreateSchema(BaseModel):
     carga_horaria: Optional[int] = None
     tem_pratica: Optional[bool] = False
     links_materiais: Optional[List[str]] = None
+    conteudo_programatico: Optional[str] = None
 
 
 class TreinamentoUpdateSchema(BaseModel):
@@ -33,6 +34,7 @@ class TreinamentoUpdateSchema(BaseModel):
     carga_horaria: Optional[int] = None
     tem_pratica: Optional[bool] = None
     links_materiais: Optional[List[str]] = None
+    conteudo_programatico: Optional[str] = None
 
 
 class TurmaTreinamentoCreateSchema(BaseModel):

--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -81,7 +81,8 @@ async function salvarTreinamento() {
         capacidade_maxima: parseInt(document.getElementById('capacidadeTrein').value) || null,
         carga_horaria: parseInt(document.getElementById('cargaTrein').value) || null,
         tem_pratica: document.getElementById('temPratica').checked,
-        links_materiais: document.getElementById('linksTrein').value ? document.getElementById('linksTrein').value.split('\n') : null
+        links_materiais: document.getElementById('linksTrein').value ? document.getElementById('linksTrein').value.split('\n') : null,
+        conteudo_programatico: document.getElementById('conteudoProgramatico').value
     };
     try {
         if (id) {
@@ -105,6 +106,7 @@ function editarTreinamento(id) {
         document.getElementById('cargaTrein').value = t.carga_horaria || '';
         document.getElementById('temPratica').checked = t.tem_pratica;
         document.getElementById('linksTrein').value = (t.links_materiais || []).join('\n');
+        document.getElementById('conteudoProgramatico').value = t.conteudo_programatico || '';
         new bootstrap.Modal(document.getElementById('treinamentoModal')).show();
     });
 }

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -120,6 +120,10 @@
                             <label class="form-label">Links para materiais (um por linha)</label>
                             <textarea class="form-control" id="linksTrein" rows="3"></textarea>
                         </div>
+                        <div class="mb-3">
+                            <label class="form-label">Conteúdo Programático</label>
+                            <textarea class="form-control" id="conteudoProgramatico" rows="5"></textarea>
+                        </div>
                     </form>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Summary
- allow storing training program content
- expose the new field in API schemas and routes
- display/edit the field in admin catalog page
- adjust JS logic to send and load the new field
- include database migration for the column

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880396d44b08323b7b077978ccc0b53