### PR TITLE
Update modals to reset forms

### DIFF
--- a/src/static/js/corpo-docente.js
+++ b/src/static/js/corpo-docente.js
@@ -10,7 +10,8 @@ class GerenciadorInstrutores {
         this.btnLimparFiltros = document.getElementById('btnLimparFiltros');
         this.filtroNome = document.getElementById('filtroNome');
         this.filtroStatus = document.getElementById('filtroStatus');
-        this.modalInstrutor = new bootstrap.Modal(document.getElementById('modalInstrutor'));
+        this.modalEl = document.getElementById('modalInstrutor');
+        this.modalInstrutor = new bootstrap.Modal(this.modalEl);
         this.modalExcluir = new bootstrap.Modal(document.getElementById('modalExcluirInstrutor'));
         this.form = document.getElementById('formInstrutor');
         this.btnSalvar = document.getElementById('btnSalvarInstrutor');
@@ -48,6 +49,13 @@ class GerenciadorInstrutores {
         });
         document.getElementById('confirmarExcluirInstrutor')
             .addEventListener('click', () => this.confirmarExclusao());
+
+        // Adiciona o listener para limpar o formulário sempre que o modal for fechado
+        this.modalEl.addEventListener('hidden.bs.modal', () => {
+            this.form.reset();
+            document.getElementById('instrutorId').value = '';
+            this.instrutorAtual = null;
+        });
     }
 
     async carregarAreas() {

--- a/src/static/js/rateio-config.js
+++ b/src/static/js/rateio-config.js
@@ -1,4 +1,15 @@
-// Conteudo atualizado para rateio-config.js
+// Função para limpar e abrir o modal para uma nova configuração
+let configEmEdicaoId = null;
+// Função para limpar e abrir o modal para uma nova configuração
+function novaConfig() {
+    document.getElementById('configForm').reset();
+    configEmEdicaoId = null; // Garante que é modo de criação
+    document.getElementById('modalConfigLabel').textContent = 'Nova Configuração';
+    // Acessa o modal pela variável global definida no escopo do DOMContentLoaded
+    if (window.configModal) {
+        window.configModal.show();
+    }
+}
 
 document.addEventListener('DOMContentLoaded', function() {
     // Validação de autenticação e permissões
@@ -7,12 +18,20 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
-    const configModal = new bootstrap.Modal(document.getElementById('configModal'));
+    const configModalEl = document.getElementById('configModal');
+    window.configModal = new bootstrap.Modal(configModalEl); // Torna o modal acessível globalmente
     const confirmacaoModal = new bootstrap.Modal(document.getElementById('confirmacaoModal'));
     const form = document.getElementById('configForm');
     const tableBody = document.getElementById('configsTableBody');
-    let configEmEdicaoId = null;
     let configParaExcluirId = null;
+
+    // Listener para limpar o form sempre que o modal for fechado
+    if (configModalEl) {
+        configModalEl.addEventListener('hidden.bs.modal', () => {
+            form.reset();
+            configEmEdicaoId = null;
+        });
+    }
 
     // Função para carregar e renderizar as configurações
     async function carregarConfiguracoes() {
@@ -63,7 +82,7 @@ document.addEventListener('DOMContentLoaded', function() {
             configEmEdicaoId = null;
             document.getElementById('modalConfigLabel').textContent = 'Nova Configuração';
         }
-        configModal.show();
+        window.configModal.show();
     }
 
     // Salvar (Criar ou Editar)
@@ -84,7 +103,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 await chamarAPI('/rateio-configs', 'POST', dados);
                 exibirAlerta('Configuração criada com sucesso!', 'success');
             }
-            configModal.hide();
+            window.configModal.hide();
             carregarConfiguracoes();
         } catch (error) {
             exibirAlerta(`Erro ao salvar: ${error.message}`, 'danger');

--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -1,5 +1,13 @@
 // Funções para administração de treinamentos e turmas
 
+// Função nova para limpar e abrir o modal
+function novoTreinamento() {
+    document.getElementById('treinamentoForm').reset();
+    document.getElementById('treinamentoId').value = '';
+    const modal = new bootstrap.Modal(document.getElementById('treinamentoModal'));
+    modal.show();
+}
+
 async function carregarCatalogo() {
     try {
         const lista = await chamarAPI('/treinamentos/catalogo');
@@ -174,4 +182,13 @@ document.addEventListener('DOMContentLoaded', () => {
     verificarPermissaoAdmin();
     if (document.getElementById('catalogoTableBody')) carregarCatalogo();
     if (document.getElementById('turmasTableBody')) carregarTurmas();
+
+    // Adiciona o listener para limpar o formulário sempre que o modal for fechado
+    const treinamentoModalEl = document.getElementById('treinamentoModal');
+    if (treinamentoModalEl) {
+        treinamentoModalEl.addEventListener('hidden.bs.modal', () => {
+            document.getElementById('treinamentoForm').reset();
+            document.getElementById('treinamentoId').value = '';
+        });
+    }
 });

--- a/src/static/laboratorios/laboratorios-turmas.html
+++ b/src/static/laboratorios/laboratorios-turmas.html
@@ -273,9 +273,24 @@
             
             // Variáveis para controle dos modais
             const confirmacaoModal = new bootstrap.Modal(document.getElementById('confirmacaoModal'));
-            const laboratorioModal = new bootstrap.Modal(document.getElementById('laboratorioModal'));
-            const turmaModal = new bootstrap.Modal(document.getElementById('turmaModal'));
+            const laboratorioModalEl = document.getElementById('laboratorioModal');
+            const turmaModalEl = document.getElementById('turmaModal');
+            const laboratorioModal = new bootstrap.Modal(laboratorioModalEl);
+            const turmaModal = new bootstrap.Modal(turmaModalEl);
             let itemParaExcluir = { tipo: null, id: null };
+
+            // ADICIONADO: Listeners para limpar os modais quando fechados
+            laboratorioModalEl.addEventListener('hidden.bs.modal', () => {
+                document.getElementById('laboratorioForm').reset();
+                document.getElementById('laboratorioId').value = '';
+                document.getElementById('btnSalvarLaboratorio').innerHTML = '<i class="bi bi-plus-circle me-2"></i>Adicionar';
+            });
+
+            turmaModalEl.addEventListener('hidden.bs.modal', () => {
+                document.getElementById('turmaForm').reset();
+                document.getElementById('turmaId').value = '';
+                document.getElementById('btnSalvarTurma').innerHTML = '<i class="bi bi-plus-circle me-2"></i>Adicionar';
+            });
             
             // Carrega os dados iniciais
             carregarLaboratorios();
@@ -501,16 +516,12 @@
             }
 
             window.novoLaboratorio = function() {
-                document.getElementById('laboratorioForm').reset();
-                document.getElementById('laboratorioId').value = '';
-                document.getElementById('btnSalvarLaboratorio').innerHTML = '<i class="bi bi-plus-circle me-2"></i>Adicionar';
+                // A limpeza agora é feita pelo listener 'hidden.bs.modal'
                 laboratorioModal.show();
             };
 
             window.novaTurma = function() {
-                document.getElementById('turmaForm').reset();
-                document.getElementById('turmaId').value = '';
-                document.getElementById('btnSalvarTurma').innerHTML = '<i class="bi bi-plus-circle me-2"></i>Adicionar';
+                // A limpeza agora é feita pelo listener 'hidden.bs.modal'
                 turmaModal.show();
             };
         });

--- a/src/static/rateio/rateio-config.html
+++ b/src/static/rateio/rateio-config.html
@@ -70,7 +70,7 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h2 class="mb-0">Configurações de Rateio</h2>
-                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#configModal">
+                    <button class="btn btn-primary" onclick="novaConfig()">
                         <i class="bi bi-plus-circle me-2"></i>NOVA CONFIGURAÇÃO
                     </button>
                 </div>

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -65,7 +65,7 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h2 class="mb-0">Gerenciar Catálogo de Treinamentos</h2>
-                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#treinamentoModal"><i class="bi bi-plus-circle me-2"></i>NOVO TREINAMENTO</button>
+                    <button class="btn btn-primary" onclick="novoTreinamento()"><i class="bi bi-plus-circle me-2"></i>NOVO TREINAMENTO</button>
                 </div>
                 
                 <div id="alertContainer" class="mt-3"></div>


### PR DESCRIPTION
## Summary
- ensure the "Novo Treinamento" button opens the modal cleanly
- add `novoTreinamento` helper and cleanup listener
- reset corpo-docente modal on close
- adjust rateio configuration modal handling
- clear laboratory and class modals when hidden

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813f83c3208323865e79e6b0a632ef