### PR TITLE
Permit trainings with duplicate names

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -136,9 +136,10 @@ def criar_treinamento():
     except ValidationError as e:
         return jsonify({"erro": e.errors()}), 400
 
-    # Verifica se o nome ou código já estão em uso
-    if Treinamento.query.filter_by(nome=payload.nome).first():
-        return jsonify({"erro": "Já existe um treinamento com este nome"}), 400
+    # Verifica se já existe um treinamento com o mesmo nome e código
+    if Treinamento.query.filter_by(nome=payload.nome, codigo=payload.codigo).first():
+        return jsonify({"erro": "Já existe um treinamento com este nome e código"}), 400
+    # Código continua único para evitar duplicidade
     if Treinamento.query.filter_by(codigo=payload.codigo).first():
         return jsonify({"erro": "Já existe um treinamento com este código"}), 400
     try:
@@ -183,14 +184,18 @@ def atualizar_treinamento(treinamento_id):
     except ValidationError as e:
         return jsonify({"erro": e.errors()}), 400
 
+    novo_nome = payload.nome if payload.nome is not None else treino.nome
+    novo_codigo = payload.codigo if payload.codigo is not None else treino.codigo
+
+    existente = Treinamento.query.filter_by(nome=novo_nome, codigo=novo_codigo).first()
+    if existente and existente.id != treinamento_id:
+        return jsonify({"erro": "Já existe um treinamento com este nome e código"}), 400
+
     if payload.nome is not None:
-        existente = Treinamento.query.filter_by(nome=payload.nome).first()
-        if existente and existente.id != treinamento_id:
-            return jsonify({"erro": "Já existe um treinamento com este nome"}), 400
         treino.nome = payload.nome
     if payload.codigo is not None:
-        existente = Treinamento.query.filter_by(codigo=payload.codigo).first()
-        if existente and existente.id != treinamento_id:
+        existente_codigo = Treinamento.query.filter_by(codigo=payload.codigo).first()
+        if existente_codigo and existente_codigo.id != treinamento_id:
             return jsonify({"erro": "Já existe um treinamento com este código"}), 400
         treino.codigo = payload.codigo
     if payload.capacidade_maxima is not None:

--- a/tests/test_treinamento_routes.py
+++ b/tests/test_treinamento_routes.py
@@ -1,0 +1,39 @@
+import jwt
+from datetime import datetime, timedelta
+
+
+def admin_headers(app):
+    with app.app_context():
+        from src.models.user import User
+        user = User.query.filter_by(email='admin@example.com').first()
+        token = jwt.encode({
+            'user_id': user.id,
+            'nome': user.nome,
+            'perfil': user.tipo,
+            'exp': datetime.utcnow() + timedelta(hours=1)
+        }, app.config['SECRET_KEY'], algorithm='HS256')
+        return {'Authorization': f'Bearer {token}'}
+
+
+def test_criar_treinamento_nome_repetido_permitido(client, app):
+    headers = admin_headers(app)
+    resp1 = client.post('/api/treinamentos/catalogo', json={'nome': 'Treino', 'codigo': 'T1'}, headers=headers)
+    assert resp1.status_code == 201
+    resp2 = client.post('/api/treinamentos/catalogo', json={'nome': 'Treino', 'codigo': 'T2'}, headers=headers)
+    assert resp2.status_code == 201
+
+
+def test_criar_treinamento_nome_codigo_iguais_falha(client, app):
+    headers = admin_headers(app)
+    client.post('/api/treinamentos/catalogo', json={'nome': 'TreinoX', 'codigo': 'TX'}, headers=headers)
+    resp = client.post('/api/treinamentos/catalogo', json={'nome': 'TreinoX', 'codigo': 'TX'}, headers=headers)
+    assert resp.status_code == 400
+
+
+def test_atualizar_treinamento_nome_duplicado_permitido(client, app):
+    headers = admin_headers(app)
+    client.post('/api/treinamentos/catalogo', json={'nome': 'A', 'codigo': 'C1'}, headers=headers)
+    r2 = client.post('/api/treinamentos/catalogo', json={'nome': 'B', 'codigo': 'C2'}, headers=headers)
+    tid2 = r2.get_json()['id']
+    resp = client.put(f'/api/treinamentos/catalogo/{tid2}', json={'nome': 'A'}, headers=headers)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow duplicate training names when adding/updating
- add tests covering duplicate name scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881475df2c08323a9550360484087f7