### PR TITLE
Fix training name uniqueness

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -136,10 +136,9 @@ def criar_treinamento():
     except ValidationError as e:
         return jsonify({"erro": e.errors()}), 400
 
-    # Verifica se já existe um treinamento com o mesmo nome e código
-    if Treinamento.query.filter_by(nome=payload.nome, codigo=payload.codigo).first():
-        return jsonify({"erro": "Já existe um treinamento com este nome e código"}), 400
-    # Código continua único para evitar duplicidade
+    # Verificações de duplicidade
+    if Treinamento.query.filter_by(nome=payload.nome).first():
+        return jsonify({"erro": "Já existe um treinamento com este nome"}), 400
     if Treinamento.query.filter_by(codigo=payload.codigo).first():
         return jsonify({"erro": "Já existe um treinamento com este código"}), 400
     try:
@@ -187,6 +186,9 @@ def atualizar_treinamento(treinamento_id):
     novo_nome = payload.nome if payload.nome is not None else treino.nome
     novo_codigo = payload.codigo if payload.codigo is not None else treino.codigo
 
+    existente_nome = Treinamento.query.filter_by(nome=novo_nome).first()
+    if existente_nome and existente_nome.id != treinamento_id:
+        return jsonify({"erro": "Já existe um treinamento com este nome"}), 400
     existente = Treinamento.query.filter_by(nome=novo_nome, codigo=novo_codigo).first()
     if existente and existente.id != treinamento_id:
         return jsonify({"erro": "Já existe um treinamento com este nome e código"}), 400

--- a/tests/test_treinamento_routes.py
+++ b/tests/test_treinamento_routes.py
@@ -15,12 +15,12 @@ def admin_headers(app):
         return {'Authorization': f'Bearer {token}'}
 
 
-def test_criar_treinamento_nome_repetido_permitido(client, app):
+def test_criar_treinamento_nome_repetido_falha(client, app):
     headers = admin_headers(app)
     resp1 = client.post('/api/treinamentos/catalogo', json={'nome': 'Treino', 'codigo': 'T1'}, headers=headers)
     assert resp1.status_code == 201
     resp2 = client.post('/api/treinamentos/catalogo', json={'nome': 'Treino', 'codigo': 'T2'}, headers=headers)
-    assert resp2.status_code == 201
+    assert resp2.status_code == 400
 
 
 def test_criar_treinamento_nome_codigo_iguais_falha(client, app):
@@ -30,10 +30,10 @@ def test_criar_treinamento_nome_codigo_iguais_falha(client, app):
     assert resp.status_code == 400
 
 
-def test_atualizar_treinamento_nome_duplicado_permitido(client, app):
+def test_atualizar_treinamento_nome_duplicado_falha(client, app):
     headers = admin_headers(app)
     client.post('/api/treinamentos/catalogo', json={'nome': 'A', 'codigo': 'C1'}, headers=headers)
     r2 = client.post('/api/treinamentos/catalogo', json={'nome': 'B', 'codigo': 'C2'}, headers=headers)
     tid2 = r2.get_json()['id']
     resp = client.put(f'/api/treinamentos/catalogo/{tid2}', json={'nome': 'A'}, headers=headers)
-    assert resp.status_code == 200
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- ensure catalog training names are unique
- update tests for new duplicate name behavior

## Testing
- `flake8 --max-line-length=120`
- `bandit -r src -ll`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688150bb78488323a8e2a38f24f57cb9