### PR TITLE
Fix editing trainings via modal

### DIFF
--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -188,6 +188,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (document.getElementById('catalogoTableBody')) carregarCatalogo();
     if (document.getElementById('turmasTableBody')) carregarTurmas();
 
+    const formTreinamento = document.getElementById('treinamentoForm');
+    if (formTreinamento) {
+        formTreinamento.addEventListener('submit', (e) => {
+            e.preventDefault();
+            salvarTreinamento();
+        });
+    }
+
     // Adiciona o listener para limpar o formulário sempre que o modal for fechado
     const treinamentoModalEl = document.getElementById('treinamentoModal');
     if (treinamentoModalEl) {

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -102,7 +102,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
-                    <form id="treinamentoForm" onsubmit="event.preventDefault(); salvarTreinamento();">
+                    <form id="treinamentoForm">
                         <input type="hidden" id="treinamentoId">
                         
                         <div class="mb-3">
@@ -145,7 +145,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" form="treinamentoForm" class="btn btn-primary">Salvar</button>
+                    <button id="btnSalvarTreinamento" type="submit" form="treinamentoForm" class="btn btn-primary">Salvar</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- wire up submit handler for training form
- add button id for modal save button

## Testing
- `pytest -k treinamento -q`

------
https://chatgpt.com/codex/tasks/task_e_688157637e508323987ce80c21ddbbc8