### PR TITLE
Allow duplicate training names

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -136,9 +136,7 @@ def criar_treinamento():
     except ValidationError as e:
         return jsonify({"erro": e.errors()}), 400
 
-    # Verificações de duplicidade
-    if Treinamento.query.filter_by(nome=payload.nome).first():
-        return jsonify({"erro": "Já existe um treinamento com este nome"}), 400
+    # Verificação de duplicidade de código
     if Treinamento.query.filter_by(codigo=payload.codigo).first():
         return jsonify({"erro": "Já existe um treinamento com este código"}), 400
     try:
@@ -182,16 +180,6 @@ def atualizar_treinamento(treinamento_id):
         payload = TreinamentoUpdateSchema(**data)
     except ValidationError as e:
         return jsonify({"erro": e.errors()}), 400
-
-    novo_nome = payload.nome if payload.nome is not None else treino.nome
-    novo_codigo = payload.codigo if payload.codigo is not None else treino.codigo
-
-    existente_nome = Treinamento.query.filter_by(nome=novo_nome).first()
-    if existente_nome and existente_nome.id != treinamento_id:
-        return jsonify({"erro": "Já existe um treinamento com este nome"}), 400
-    existente = Treinamento.query.filter_by(nome=novo_nome, codigo=novo_codigo).first()
-    if existente and existente.id != treinamento_id:
-        return jsonify({"erro": "Já existe um treinamento com este nome e código"}), 400
 
     if payload.nome is not None:
         treino.nome = payload.nome

--- a/tests/test_treinamento_routes.py
+++ b/tests/test_treinamento_routes.py
@@ -15,12 +15,12 @@ def admin_headers(app):
         return {'Authorization': f'Bearer {token}'}
 
 
-def test_criar_treinamento_nome_repetido_falha(client, app):
+def test_criar_treinamento_nome_repetido_permitido(client, app):
     headers = admin_headers(app)
     resp1 = client.post('/api/treinamentos/catalogo', json={'nome': 'Treino', 'codigo': 'T1'}, headers=headers)
     assert resp1.status_code == 201
     resp2 = client.post('/api/treinamentos/catalogo', json={'nome': 'Treino', 'codigo': 'T2'}, headers=headers)
-    assert resp2.status_code == 400
+    assert resp2.status_code == 201
 
 
 def test_criar_treinamento_nome_codigo_iguais_falha(client, app):
@@ -30,10 +30,10 @@ def test_criar_treinamento_nome_codigo_iguais_falha(client, app):
     assert resp.status_code == 400
 
 
-def test_atualizar_treinamento_nome_duplicado_falha(client, app):
+def test_atualizar_treinamento_nome_duplicado_permitido(client, app):
     headers = admin_headers(app)
     client.post('/api/treinamentos/catalogo', json={'nome': 'A', 'codigo': 'C1'}, headers=headers)
     r2 = client.post('/api/treinamentos/catalogo', json={'nome': 'B', 'codigo': 'C2'}, headers=headers)
     tid2 = r2.get_json()['id']
     resp = client.put(f'/api/treinamentos/catalogo/{tid2}', json={'nome': 'A'}, headers=headers)
-    assert resp.status_code == 400
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- permit multiple training records to share the same name
- update tests to reflect new behaviour

## Testing
- `pytest -q tests/test_treinamento_routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688159267e3083238d376544cc15b4c3