### PR TITLE
Fix treino admin modal and add turma GET

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -378,3 +378,19 @@ def exportar_inscricoes(turma_id):
     output.headers["Content-Disposition"] = "attachment; filename=inscricoes.csv"
     output.headers["Content-Type"] = "text/csv"
     return output
+
+
+@treinamento_bp.route("/treinamentos/turmas/<int:turma_id>", methods=["GET"])
+@admin_required
+def obter_turma_treinamento(turma_id):
+    """Obtém detalhes de uma turma de treinamento."""
+    turma = db.session.get(TurmaTreinamento, turma_id)
+    if not turma:
+        return jsonify({"erro": "Turma não encontrada"}), 404
+
+    dados_turma = turma.to_dict()
+    dados_turma["treinamento"] = (
+        turma.treinamento.to_dict() if turma.treinamento else None
+    )
+
+    return jsonify(dados_turma)


### PR DESCRIPTION
## Summary
- add missing API endpoint to get a single turma
- overhaul admin JS for trainings

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815ce408c483239bd576466a288556