### PR TITLE
Add presence tracking for training

### DIFF
--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -113,6 +113,9 @@ class InscricaoTreinamento(db.Model):
     nota_teoria = db.Column(db.Float, nullable=True)
     nota_pratica = db.Column(db.Float, nullable=True)
     status_aprovacao = db.Column(db.String(20), nullable=True)
+    # --- NOVOS CAMPOS DE PRESENCA ---
+    presenca_teoria = db.Column(db.Boolean, default=False, nullable=False)
+    presenca_pratica = db.Column(db.Boolean, default=False, nullable=False)
     # ------------------------------------
 
     usuario = db.relationship("User", backref="inscricoes_treinamento")
@@ -136,6 +139,8 @@ class InscricaoTreinamento(db.Model):
             "nota_teoria": self.nota_teoria,
             "nota_pratica": self.nota_pratica,
             "status_aprovacao": self.status_aprovacao,
+            "presenca_teoria": self.presenca_teoria,
+            "presenca_pratica": self.presenca_pratica,
             # ---------------------------------------------
         }
 

--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -445,6 +445,10 @@ def avaliar_inscricao(inscricao_id):
         inscricao.nota_pratica = float(nota_pratica) if nota_pratica not in [None, ''] else None
         inscricao.status_aprovacao = data.get('status_aprovacao')
 
+        # Campos de presença
+        inscricao.presenca_teoria = data.get('presenca_teoria', False)
+        inscricao.presenca_pratica = data.get('presenca_pratica', False)
+
         db.session.commit()
         return jsonify(inscricao.to_dict())
 

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -67,13 +67,55 @@
             <!-- Conteúdo principal -->
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Lista de Inscrições</h2>
+                    <h2 class="mb-0">Lista de Presença e Avaliação</h2>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-header">
+                        <h5 class="mb-0">Dados do Treinamento</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <strong>Nome do Treinamento:</strong>
+                                <p id="infoNomeTreinamento" class="mb-0">-</p>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <strong>Instrutor:</strong>
+                                <p id="infoInstrutor" class="mb-0">-</p>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <strong>Período:</strong>
+                                <p id="infoPeriodo" class="mb-0">-</p>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <strong>Duração:</strong>
+                                <p id="infoDuracao" class="mb-0">-</p>
+                            </div>
+                            <div class="col-md-3 mb-3">
+                                <strong>Horário:</strong>
+                                <p id="infoHorario" class="mb-0">-</p>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <strong>Local de Realização:</strong>
+                                <p id="infoLocal" class="mb-0">-</p>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <strong>Instituição:</strong>
+                                <p class="mb-0">SENAI Conceição do Mato Dentro</p>
+                            </div>
+                            <div class="col-12">
+                                <strong>Conteúdo Programático:</strong>
+                                <p id="infoConteudo" class="mb-0" style="white-space: pre-wrap;">-</p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="card mt-4">
                     <div class="card-body p-0">
                         <div class="d-flex justify-content-end p-3">
                             <button id="btnExportarInscricoes" class="btn btn-sm btn-outline-secondary me-2">Exportar Inscrições</button>
-                            <button id="btnSalvarNotas" class="btn btn-sm btn-success">
+                            <button id="btnSalvarAlteracoes" class="btn btn-sm btn-success">
                                 <i class="bi bi-check-lg me-1"></i> Salvar Alterações
                             </button>
                         </div>
@@ -81,10 +123,11 @@
                             <table class="table table-striped table-hover">
                                 <thead>
                                     <tr>
-                                        <th>ID</th>
                                         <th>Nome</th>
                                         <th>CPF</th>
                                         <th>Empresa</th>
+                                        <th class="text-center" style="width: 100px;">Presença Teoria</th>
+                                        <th id="thPresencaPratica" class="text-center" style="width: 100px; display: none;">Presença Prática</th>
                                         <th style="width: 120px;">Nota Teoria</th>
                                         <th style="width: 120px;">Nota Prática</th>
                                         <th style="width: 150px;">Status</th>


### PR DESCRIPTION
## Summary
- track presence in InscricaoTreinamento model
- store presence info via avaliacao endpoint
- show training header on admin-inscricoes page
- add checkboxes for presence and save all fields

## Testing
- `pytest -q`
- `./scripts/auto_migrate.sh "Adiciona campos de presenca nas inscricoes"` *(fails: duplicate column capacidade_maxima)*

------
https://chatgpt.com/codex/tasks/task_e_6882431e6c288323ba4b4eab8408d7fb