### PR TITLE
Add export modal with PDF support

### DIFF
--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -68,6 +68,10 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h2 class="mb-0">Lista de Presença e Avaliação</h2>
+                    <a href="/treinamentos/admin-turmas.html" class="btn btn-outline-secondary">
+                        <i class="bi bi-arrow-left me-1"></i>
+                        Voltar para Turmas
+                    </a>
                 </div>
 
                 <div class="card mt-4">
@@ -116,7 +120,8 @@
                         <div class="d-flex justify-content-end p-3">
                             <button id="btnExportarInscricoes" class="btn btn-sm btn-outline-secondary me-2">Exportar Inscrições</button>
                             <button id="btnSalvarAlteracoes" class="btn btn-sm btn-success">
-                                <i class="bi bi-check-lg me-1"></i> Salvar Alterações
+                                <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                                <span class="btn-text"><i class="bi bi-check-lg me-1"></i> Salvar Alterações</span>
                             </button>
                         </div>
                         <div class="table-responsive">
@@ -139,6 +144,30 @@
                     </div>
                 </div>
             </main>
+        </div>
+    </div>
+
+    <div class="modal fade" id="exportarModal" tabindex="-1" aria-labelledby="exportarModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="exportarModalLabel">Exportar Inscrições</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Selecione o formato para exportar a lista de presença e avaliação:</p>
+                    <div class="d-grid gap-2">
+                        <button id="btnExportarPDF" class="btn btn-danger">
+                            <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                            <span class="btn-text"><i class="bi bi-file-earmark-pdf me-2"></i>Exportar para PDF</span>
+                        </button>
+                        <button id="btnExportarXLSX" class="btn btn-success">
+                            <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                            <span class="btn-text"><i class="bi bi-file-earmark-excel me-2"></i>Exportar para Excel</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- add back link to turma listing
- show spinner while saving or exporting
- export inscriptions via modal with PDF and XLSX options
- support PDF export on backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688267414ea4832399cca5a75a7bc66f