### PR TITLE
Fix locale initialization error

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -38,8 +38,12 @@ from reportlab.lib import colors
 from datetime import datetime
 import locale
 
-# Configura o locale para o formato de data em português
-locale.setlocale(locale.LC_TIME, "pt_BR.UTF-8")
+# Configura o locale para o formato de data em português. Em ambientes onde
+# esse locale não estiver disponível, mantemos o padrão sem gerar erro.
+try:
+    locale.setlocale(locale.LC_TIME, "pt_BR.UTF-8")
+except locale.Error:
+    pass
 
 
 treinamento_bp = Blueprint("treinamento", __name__)


### PR DESCRIPTION
## Summary
- handle missing pt_BR.UTF-8 locale in `treinamento` routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6882c78736908323b96782632b36879c