### PR TITLE
Fix header background color across table

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -485,7 +485,7 @@ def exportar_inscricoes(turma_id):
         header_table.setStyle(
             TableStyle([
                 ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-                ("BACKGROUND", (1, 0), (1, 0), cor_azul_senai),
+                ("BACKGROUND", (0, 0), (-1, -1), cor_azul_senai),  # Cor azul em toda a linha
             ])
         )
         elements.append(header_table)


### PR DESCRIPTION
## Summary
- update header table background style to color the entire row

## Testing
- `pytest -k treinamento -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6882cf81ea288323a58f516f517c20d2