### PR TITLE
Add admin interface for enrolling participants

### DIFF
--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -98,6 +98,45 @@ async function excluirTreinamento(id) {
     }
 }
 
+/**
+ * Abre o modal de inscrição para administradores.
+ * @param {number} turmaId - O ID da turma onde o participante será inscrito.
+ */
+function abrirModalInscricaoAdmin(turmaId) {
+    document.getElementById('adminInscricaoForm').reset();
+    document.getElementById('adminTurmaId').value = turmaId;
+    const modal = new bootstrap.Modal(document.getElementById('adminInscricaoModal'));
+    modal.show();
+}
+
+/**
+ * Envia os dados do formulário de inscrição do administrador para o servidor.
+ */
+async function enviarInscricaoAdmin() {
+    const btn = document.getElementById('btnEnviarAdminInscricao');
+
+    await executarAcaoComFeedback(btn, async () => {
+        const turmaId = document.getElementById('adminTurmaId').value;
+        const body = {
+            nome: document.getElementById('adminNome').value,
+            email: document.getElementById('adminEmail').value,
+            cpf: document.getElementById('adminCpf').value,
+            data_nascimento: document.getElementById('adminDataNascimento').value || null,
+            empresa: document.getElementById('adminEmpresa').value || null
+        };
+
+        try {
+            await chamarAPI(`/treinamentos/turmas/${turmaId}/inscricoes/admin`, 'POST', body);
+            exibirAlerta('Participante inscrito com sucesso!', 'success');
+            const modal = bootstrap.Modal.getInstance(document.getElementById('adminInscricaoModal'));
+            modal.hide();
+        } catch (e) {
+            exibirAlerta(e.message, 'danger');
+            throw e;
+        }
+    });
+}
+
 // Carrega a lista de turmas na tabela
 async function carregarTurmas() {
     try {
@@ -117,6 +156,9 @@ async function carregarTurmas() {
                 <td>${formatarData(t.data_inicio)}</td>
                 <td>${formatarData(t.data_fim)}</td>
                 <td>
+                    <button class="btn btn-sm btn-outline-success me-1" onclick="abrirModalInscricaoAdmin(${t.turma_id})" title="Adicionar Participante">
+                        <i class="bi bi-person-plus"></i>
+                    </button>
                     <a class="btn btn-sm btn-outline-info me-1" href="/treinamentos/admin-inscricoes.html?turma=${t.turma_id}" title="Ver Inscrições"><i class="bi bi-people"></i></a>
                     <button class="btn btn-sm btn-outline-primary" onclick="editarTurma(${t.turma_id})" title="Editar Turma"><i class="bi bi-pencil"></i></button>
                 </td>`;
@@ -395,6 +437,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (document.getElementById('turmasTableBody')) {
         carregarTurmas();
+    }
+
+    const btnEnviarAdmin = document.getElementById('btnEnviarAdminInscricao');
+    if (btnEnviarAdmin) {
+        btnEnviarAdmin.addEventListener('click', enviarInscricaoAdmin);
     }
 
     const formTreinamento = document.getElementById('treinamentoForm');

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -149,6 +149,49 @@
         </div>
     </div>
 
+    <div class="modal fade" id="adminInscricaoModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Inscrever Novo Participante</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="adminInscricaoForm">
+                        <input type="hidden" id="adminTurmaId">
+                        <div class="mb-3">
+                            <label class="form-label" for="adminNome">Nome Completo *</label>
+                            <input type="text" class="form-control" id="adminNome" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="adminEmail">Email *</label>
+                            <input type="email" class="form-control" id="adminEmail" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="adminCpf">CPF *</label>
+                            <input type="text" class="form-control" id="adminCpf" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="adminDataNascimento">Data de Nascimento</label>
+                            <input type="date" class="form-control" id="adminDataNascimento">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="adminEmpresa">Empresa</label>
+                            <input type="text" class="form-control" id="adminEmpresa">
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" class="btn btn-primary" id="btnEnviarAdminInscricao">
+                        <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                        <span class="btn-text">Inscrever Participante</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/treinamentos-admin.js"></script>


### PR DESCRIPTION
## Summary
- add modal for admin to register participants in `admin-turmas.html`
- implement JS helpers to handle admin enrollment
- show new button in admin turmas list
- wire button to new API endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68836d1415b0832385829697e39a2429