### PR TITLE
Restore training course functions

### DIFF
--- a/src/static/js/treinamentos.js
+++ b/src/static/js/treinamentos.js
@@ -1,9 +1,24 @@
+// Conteúdo completo e corrigido para o ficheiro: src/static/js/treinamentos.js
+
 // Armazena os dados do usuário logado para reutilização
 let dadosUsuarioLogado = null;
 
+/**
+ * Listener que é executado quando o conteúdo da página termina de carregar.
+ * Ele verifica qual página está ativa e chama a função de carregamento correspondente.
+ */
 document.addEventListener('DOMContentLoaded', () => {
-    carregarTreinamentos();
+    // Verifica se estamos na página de Cursos Disponíveis
+    if (document.getElementById('cursosContainer')) {
+        carregarTreinamentos();
+    }
 
+    // Verifica se estamos na página Meus Cursos
+    if (document.getElementById('listaMeusCursos')) {
+        carregarMeusCursos();
+    }
+
+    // Adiciona o listener para o botão de submissão do modal de inscrição
     const btnEnviar = document.getElementById('btnEnviarInscricao');
     if (btnEnviar) {
         btnEnviar.addEventListener('click', () => {
@@ -16,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    // Adiciona o listener para o checkbox de "inscrever outro"
     const checkInscreverOutro = document.getElementById('inscreverOutroCheck');
     if (checkInscreverOutro) {
         checkInscreverOutro.addEventListener('change', (e) => {
@@ -24,13 +40,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 
+/**
+ * Carrega a lista de turmas disponíveis e as exibe na página.
+ */
 async function carregarTreinamentos() {
     try {
         const turmas = await chamarAPI('/treinamentos');
         const container = document.getElementById('cursosContainer');
         if (!container) return;
 
-        container.innerHTML = '';
+        container.innerHTML = ''; // Limpa o spinner de carregamento
         if (turmas.length === 0) {
             container.innerHTML = '<p class="text-center">Nenhum curso disponível no momento.</p>';
             return;
@@ -45,7 +64,7 @@ async function carregarTreinamentos() {
                             <p class="card-text">${escapeHTML(t.treinamento.descricao || '')}</p>
                             <p class="card-text">
                                 <small class="text-muted">
-                                    Início: ${formatarData(t.data_inicio)}
+                                    Início: ${formatarData(t.data_inicio)} - Fim: ${formatarData(t.data_fim)}
                                 </small>
                             </p>
                             <button class="btn btn-primary" onclick="abrirModalInscricao(${t.turma_id})">
@@ -58,12 +77,42 @@ async function carregarTreinamentos() {
         });
     } catch (e) {
         exibirAlerta(e.message, 'danger');
+        const container = document.getElementById('cursosContainer');
+        if (container) container.innerHTML = '<p class="text-center text-danger">Falha ao carregar os cursos.</p>';
     }
 }
 
+/**
+ * (FUNÇÃO RESTAURADA) Carrega os cursos em que o usuário está inscrito.
+ */
+async function carregarMeusCursos() {
+    try {
+        const cursos = await chamarAPI('/treinamentos/minhas');
+        const ul = document.getElementById('listaMeusCursos');
+        ul.innerHTML = ''; // Limpa o spinner
+        if (cursos.length === 0) {
+            ul.innerHTML = '<li class="list-group-item text-center">Você não está inscrito em nenhum curso.</li>';
+            return;
+        }
+        cursos.forEach(c => {
+            const li = document.createElement('li');
+            li.className = 'list-group-item';
+            li.textContent = `${c.treinamento.nome} - Início em ${formatarData(c.data_inicio)}`;
+            ul.appendChild(li);
+        });
+    } catch(e) {
+        exibirAlerta(e.message, 'danger');
+        const ul = document.getElementById('listaMeusCursos');
+        if (ul) ul.innerHTML = '<li class="list-group-item text-center text-danger">Falha ao carregar seus cursos.</li>';
+    }
+}
+
+/**
+ * Abre o modal de inscrição, pré-preenchendo com dados do usuário logado.
+ * @param {number} turmaId - O ID da turma para a qual a inscrição será feita.
+ */
 async function abrirModalInscricao(turmaId) {
     try {
-        // Guarda os dados do usuário logado se ainda não tivermos
         if (!dadosUsuarioLogado) {
             dadosUsuarioLogado = await getUsuarioLogado();
         }
@@ -72,8 +121,6 @@ async function abrirModalInscricao(turmaId) {
         const modal = new bootstrap.Modal(modalEl);
 
         document.getElementById('turmaId').value = turmaId;
-
-        // Redefine o formulário para o estado padrão (inscrever a si mesmo)
         document.getElementById('inscreverOutroCheck').checked = false;
         toggleFormularioExterno(false);
 
@@ -83,29 +130,29 @@ async function abrirModalInscricao(turmaId) {
     }
 }
 
+/**
+ * Alterna o estado do formulário de inscrição entre "para mim" e "para outro".
+ * @param {boolean} isExterno - True se a inscrição for para outra pessoa.
+ */
 function toggleFormularioExterno(isExterno) {
     const form = document.getElementById('inscricaoForm');
     const inputs = form.querySelectorAll('input:not([type=hidden]):not([type=checkbox])');
 
     if (isExterno) {
-        // Habilita e limpa os campos para inserir dados de outra pessoa
         inputs.forEach(input => {
             input.readOnly = false;
             input.value = '';
         });
-        // A data de nascimento deve ser do tipo date
         document.getElementById('dataNascimento').type = 'date';
-        // Foca no primeiro campo
         document.getElementById('nome').focus();
     } else {
-        // Preenche os campos com os dados do usuário logado e os desabilita
         if (dadosUsuarioLogado) {
             document.getElementById('nome').value = dadosUsuarioLogado.nome;
             document.getElementById('email').value = dadosUsuarioLogado.email;
-            document.getElementById('cpf').value = dadosUsuarioLogado.cpf;
+            document.getElementById('cpf').value = dadosUsuarioLogado.cpf || '';
             document.getElementById('dataNascimento').type = 'text';
             document.getElementById('dataNascimento').value = formatarData(dadosUsuarioLogado.data_nascimento);
-            document.getElementById('empresa').value = dadosUsuarioLogado.empresa;
+            document.getElementById('empresa').value = dadosUsuarioLogado.empresa || '';
         }
         inputs.forEach(input => {
             input.readOnly = true;
@@ -113,10 +160,14 @@ function toggleFormularioExterno(isExterno) {
     }
 }
 
+/**
+ * Envia a inscrição para o próprio usuário logado.
+ */
 async function enviarInscricao() {
     const turmaId = document.getElementById('turmaId').value;
     try {
-        await chamarAPI(`/treinamentos/${turmaId}/inscricoes`, 'POST');
+        // Para auto-inscrição, o corpo pode ser vazio, pois o backend usa o usuário da sessão.
+        await chamarAPI(`/treinamentos/${turmaId}/inscricoes`, 'POST', {});
         exibirAlerta('Inscrição realizada com sucesso!', 'success');
         bootstrap.Modal.getInstance(document.getElementById('inscricaoModal')).hide();
     } catch (e) {
@@ -124,6 +175,9 @@ async function enviarInscricao() {
     }
 }
 
+/**
+ * Envia a inscrição para um participante externo.
+ */
 async function enviarInscricaoExterna() {
     const turmaId = document.getElementById('turmaId').value;
     const body = {
@@ -134,7 +188,6 @@ async function enviarInscricaoExterna() {
         empresa: document.getElementById('empresa').value,
     };
 
-    // Validação simples
     if (!body.nome || !body.email || !body.cpf) {
         exibirAlerta('Nome, Email e CPF são obrigatórios.', 'warning');
         return;


### PR DESCRIPTION
## Summary
- restore `carregarMeusCursos` and update `DOMContentLoaded` logic in `treinamentos.js`
- handle course loading errors and show course end date

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68838fee09408323a7e668410fdc6526