### PR TITLE
Fix admin inscriptions UI and training load

### DIFF
--- a/src/static/js/treinamentos.js
+++ b/src/static/js/treinamentos.js
@@ -9,7 +9,7 @@ let dadosUsuarioLogado = null;
  */
 document.addEventListener('DOMContentLoaded', () => {
     // Verifica se estamos na página de Cursos Disponíveis
-    if (document.getElementById('cursosContainer')) {
+    if (document.getElementById('listaTreinamentos')) {
         carregarTreinamentos();
     }
 
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
 async function carregarTreinamentos() {
     try {
         const turmas = await chamarAPI('/treinamentos');
-        const container = document.getElementById('cursosContainer');
+        const container = document.getElementById('listaTreinamentos');
         if (!container) return;
 
         container.innerHTML = ''; // Limpa o spinner de carregamento
@@ -78,7 +78,7 @@ async function carregarTreinamentos() {
         });
     } catch (e) {
         exibirAlerta(e.message, 'danger');
-        const container = document.getElementById('cursosContainer');
+        const container = document.getElementById('listaTreinamentos');
         if (container) container.innerHTML = '<p class="text-center text-danger">Falha ao carregar os cursos.</p>';
     }
 }

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -118,6 +118,9 @@
                 <div class="card mt-4">
                     <div class="card-body p-0">
                         <div class="d-flex justify-content-end p-3">
+                            <button class="btn btn-sm btn-primary me-2" onclick="abrirModalInscricaoAdmin(new URLSearchParams(window.location.search).get('turma'))">
+                                <i class="bi bi-person-plus-fill me-1"></i> Adicionar Participante
+                            </button>
                             <button id="btnExportarInscricoes" class="btn btn-sm btn-outline-secondary me-2">Exportar Inscrições</button>
                             <button id="btnSalvarAlteracoes" class="btn btn-sm btn-success">
                                 <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
- show the **Adicionar Participante** button in the admin inscriptions page
- load trainings using the correct container ID so courses list renders

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6883ad558a488323b5c51e2f81db5613