### PR TITLE
Fix training history page menu

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -589,7 +589,8 @@ document.addEventListener('DOMContentLoaded', function() {
             '/treinamentos/meus-cursos.html',
             '/treinamentos/admin-catalogo.html',
             '/treinamentos/admin-turmas.html',
-            '/treinamentos/admin-inscricoes.html'
+            '/treinamentos/admin-inscricoes.html',
+            '/treinamentos/admin-historico-turmas.html'
         ];
 
         if (!paginasDeExclusao.includes(paginaAtual)) {


### PR DESCRIPTION
## Summary
- hide "Laboratórios e Turmas" and "Logs" links on training history page by adding it to the exclusion list in `app.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6883d79fd3248323a2a5dc61bc27ea93