### PR TITLE
Add active and past training pages

### DIFF
--- a/src/static/js/historico-passado.js
+++ b/src/static/js/historico-passado.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+    verificarAutenticacao();
+    verificarPermissaoAdmin();
+    carregarHistoricoPassado(); // Nome da função alterado para clareza
+});
+
+async function carregarHistoricoPassado() {
+    try {
+        // A rota /treinamentos/historico agora retorna apenas turmas passadas
+        const turmas = await chamarAPI('/treinamentos/historico');
+        const tbody = document.getElementById('turmasTableBody');
+        if (!tbody) return;
+
+        tbody.innerHTML = '';
+        if (turmas.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="5" class="text-center">Nenhum histórico de turmas encerradas encontrado.</td></tr>';
+            return;
+        }
+
+        for (const t of turmas) {
+            const tr = document.createElement('tr');
+            // Botão de Ações simplificado, apenas para ver inscrições
+            const botoesAcoes = `
+                <a class="btn btn-sm btn-outline-info me-1" href="/treinamentos/admin-inscricoes.html?turma=${t.turma_id}" title="Ver Inscrições"><i class="bi bi-people"></i></a>
+            `;
+
+            tr.innerHTML = `
+                <td>${t.turma_id}</td>
+                <td>${escapeHTML(t.treinamento.nome)}</td>
+                <td>${formatarData(t.data_inicio)}</td>
+                <td>${formatarData(t.data_fim)}</td>
+                <td>${botoesAcoes}</td>`;
+            tbody.appendChild(tr);
+        }
+    } catch (e) {
+        exibirAlerta(e.message, 'danger');
+    }
+}

--- a/src/static/js/historico-turmas.js
+++ b/src/static/js/historico-turmas.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 async function carregarHistorico() {
     try {
-        const turmas = await chamarAPI('/treinamentos/historico');
+        const turmas = await chamarAPI('/treinamentos/turmas-ativas');
         const tbody = document.getElementById('turmasTableBody');
         if (!tbody) return;
 

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -33,7 +33,10 @@
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
+                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill me-1"></i> Turmas Ativas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
@@ -61,7 +64,8 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas Ativas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
                     </div>
                 </div>
             </div>

--- a/src/static/treinamentos/admin-historico-passado.html
+++ b/src/static/treinamentos/admin-historico-passado.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gerenciar Turmas de Treinamento</title>
+    <title>Histórico de Turmas Encerradas</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
@@ -30,13 +30,13 @@
                         <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link active" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas</a>
+                        <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas</a>
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill me-1"></i> Turmas Ativas</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
+                        <a class="nav-link active" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
@@ -63,17 +63,16 @@
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
-                        <a class="nav-link active admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas Ativas</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas</a>
+                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas Ativas</a>
+                        <a class="nav-link active admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
                     </div>
                 </div>
             </div>
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Gerenciar Turmas</h2>
-                    <button class="btn btn-primary" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>NOVA TURMA</button>
+                    <h2 class="mb-0">Histórico de Turmas Encerradas</h2>
                 </div>
                 
                 <div id="alertContainer" class="mt-3"></div>
@@ -202,7 +201,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
-    <script src="/js/treinamentos-admin.js"></script>
+    <script src="/js/historico-passado.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const usuario = getUsuarioLogado();

--- a/src/static/treinamentos/admin-historico-turmas.html
+++ b/src/static/treinamentos/admin-historico-turmas.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Histórico de Turmas</title>
+    <title>Turmas Ativas</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
@@ -33,7 +33,10 @@
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link active" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
+                        <a class="nav-link active" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill me-1"></i> Turmas Ativas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
@@ -61,14 +64,15 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas</a>
-                        <a class="nav-link active admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
+                        <a class="nav-link active admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas Ativas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
                     </div>
                 </div>
             </div>
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Histórico de Turmas</h2>
+                    <h2 class="mb-0">Turmas Ativas</h2>
                 </div>
                 
                 <div id="alertContainer" class="mt-3"></div>

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -33,7 +33,10 @@
                         <a class="nav-link active" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
+                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill me-1"></i> Turmas Ativas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
@@ -61,7 +64,8 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas Ativas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
                     </div>
                 </div>
             </div>

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -33,7 +33,10 @@
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
+                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill me-1"></i> Turmas Ativas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
@@ -61,7 +64,8 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas Ativas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
                     </div>
                 </div>
             </div>

--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -33,7 +33,10 @@
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
+                        <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill me-1"></i> Turmas Ativas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Histórico</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
@@ -61,7 +64,8 @@
                         <a class="nav-link active" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas Ativas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Histórico de Turmas</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add route for active classes
- restrict historical classes to past ones
- add page for historical classes and JS loader
- rename history page to active classes and update script
- add menu links for active and historical classes across training pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6883d9a484908323a9d966fddbee40d8