### PR TITLE
Add participant removal feature

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -935,6 +935,23 @@ def avaliar_inscricao(inscricao_id):
         return handle_internal_error(e)
 
 
+@treinamento_bp.route("/treinamentos/inscricoes/<int:inscricao_id>", methods=["DELETE"])
+@admin_required
+def remover_inscricao(inscricao_id):
+    """Remove uma inscrição de uma turma."""
+    inscricao = db.session.get(InscricaoTreinamento, inscricao_id)
+    if not inscricao:
+        return jsonify({"erro": "Inscrição não encontrada"}), 404
+
+    try:
+        db.session.delete(inscricao)
+        db.session.commit()
+        return jsonify({"mensagem": "Inscrição removida com sucesso"}), 200
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
 @treinamento_bp.route("/treinamentos/<int:turma_id>/inscricoes/externo", methods=["POST"])
 @login_required
 def create_inscricao_treinamento_externo(turma_id):

--- a/src/static/js/treinamentos-admin.js
+++ b/src/static/js/treinamentos-admin.js
@@ -46,6 +46,7 @@ async function carregarCatalogo() {
     }
 }
 
+
 // Salva um treinamento (novo ou existente)
 async function salvarTreinamento() {
     const id = document.getElementById('treinamentoId').value;
@@ -386,7 +387,7 @@ async function carregarInscricoes(turmaId) {
         const tbody = document.getElementById('inscricoesTableBody');
         tbody.innerHTML = '';
         if (inscricoes.length === 0) {
-            tbody.innerHTML = '<tr><td colspan="8" class="text-center">Nenhuma inscrição.</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="9" class="text-center">Nenhuma inscrição.</td></tr>';
             return;
         }
 
@@ -401,6 +402,14 @@ async function carregarInscricoes(turmaId) {
                 <td class="text-center">
                     <input class="form-check-input presenca-pratica-check" type="checkbox" ${i.presenca_pratica ? 'checked' : ''}>
                 </td>` : '';
+
+            const acoesHtml = `
+                <td>
+                    <button class="btn btn-sm btn-outline-danger" onclick="confirmarExclusaoParticipante(${i.id}, '${escapeHTML(i.nome)}')">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </td>
+            `;
 
             tr.innerHTML = `
                 <td>${escapeHTML(i.nome)}</td>
@@ -423,11 +432,34 @@ async function carregarInscricoes(turmaId) {
                         <option value="Reprovado" ${statusReprovado}>Reprovado</option>
                     </select>
                 </td>
+                ${acoesHtml}
             `;
             tbody.appendChild(tr);
         }
     } catch (e) {
         exibirAlerta(e.message, 'danger');
+    }
+}
+
+// Função para confirmar e executar a exclusão do participante
+function confirmarExclusaoParticipante(inscricaoId, nome) {
+    if (confirm(`Tem a certeza de que deseja remover o participante "${nome}" da turma?`)) {
+        executarExclusaoParticipante(inscricaoId);
+    }
+}
+
+// Função que chama a API para excluir
+async function executarExclusaoParticipante(inscricaoId) {
+    try {
+        await chamarAPI(`/treinamentos/inscricoes/${inscricaoId}`, 'DELETE');
+        exibirAlerta('Participante removido com sucesso!', 'success');
+
+        const linhaParaRemover = document.querySelector(`#inscricoesTableBody tr[data-id='${inscricaoId}']`);
+        if (linhaParaRemover) {
+            linhaParaRemover.remove();
+        }
+    } catch (e) {
+        exibirAlerta(`Erro ao remover participante: ${e.message}`, 'danger');
     }
 }
 

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -149,6 +149,7 @@
                                         <th style="width: 120px;">Nota Teoria</th>
                                         <th style="width: 120px;">Nota Prática</th>
                                         <th style="width: 150px;">Status</th>
+                                        <th style="width: 80px;">Ações</th>
                                     </tr>
                                 </thead>
                                 <tbody id="inscricoesTableBody"></tbody>


### PR DESCRIPTION
## Summary
- allow admins to remove individual course registrations
- show delete button on enrollment table and handle DELETE via JS
- update admin inscriptions table with an Ações column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6884bffe936083238643061b1d4fc88d