### PR TITLE
Fix numbering in PDF export

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -813,10 +813,10 @@ def exportar_inscricoes(turma_id):
         ]
         
         dados_alunos = []
-        for idx, i in enumerate(inscricoes):
+        for idx, i in enumerate(inscricoes, 1):
             dados_alunos.append(
                 [
-                    str(idx + 1),
+                    str(idx),
                     i.cpf or "",
                     Paragraph(i.nome, style_normal),
                     i.empresa or "", "", "", "", "", ""


### PR DESCRIPTION
## Summary
- fix index numbering in PDF export loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885304005f88323998aa93dfd51d905