### PR TITLE
Improve course list with cards and countdown

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -75,7 +75,7 @@ def listar_turmas_agendadas():
                 "data_fim": turma.data_fim.isoformat() if turma.data_fim else None,
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
-                "instrutor": turma.instrutor.to_dict() if turma.instrutor else None,
+                "instrutor_nome": turma.instrutor.nome if turma.instrutor else "A definir",
             }
         )
     return jsonify(dados)

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -1166,3 +1166,26 @@ input, select, textarea {
 .lista-materiais i {
     margin-right: 8px;
 }
+
+.curso-card-disponivel {
+    border-left: 5px solid var(--primary-color);
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+.curso-card-disponivel:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 16px rgba(0,0,0,0.1);
+}
+.curso-info-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 0.5rem;
+    color: #555;
+}
+.curso-info-item i {
+    color: var(--primary-color);
+}
+.countdown-timer {
+    font-weight: bold;
+    color: var(--danger-color);
+}

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -77,12 +77,7 @@
                 
                 <div id="alertContainer" class="mt-3"></div>
 
-                <div id="listaTreinamentos" class="mt-4">
-                    <div class="text-center">
-                        <div class="spinner-border text-primary" role="status">
-                            <span class="visually-hidden">Carregando...</span>
-                        </div>
-                    </div>
+                <div id="cursos-disponiveis-cards-container" class="row row-cols-1 row-cols-lg-2 g-4 mt-3">
                 </div>
             </main>
         </div>


### PR DESCRIPTION
## Summary
- expose instructor names in `listar_turmas_agendadas`
- rebuild course list page to use responsive card layout
- show countdown timer for enrolment on each card
- add styling for new course cards and countdown

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ff6d0ff883239200b4898715b9b1