### PR TITLE
Remove course summary and keep signup enabled

### DIFF
--- a/src/static/js/treinamentos.js
+++ b/src/static/js/treinamentos.js
@@ -98,14 +98,13 @@ async function carregarTreinamentos() {
 
         turmas.forEach(t => {
             const isInscrito = minhasInscricoesIds.has(t.turma_id);
-            const botaoHtml = `<button class="btn ${isInscrito ? 'btn-success' : 'btn-primary'}" onclick="abrirModalInscricao(${t.turma_id})" ${isInscrito ? 'disabled' : ''}>${isInscrito ? '<i class="bi bi-check-circle-fill"></i> INSCRITO' : 'INSCREVER-SE'}</button>`;
+            const botaoHtml = `<button class="btn ${isInscrito ? 'btn-success' : 'btn-primary'}" onclick="abrirModalInscricao(${t.turma_id})">${isInscrito ? '<i class="bi bi-check-circle-fill"></i> INSCRITO' : 'INSCREVER-SE'}</button>`;
 
             const cardHtml = `
             <div class="col">
                 <div class="card h-100 curso-card-disponivel">
                     <div class="card-body">
                         <h5 class="card-title">${escapeHTML(t.treinamento.nome)}</h5>
-                        <p class="card-text text-muted small">${escapeHTML((t.treinamento.conteudo_programatico || '').substring(0, 150))}...</p>
                         <hr>
                         <div class="curso-info-item">
                             <i class="bi bi-calendar-range"></i>


### PR DESCRIPTION
## Summary
- hide the course summary paragraph when listing available classes
- keep the enrollment button enabled even if the user is already registered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688801c55e188323a3e7a12a6e5ed883