### PR TITLE
Fix countdown display for training registrations

### DIFF
--- a/src/static/js/treinamentos.js
+++ b/src/static/js/treinamentos.js
@@ -152,7 +152,12 @@ function iniciarContadores() {
             timerEl.textContent = 'Data inválida';
             return;
         }
-        const dataFim = new Date(`${fim}T23:59:59`);
+        let dataFim = new Date(fim);
+        if (isNaN(dataFim.getTime())) {
+            timerEl.textContent = 'Data inválida';
+            return;
+        }
+        dataFim.setHours(23, 59, 59, 999);
 
         const intervalId = setInterval(() => {
             const agora = new Date();


### PR DESCRIPTION
## Summary
- prevent invalid dates in countdown timer for course registration deadlines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881183447c8323b525716735315da2