### PR TITLE
Refactor courses view with status-based sections

### DIFF
--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -69,11 +69,70 @@
 
                 <div id="alertContainer" class="mt-3"></div>
                 
-                <div id="listaMeusCursos" class="row mt-4">
+                <h4 class="mt-4">Em Andamento</h4>
+                <hr>
+                <div id="cursos-em-andamento" class="row">
+                    </div>
+
+                <h4 class="mt-5">Em Breve</h4>
+                <hr>
+                <div id="cursos-em-breve" class="row">
+                    </div>
+
+                <div class="accordion mt-5" id="accordionConcluidos">
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="headingConcluidos">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseConcluidos" aria-expanded="false" aria-controls="collapseConcluidos">
+                                <h4>Concluídos</h4>
+                            </button>
+                        </h2>
+                        <div id="collapseConcluidos" class="accordion-collapse collapse" aria-labelledby="headingConcluidos" data-bs-parent="#accordionConcluidos">
+                            <div class="accordion-body">
+                                <div id="cursos-concluidos" class="row">
+                                    </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </main>
         </div>
     </div>
+
+    <div class="modal fade" id="cursoDetalhesModal" tabindex="-1" aria-labelledby="cursoDetalhesModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="cursoDetalhesModalLabel">Detalhes do Treinamento</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <h3 id="modalNomeTreinamento"></h3>
+                    <hr>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <p><strong><i class="bi bi-calendar-range"></i> Período:</strong> <span id="modalPeriodo"></span></p>
+                            <p><strong><i class="bi bi-clock"></i> Horário:</strong> <span id="modalHorario"></span></p>
+                        </div>
+                        <div class="col-md-6">
+                            <p><strong><i class="bi bi-person-workspace"></i> Instrutor:</strong> <span id="modalInstrutor"></span></p>
+                            <p><strong><i class="bi bi-geo-alt-fill"></i> Local:</strong> <span id="modalLocal"></span></p>
+                        </div>
+                    </div>
+                    <hr>
+                    <h6><strong><i class="bi bi-file-text"></i> Conteúdo Programático:</strong></h6>
+                    <p id="modalConteudo" style="white-space: pre-wrap;"></p>
+                    
+                    <h6><strong><i class="bi bi-collection"></i> Materiais e Links:</strong></h6>
+                    <ul id="modalLinks" class="list-group">
+                        </ul>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>


### PR DESCRIPTION
## Summary
- rework `meus-cursos.html` to display courses in sections for *Em Andamento*, *Em Breve*, and *Concluídos*
- add modal for course details
- update `treinamentos.js` to categorize courses by status and populate the detail modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b70f8c448323abe0cf42e8528663