### PR TITLE
Allow secretaria to access admin routes

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -42,7 +42,7 @@ def verificar_autenticacao(req):
 
 def verificar_admin(user: User) -> bool:
     """Verifica se o usuário fornecido tem privilégios de administrador."""
-    return user is not None and user.tipo == 'admin'
+    return user is not None and user.tipo in ['admin', 'secretaria']
 
 
 def login_required(func):


### PR DESCRIPTION
## Summary
- refine permission check so secretary users can be treated as admins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d23818588323807dcfde4fb42bc6