### PR TITLE
Allow updating active training classes

### DIFF
--- a/src/routes/treinamento.py
+++ b/src/routes/treinamento.py
@@ -412,17 +412,15 @@ def atualizar_turma_treinamento(turma_id):
     if not turma:
         return jsonify({"erro": "Turma não encontrada"}), 404
 
-    data_inicio_turma = (
-        turma.data_inicio.date()
-        if isinstance(turma.data_inicio, datetime)
-        else turma.data_inicio
+    data_fim_turma = (
+        turma.data_fim.date()
+        if isinstance(turma.data_fim, datetime)
+        else turma.data_fim
     )
-    if data_inicio_turma <= date.today():
+    if data_fim_turma < date.today():
         return (
             jsonify(
-                {
-                    "erro": "Não é possível modificar uma turma que já iniciou ou foi concluída."
-                }
+                {"erro": "Não é possível modificar uma turma que já foi concluída."}
             ),
             403,
         )

--- a/tests/test_treinamento_routes.py
+++ b/tests/test_treinamento_routes.py
@@ -37,3 +37,30 @@ def test_atualizar_treinamento_nome_duplicado_permitido(client, app):
     tid2 = r2.get_json()['id']
     resp = client.put(f'/api/treinamentos/catalogo/{tid2}', json={'nome': 'A'}, headers=headers)
     assert resp.status_code == 200
+
+
+def test_atualizar_turma_ativa_permitido(client, app):
+    headers = admin_headers(app)
+    r = client.post('/api/treinamentos/catalogo', json={'nome': 'Trein', 'codigo': 'T99'}, headers=headers)
+    treino_id = r.get_json()['id']
+
+    hoje = datetime.utcnow().date()
+    resp_turma = client.post(
+        '/api/treinamentos/turmas',
+        json={
+            'treinamento_id': treino_id,
+            'data_inicio': (hoje - timedelta(days=1)).isoformat(),
+            'data_fim': (hoje + timedelta(days=1)).isoformat(),
+        },
+        headers=headers,
+    )
+    assert resp_turma.status_code == 201
+    turma_id = resp_turma.get_json()['id']
+
+    resp_up = client.put(
+        f'/api/treinamentos/turmas/{turma_id}',
+        json={'local_realizacao': 'Nova'},
+        headers=headers,
+    )
+    assert resp_up.status_code == 200
+    assert resp_up.get_json()['local_realizacao'] == 'Nova'


### PR DESCRIPTION
## Summary
- allow editing active training classes in `atualizar_turma_treinamento`
- test updating an ongoing class works

## Testing
- `flake8 --max-line-length=120 --exit-zero`
- `bandit -r src -ll`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e4ed723083238e0a0bcbd3630908