### PR TITLE
Add admin logs page for trainings

### DIFF
--- a/src/static/treinamentos/admin-historico-passado.html
+++ b/src/static/treinamentos/admin-historico-passado.html
@@ -66,6 +66,7 @@
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
             </div>

--- a/src/static/treinamentos/admin-historico-turmas.html
+++ b/src/static/treinamentos/admin-historico-turmas.html
@@ -66,6 +66,7 @@
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
             </div>

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -66,6 +66,7 @@
                         <a class="nav-link active admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
             </div>

--- a/src/static/treinamentos/admin-logs.html
+++ b/src/static/treinamentos/admin-logs.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Catálogo de Treinamentos</title>
+    <title>Logs de Treinamentos</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
@@ -27,7 +27,7 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link active" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
@@ -57,24 +57,23 @@
     <div class="container-fluid py-4">
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
-                <div class="sidebar rounded shadow-sm">
+                <div class="sidebar rounded shadow-sm" id="sidebar-menu">
                     <h5 class="mb-3">Menu Principal</h5>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link active admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
+                        <a class="nav-link active admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
             </div>
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Gerenciar Catálogo de Treinamentos</h2>
-                    <button class="btn btn-primary" onclick="novoTreinamento()"><i class="bi bi-plus-circle me-2"></i>NOVO TREINAMENTO</button>
+                    <h2 class="mb-0">Logs de Atividades</h2>
                 </div>
                 
                 <div id="alertContainer" class="mt-3"></div>
@@ -85,16 +84,13 @@
                             <table class="table table-striped table-hover">
                                 <thead>
                                     <tr>
-                                        <th>ID</th>
-                                        <th>Nome</th>
-                                        <th>Código</th>
-                                        <th>Tipo</th>
-                                        <th>Carga Horária</th>
-                                        <th>Capacidade</th>
-                                        <th>Ações</th>
+                                        <th>Data/Hora</th>
+                                        <th>Usuário</th>
+                                        <th>Ação</th>
+                                        <th>Detalhes</th>
                                     </tr>
                                 </thead>
-                                <tbody id="catalogoTableBody"></tbody>
+                                <tbody id="logsTableBody"></tbody>
                             </table>
                         </div>
                     </div>
@@ -103,73 +99,8 @@
         </div>
     </div>
 
-    <div class="modal fade" id="treinamentoModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Treinamento</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">
-                    <form id="treinamentoForm">
-                        <input type="hidden" id="treinamentoId">
-                        
-                        <div class="mb-3">
-                            <label class="form-label">Nome</label>
-                            <input type="text" class="form-control" id="nomeTrein" required>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Código</label>
-                            <input type="text" class="form-control" id="codigoTrein" required>
-                        </div>
-                        <div class="mb-3">
-                            <label for="tipoTrein" class="form-label">Tipo</label>
-                            <select class="form-select" id="tipoTrein">
-                                <option value="Inicial">Inicial</option>
-                                <option value="Periódico">Periódico</option>
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Conteúdo Programático</label>
-                            <textarea class="form-control" id="conteudoTrein" rows="4"></textarea>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Carga Horária</label>
-                            <input type="number" class="form-control" id="cargaTrein">
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Capacidade Máxima</label>
-                            <input type="number" class="form-control" id="capacidadeTrein">
-                        </div>
-                        <div class="form-check mb-3">
-                            <input class="form-check-input" type="checkbox" id="temPratica">
-                            <label class="form-check-label ms-2" for="temPratica">Possui parte prática</label>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Links para materiais (um por linha)</label>
-                            <textarea class="form-control" id="linksTrein" rows="3"></textarea>
-                        </div>
-
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button id="btnSalvarTreinamento" type="submit" form="treinamentoForm" class="btn btn-primary">Salvar</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
-    <script src="/js/treinamentos-admin.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const usuario = getUsuarioLogado();
-            if (usuario) {
-                document.getElementById('userName').textContent = usuario.nome;
-            }
-        });
-    </script>
+    <script src="/js/treinamentos-logs.js"></script>
 </body>
 </html>

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -66,6 +66,7 @@
                         <a class="nav-link active admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
             </div>

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -66,6 +66,7 @@
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
             </div>

--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -66,6 +66,7 @@
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                         </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add `admin-logs.html` for viewing audit logs of trainings
- expose Logs entry in the sidebar menu of every trainings page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889335211688323b966a549323b58b5