### PR TITLE
Add training logs display script

### DIFF
--- a/src/static/js/treinamentos-logs.js
+++ b/src/static/js/treinamentos-logs.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+    verificarAutenticacao();
+    verificarPermissaoAdmin();
+    carregarLogs();
+});
+
+async function carregarLogs() {
+    const tbody = document.getElementById('logsTableBody');
+    tbody.innerHTML = '<tr><td colspan="4" class="text-center">Carregando...</td></tr>';
+
+    try {
+        const logs = await chamarAPI('/treinamentos/logs');
+        
+        if (logs.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="4" class="text-center">Nenhum log encontrado.</td></tr>';
+            return;
+        }
+
+        tbody.innerHTML = ''; // Limpa a tabela
+        logs.forEach(log => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${formatarData(log.timestamp)}</td>
+                <td>${escapeHTML(log.usuario)}</td>
+                <td><span class="badge bg-secondary">${escapeHTML(log.acao)}</span></td>
+                <td>${escapeHTML(log.info)}</td>
+            `;
+            tbody.appendChild(tr);
+        });
+    } catch (e) {
+        tbody.innerHTML = `<tr><td colspan="4" class="text-center text-danger">Erro ao carregar logs: ${e.message}</td></tr>`;
+    }
+}


### PR DESCRIPTION
## Summary
- add JS to fetch and render training logs

## Testing
- `pytest -q`
- `flake8 --max-line-length=120 --exit-zero`
- `bandit -r src -ll`


------
https://chatgpt.com/codex/tasks/task_e_68893592652483239a8acd993bfc27a7