### PR TITLE
Fix login script loading

### DIFF
--- a/src/static/admin-login.html
+++ b/src/static/admin-login.html
@@ -55,58 +55,7 @@
     </div>
     
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', async function() {
-            let siteKey = '';
-            try {
-                const resp = await fetch('/api/recaptcha/site-key');
-                const data = await resp.json();
-                siteKey = data.site_key || '';
-                if (siteKey) {
-                    const s = document.createElement('script');
-                    s.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
-                    document.head.appendChild(s);
-                }
-            } catch (e) {
-                console.error('Erro ao carregar site key:', e);
-            }
-
-            const loginForm = document.getElementById('loginForm');
-            if (loginForm) {
-                loginForm.addEventListener('submit', async function(e) {
-                    e.preventDefault();
-                    const btn = document.getElementById('btnLogin');
-                    btn.disabled = true;
-                    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> A ENTRAR...';
-
-                    const email = document.getElementById('email').value;
-                    const senha = document.getElementById('senha').value;
-                    let token = '';
-
-                    if (siteKey && window.grecaptcha) {
-                        try {
-                            token = await new Promise((resolve, reject) => {
-                                grecaptcha.ready(() => {
-                                    grecaptcha.execute(siteKey, { action: 'login' }).then(resolve).catch(reject);
-                                });
-                            });
-                        } catch (err) {
-                            console.error('Erro ao obter token reCAPTCHA:', err);
-                        }
-                    }
-
-                    try {
-                        await realizarLogin(email, senha, token);
-                    } catch (error) {
-                        exibirAlerta(error.message, 'danger');
-                        btn.disabled = false;
-                        btn.innerHTML = 'ENTRAR';
-                    }
-                });
-            }
-        });
-    </script>
+    <script src="/js/app.js" defer></script>
     <div aria-live="polite" aria-atomic="true" class="position-relative">
     <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
     </div>

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -19,6 +19,64 @@ function sanitizeHTML(html) {
     return window.DOMPurify ? DOMPurify.sanitize(html) : html;
 }
 
+// ----- Inicialização da página de login -----
+document.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('loginForm')) {
+        inicializarLogicaLogin();
+    }
+});
+
+async function inicializarLogicaLogin() {
+    let siteKey = '';
+    try {
+        const resp = await fetch('/api/recaptcha/site-key');
+        const data = await resp.json();
+        siteKey = data.site_key || '';
+        if (siteKey) {
+            const s = document.createElement('script');
+            s.src = `https://www.google.com/recaptcha/api.js?render=${siteKey}`;
+            document.head.appendChild(s);
+        }
+    } catch (e) {
+        console.error('Erro ao carregar site key do reCAPTCHA:', e);
+    }
+
+    const loginForm = document.getElementById('loginForm');
+    if (!loginForm) return;
+
+    loginForm.addEventListener('submit', async function(e) {
+        e.preventDefault();
+        const btn = document.getElementById('btnLogin');
+
+        await executarAcaoComFeedback(btn, async () => {
+            const email = document.getElementById('email').value;
+            const senha = document.getElementById('senha').value;
+            let token = '';
+
+            if (siteKey && window.grecaptcha) {
+                try {
+                    token = await new Promise((resolve, reject) => {
+                        grecaptcha.ready(() => {
+                            grecaptcha.execute(siteKey, { action: 'login' })
+                                .then(resolve)
+                                .catch(reject);
+                        });
+                    });
+                } catch (err) {
+                    console.error('Erro ao obter token reCAPTCHA:', err);
+                }
+            }
+
+            try {
+                await realizarLogin(email, senha, token);
+            } catch (error) {
+                exibirAlerta(error.message, 'danger');
+                // o estado do botão é restaurado por executarAcaoComFeedback
+            }
+        });
+    });
+}
+
 // Funções de autenticação
 /**
  * Realiza o login do usuário


### PR DESCRIPTION
## Summary
- load admin login logic only after DOM ready
- add login page helper to `app.js`
- defer `app.js` on login page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a0e425d2c8323b2ec475183de8728