### PR TITLE
Add CPF validation in backend and training form

### DIFF
--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -24,6 +24,25 @@ from src.auth import (
     admin_required,
 )
 
+
+def is_cpf_valid(cpf: str) -> bool:
+    """Valida um CPF brasileiro."""
+    cpf = ''.join(re.findall(r'\d', str(cpf)))
+    if not cpf or len(cpf) != 11 or cpf == cpf[0] * 11:
+        return False
+
+    soma = sum(int(cpf[i]) * (10 - i) for i in range(9))
+    d1 = (soma * 10 % 11) % 10
+    if d1 != int(cpf[9]):
+        return False
+
+    soma = sum(int(cpf[i]) * (11 - i) for i in range(10))
+    d2 = (soma * 10 % 11) % 10
+    if d2 != int(cpf[10]):
+        return False
+
+    return True
+
 user_bp = Blueprint("user", __name__)
 
 # chaves do Google reCAPTCHA
@@ -272,8 +291,10 @@ def atualizar_usuario(id):
         usuario.email = data["email"]
 
     # Novos campos opcionais
-    if "cpf" in data:
-        usuario.cpf = data["cpf"]
+    if "cpf" in data and data["cpf"]:
+        if not is_cpf_valid(data["cpf"]):
+            return jsonify({"erro": "CPF inválido"}), 400
+        usuario.cpf = ''.join(re.findall(r'\d', str(data["cpf"])))
     if "empresa" in data:
         usuario.empresa = data["empresa"]
     if "data_nascimento" in data and data["data_nascimento"]:

--- a/src/static/js/treinamentos.js
+++ b/src/static/js/treinamentos.js
@@ -7,6 +7,51 @@ let contadoresIntervals = [];
 let cacheMeusCursos = []; // Cache para os dados dos cursos do usuário
 
 /**
+ * Aplica a máscara de CPF (nnn.nnn.nnn-nn) a um campo de input.
+ * @param {HTMLInputElement} input - O elemento do campo de CPF.
+ */
+function mascaraCpf(input) {
+    let value = input.value.replace(/\D/g, '');
+    value = value.replace(/(\d{3})(\d)/, '$1.$2');
+    value = value.replace(/(\d{3})(\d)/, '$1.$2');
+    value = value.replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+    input.value = value;
+}
+
+/**
+ * Valida um CPF e atualiza a classe do input para feedback visual.
+ * @param {HTMLInputElement} input - O elemento do campo de CPF.
+ */
+function validarCPF(input) {
+    let cpf = input.value.replace(/\D/g, '');
+    if (cpf.length !== 11 || /^(\d)\1+$/.test(cpf)) {
+        input.classList.remove('is-valid');
+        input.classList.add('is-invalid');
+        return;
+    }
+    let soma = 0, resto;
+    for (let i = 1; i <= 9; i++) soma += parseInt(cpf.substring(i - 1, i)) * (11 - i);
+    resto = (soma * 10) % 11;
+    if (resto == 10 || resto == 11) resto = 0;
+    if (resto != parseInt(cpf.substring(9, 10))) {
+        input.classList.remove('is-valid');
+        input.classList.add('is-invalid');
+        return;
+    }
+    soma = 0;
+    for (let i = 1; i <= 10; i++) soma += parseInt(cpf.substring(i - 1, i)) * (12 - i);
+    resto = (soma * 10) % 11;
+    if (resto == 10 || resto == 11) resto = 0;
+    if (resto != parseInt(cpf.substring(10, 11))) {
+        input.classList.remove('is-valid');
+        input.classList.add('is-invalid');
+        return;
+    }
+    input.classList.remove('is-invalid');
+    input.classList.add('is-valid');
+}
+
+/**
  * Listener que é executado quando o conteúdo da página termina de carregar.
  */
 document.addEventListener('DOMContentLoaded', () => {
@@ -69,6 +114,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const modalForm = new bootstrap.Modal(modalFormEl);
             modalForm.show();
+        });
+    }
+
+    // Listener para campo de CPF
+    const cpfInput = document.getElementById('cpf');
+    if (cpfInput) {
+        cpfInput.addEventListener('input', () => {
+            mascaraCpf(cpfInput);
+            if (cpfInput.value.length === 14) {
+                validarCPF(cpfInput);
+            } else {
+                cpfInput.classList.remove('is-valid', 'is-invalid');
+            }
         });
     }
 });


### PR DESCRIPTION
## Summary
- validate CPF numbers in user update route
- add CPF masking/validation on training registration

## Testing
- `flake8 --max-line-length=120 --exit-zero`
- `bandit -r src -ll`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2498d0708323a3071c1fbf98dd44