### PR TITLE
Normalize user fields to uppercase

### DIFF
--- a/src/models/user.py
+++ b/src/models/user.py
@@ -22,7 +22,7 @@ class User(db.Model):
     __tablename__ = 'usuarios'
     
     id = db.Column(db.Integer, primary_key=True)
-    nome = db.Column(db.String(100), nullable=False)
+    _nome = db.Column("nome", db.String(100), nullable=False)
     username = db.Column(db.String(100), unique=True, nullable=False)
     email = db.Column(db.String(100), unique=True, nullable=False)
     senha_hash = db.Column(db.String(256), nullable=False)
@@ -32,12 +32,28 @@ class User(db.Model):
     # Novos campos opcionais
     cpf = db.Column(db.String(20), nullable=True)
     data_nascimento = db.Column(db.Date, nullable=True)
-    empresa = db.Column(db.String(150), nullable=True)
+    _empresa = db.Column("empresa", db.String(150), nullable=True)
     data_criacao = db.Column(db.DateTime, default=datetime.utcnow)
     data_atualizacao = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     
     # Relacionamento com agendamentos
     agendamentos = db.relationship('Agendamento', backref='usuario', lazy=True)
+
+    @property
+    def nome(self):
+        return self._nome
+
+    @nome.setter
+    def nome(self, value):
+        self._nome = value.upper() if value else None
+
+    @property
+    def empresa(self):
+        return self._empresa
+
+    @empresa.setter
+    def empresa(self, value):
+        self._empresa = value.upper() if value else None
     
     def __init__(self, nome, email, senha, tipo='comum', username=None):
         """

--- a/src/routes/treinamentos/treinamento.py
+++ b/src/routes/treinamentos/treinamento.py
@@ -1260,7 +1260,7 @@ def listar_logs_treinamentos():
     """Lista os logs de auditoria relacionados a treinamentos e inscrições."""
     try:
         logs = (
-            db.session.query(AuditLog, User.nome)
+            db.session.query(AuditLog, User._nome)
             .join(User, User.id == AuditLog.user_id)
             .filter(
                 AuditLog.entity.in_([


### PR DESCRIPTION
## Summary
- store `nome` and `empresa` in uppercase using property setters
- adjust training log query to reference renamed private name column

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689206660f7c832380d6e71e8a92e9c1