### PR TITLE
feat: enforce secure cookies for auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Todas as variáveis disponíveis estão listadas em `.env.example`.
    administrador será criado automaticamente apenas se `ADMIN_EMAIL` e
    `ADMIN_PASSWORD` estiverem definidos.
 
+   As rotas de autenticação utilizam cookies com `Secure` e `SameSite=Strict`.
+   Em produção, a aplicação deve ser servida via **HTTPS** para que esses
+   cookies sejam aceitos pelos navegadores. Para testes locais sem HTTPS, é
+   possível definir `COOKIE_SECURE=False` e `COOKIE_SAMESITE=Lax` no arquivo
+   `.env`.
+
 6. As rotas de autenticação e cadastro possuem uma limitação de
    requisições por minuto para evitar abusos de login ou criação de contas.
 

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -466,17 +466,21 @@ def login():
             refresh_token=refresh_token,
             usuario=usuario.to_dict(),
         )
+        secure_cookie = current_app.config.get("COOKIE_SECURE", True)
+        samesite_cookie = current_app.config.get("COOKIE_SAMESITE", "Strict")
         resp.set_cookie(
             "access_token",
             access_token,
             httponly=True,
-            samesite="Lax",
+            secure=secure_cookie,
+            samesite=samesite_cookie,
         )
         resp.set_cookie(
             "refresh_token",
             refresh_token,
             httponly=True,
-            samesite="Lax",
+            secure=secure_cookie,
+            samesite=samesite_cookie,
         )
         return resp, 200
     except SQLAlchemyError as e:
@@ -499,11 +503,14 @@ def refresh_token():
         return jsonify({"erro": "Refresh token inválido"}), 401
     novo_token = gerar_token_acesso(usuario)
     resp = jsonify({"token": novo_token})
+    secure_cookie = current_app.config.get("COOKIE_SECURE", True)
+    samesite_cookie = current_app.config.get("COOKIE_SAMESITE", "Strict")
     resp.set_cookie(
         "access_token",
         novo_token,
         httponly=True,
-        samesite="Lax",
+        secure=secure_cookie,
+        samesite=samesite_cookie,
     )
     return resp
 
@@ -545,7 +552,21 @@ def logout():
     if not token and not refresh:
         return jsonify({"erro": "Token obrigatório"}), 400
 
+    secure_cookie = current_app.config.get("COOKIE_SECURE", True)
+    samesite_cookie = current_app.config.get("COOKIE_SAMESITE", "Strict")
     resp = jsonify({"mensagem": "Logout realizado"})
-    resp.set_cookie("access_token", "", expires=0)
-    resp.set_cookie("refresh_token", "", expires=0)
+    resp.set_cookie(
+        "access_token",
+        "",
+        expires=0,
+        secure=secure_cookie,
+        samesite=samesite_cookie,
+    )
+    resp.set_cookie(
+        "refresh_token",
+        "",
+        expires=0,
+        secure=secure_cookie,
+        samesite=samesite_cookie,
+    )
     return resp


### PR DESCRIPTION
## Summary
- secure cookies for login, refresh, logout routes using configurable flags
- document need for HTTPS in production and development overrides

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896082c9f4483239d416c0dd7aef34f