### PR TITLE
chore: add dependency auditing and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,37 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .
-        pip install pytest flake8 bandit
+        pip install pytest flake8 bandit pip-audit
 
     - name: Lint with flake8
       run: flake8 --max-line-length=120 --exit-zero
 
     - name: Security scan with bandit
       run: bandit -r src -ll
+
+    - name: Audit dependencies with pip-audit
+      run: |
+        pip-audit -f json --progress-spinner off > audit.json
+        python - <<'PY'
+import json, sys
+data = json.load(open('audit.json'))
+def is_high(v):
+    for s in v.get('severity', []):
+        score = s.get('score')
+        if score is not None:
+            try:
+                if float(score) >= 7:
+                    return True
+            except (ValueError, TypeError):
+                pass
+        level = s.get('severity')
+        if isinstance(level, str) and level.upper() in {'HIGH', 'CRITICAL'}:
+            return True
+    return False
+if any(is_high(v) for d in data.get('dependencies', []) for v in d.get('vulns', [])):
+    print('High severity vulnerabilities found', file=sys.stderr)
+    sys.exit(1)
+PY
 
     - name: Run tests
       run: pytest

--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ Actions. O workflow `.github/workflows/ci.yml` instala as dependências do
 projeto e executa o `flake8`, o `bandit` e a suíte de testes com `pytest` a
 cada push ou pull request para a branch `main`.
 
+## Auditoria de dependências
+
+Para verificar vulnerabilidades nas dependências localmente, utilize o
+[`pip-audit`](https://pypi.org/project/pip-audit/):
+
+```bash
+pip install pip-audit
+pip-audit --progress-spinner off
+```
+
+O comando acima analisa o ambiente atual e retorna código de saída diferente de
+zero se encontrar vulnerabilidades de severidade alta ou crítica.
+
 
 ## Migrações automáticas
 


### PR DESCRIPTION
## Summary
- configure Dependabot to check pip and Docker weekly
- audit dependencies in CI with pip-audit and fail on high severity issues
- document how to run pip-audit locally

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689615c012d0832395de2e72352ee7d2