### PR TITLE
Add Pydantic schemas for user endpoints

### DIFF
--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -2,10 +2,12 @@ from .sala import SalaCreateSchema, SalaUpdateSchema
 from .instrutor import InstrutorCreateSchema, InstrutorUpdateSchema
 from .ocupacao import OcupacaoCreateSchema, OcupacaoUpdateSchema
 from .rateio import RateioConfigCreateSchema, LancamentoRateioSchema
+from .user import UserCreateSchema, UserUpdateSchema
 
 __all__ = [
     'SalaCreateSchema', 'SalaUpdateSchema',
     'InstrutorCreateSchema', 'InstrutorUpdateSchema',
     'OcupacaoCreateSchema', 'OcupacaoUpdateSchema',
     'RateioConfigCreateSchema', 'LancamentoRateioSchema',
+    'UserCreateSchema', 'UserUpdateSchema',
 ]

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -1,0 +1,100 @@
+"""Pydantic models for user-related operations."""
+
+from datetime import date
+import re
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
+
+from src.services.user_service import PASSWORD_REGEX
+
+
+def _is_cpf_valid(cpf: str) -> bool:
+    cpf = ''.join(re.findall(r"\d", str(cpf)))
+    if not cpf or len(cpf) != 11 or cpf == cpf[0] * 11:
+        return False
+    soma = sum(int(cpf[i]) * (10 - i) for i in range(9))
+    d1 = (soma * 10 % 11) % 10
+    if d1 != int(cpf[9]):
+        return False
+    soma = sum(int(cpf[i]) * (11 - i) for i in range(10))
+    d2 = (soma * 10 % 11) % 10
+    return d2 == int(cpf[10])
+
+
+class UserCreateSchema(BaseModel):
+    nome: str
+    email: EmailStr
+    senha: str
+    confirmar_senha: Optional[str] = Field(default=None, alias="confirmarSenha")
+    username: Optional[str] = None
+
+    @field_validator("senha")
+    @classmethod
+    def validar_senha(cls, v: str) -> str:
+        if not PASSWORD_REGEX.match(v):
+            raise ValueError(
+                "Senha deve ter ao menos 8 caracteres, incluindo letra maiúscula, letra minúscula, número e caractere especial"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def senhas_coincidem(self):
+        if self.confirmar_senha is not None and self.senha != self.confirmar_senha:
+            raise ValueError("As senhas não coincidem")
+        return self
+
+    class Config:
+        populate_by_name = True
+
+
+class UserUpdateSchema(BaseModel):
+    nome: Optional[str] = None
+    email: Optional[EmailStr] = None
+    cpf: Optional[str] = None
+    empresa: Optional[str] = None
+    data_nascimento: Optional[date] = None
+    tipo: Optional[str] = None
+    senha: Optional[str] = None
+    senha_atual: Optional[str] = Field(default=None, alias="senha_atual")
+
+    @field_validator("cpf")
+    @classmethod
+    def validar_cpf(cls, v: str) -> str:
+        if v:
+            digits = ''.join(filter(str.isdigit, v))
+            if not _is_cpf_valid(digits):
+                raise ValueError("CPF inválido")
+            return digits
+        return v
+
+    @field_validator("senha")
+    @classmethod
+    def validar_nova_senha(cls, v: str) -> str:
+        if v and not PASSWORD_REGEX.match(v):
+            raise ValueError(
+                "Senha deve ter ao menos 8 caracteres, incluindo letra maiúscula, letra minúscula, número e caractere especial"
+            )
+        return v
+
+    @field_validator("tipo")
+    @classmethod
+    def validar_tipo(cls, v: str) -> str:
+        if v and v not in {"comum", "admin", "secretaria"}:
+            raise ValueError("Tipo de usuário inválido")
+        return v
+
+    @field_validator("data_nascimento", mode="before")
+    @classmethod
+    def parse_data(cls, v):
+        if v in (None, ""):
+            return None
+        if isinstance(v, date):
+            return v
+        try:
+            return date.fromisoformat(v)
+        except (ValueError, TypeError):
+            raise ValueError("Formato de data de nascimento inválido. Use YYYY-MM-DD")
+
+    class Config:
+        populate_by_name = True

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -23,34 +23,13 @@ def criar_usuario(dados: Dict[str, Any]) -> Tuple[Optional[User], Optional[Tuple
         opcionalmente um tupla ``(mensagem, status)`` quando houver erro de
         validação.
     """
-    nome = dados.get("nome", "").strip()
-    email = dados.get("email", "").strip()
+    nome = dados.get("nome")
+    email = dados.get("email")
     senha = dados.get("senha")
-    confirmar = dados.get("confirmarSenha")
     username = dados.get("username") or (email.split("@")[0] if email else "")
 
-    if not all([nome, email, senha]):
-        return None, ({"erro": "Dados incompletos"}, 400)
-
-    if "confirmarSenha" in dados and not confirmar:
-        return None, ({"erro": "Dados incompletos"}, 400)
-
-    if confirmar is not None and senha != confirmar:
-        return None, ({"erro": "As senhas não coincidem"}, 400)
-
     if User.query.filter_by(email=email).first():
-        return None, ({"erro": "Este e-mail já está registado"}, 400)
-
-    if not PASSWORD_REGEX.match(senha):
-        return (
-            None,
-            (
-                {
-                    "erro": "Senha deve ter ao menos 8 caracteres, incluindo letra maiúscula, letra minúscula, número e caractere especial"
-                },
-                400,
-            ),
-        )
+        return None, ({"erro": "Email já cadastrado"}, 400)
 
     try:
         novo_usuario = User(


### PR DESCRIPTION
## Summary
- create `UserCreateSchema` and `UserUpdateSchema` for user payload validation
- leverage schemas in user routes and simplify service logic
- update tests to build requests using new schemas

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689640d59c6883238d2449660a088e3b