### PR TITLE
Remove locale initialization in training routes

### DIFF
--- a/src/routes/treinamentos/treinamento.py
+++ b/src/routes/treinamentos/treinamento.py
@@ -45,22 +45,6 @@ from reportlab.platypus import (
 )
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib import colors
-import locale
-import logging
-
-# Configura o locale para o formato de data em português
-for loc in ("pt_BR.UTF-8", "pt_BR.utf8", "pt_BR"):
-    try:
-        locale.setlocale(locale.LC_TIME, loc)
-        break
-    except locale.Error:
-        continue
-else:
-    locale.setlocale(locale.LC_TIME, "C")  # Fallback para um locale seguro
-    logging.warning(
-        "Locale 'pt_BR' not available. Falling back to 'C'."
-    )
-
 
 treinamento_bp = Blueprint("treinamento", __name__)
 


### PR DESCRIPTION
## Summary
- remove unnecessary locale setup in training routes that caused missing locale warnings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896a4507d488323b3091162f5627141