### PR TITLE
fix: install build tools for poetry build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN pip install poetry
+RUN apt-get update && \
+    apt-get install -y build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install poetry
 
 COPY poetry.lock pyproject.toml ./
 


### PR DESCRIPTION
## Summary
- install build-essential in builder image to supply the C compiler for native dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a7f42d288323a9193360c67603bf