### PR TITLE
chore: pin python to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS builder
+FROM python:3.12-slim AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -18,7 +18,7 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry lock --no-interaction
 RUN poetry install --no-root --without dev
 
-FROM python:3.13-slim AS runtime
+FROM python:3.12-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/poetry.lock
+++ b/poetry.lock
@@ -2072,5 +2072,5 @@ email = ["email-validator"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.11,<4"
-content-hash = "01c8a29a4a7cea2d83484fd53d91323f21ab06ab6d0769a4775077fac490153e"
+python-versions = ">=3.11,<3.13"
+content-hash = "cb0ab37bdb7ac6161d20b4dbd069e256184265507b50166bb1d256aa532963c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Codex",email = "codex@openai.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.11,<4"
+requires-python = ">=3.11,<3.13"
 dependencies = [
     "flask (==3.1.1)",
     "flask-sqlalchemy (==3.1.1)",
@@ -41,7 +41,7 @@ readme = "README.md"
 packages = [{ include = "src" }]
 
 [tool.poetry.dependencies]
-python = ">=3.11,<4"
+python = ">=3.11,<3.13"
 flask = "3.1.1"
 flask-sqlalchemy = "3.1.1"
 sqlalchemy = "2.0.23"


### PR DESCRIPTION
## Summary
- pin builder and runtime images to Python 3.12
- restrict supported Python version to <3.13

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896abeb06a0832398dad76de5e2d8b2