### PR TITLE
chore: add eslint, pre-commit and sonarcloud config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["airbnb-base"],
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "ignorePatterns": ["dist/", "build/"],
+  "rules": {}
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,8 @@ PY
 
     - name: Run tests
       run: pytest
+
+    - name: SonarCloud Scan
+      uses: SonarSource/sonarcloud-github-action@v2
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+      - id: bandit
+        args: ["-r", "src"]
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+      - id: eslint
+        files: '\\.(js|jsx|ts|tsx)$'
+        additional_dependencies:
+          - eslint
+          - eslint-config-airbnb-base
+          - eslint-plugin-import

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=conecta-senai
+sonar.organization=your-organization
+sonar.host.url=https://sonarcloud.io
+sonar.sources=src
+sonar.tests=tests
+sonar.python.version=3.12


### PR DESCRIPTION
## Summary
- add base eslint config
- add flake8, bandit and eslint pre-commit hooks
- run SonarCloud analysis in CI

## Testing
- `pre-commit run --files .eslintrc.json .pre-commit-config.yaml .github/workflows/ci.yml sonar-project.properties`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896b29205088323b50ee948c1b19b0a