### PR TITLE
Normalize static text casing and remove forced uppercase

### DIFF
--- a/src/static/admin/login.html
+++ b/src/static/admin/login.html
@@ -42,7 +42,7 @@
                             <a href="#" class="text-muted small">Esqueceu-se da senha?</a>
                         </div>
                         <div class="d-grid">
-                            <button class="btn btn-primary btn-lg" type="submit" id="btnLogin">ENTRAR</button>
+                        <button class="btn btn-primary btn-lg" type="submit" id="btnLogin">Entrar</button>
                         </div>
                     </form>
                     <div class="text-center mt-4">
@@ -77,7 +77,7 @@
                     e.preventDefault();
                     const btn = document.getElementById('btnLogin');
                     btn.disabled = true;
-                    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> A ENTRAR...';
+                    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Entrando...';
 
                     const email = document.getElementById('email').value;
                     const senha = document.getElementById('senha').value;
@@ -100,7 +100,7 @@
                     } catch (error) {
                         exibirAlerta(error.message, 'danger');
                         btn.disabled = false;
-                        btn.innerHTML = 'ENTRAR';
+                        btn.innerHTML = 'Entrar';
                     }
                 });
             }

--- a/src/static/admin/usuarios.html
+++ b/src/static/admin/usuarios.html
@@ -69,12 +69,12 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <div class="d-flex justify-content-between align-items-center mb-4">
-                    <h2 class="mb-0">Gerenciamento de Usuários</h2>
-                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#usuarioModal">
-                        <i class="bi bi-person-plus me-2"></i>NOVO USUÁRIO
-                    </button>
-                </div>
+                    <div class="d-flex justify-content-between align-items-center mb-4">
+                        <h2 class="mb-0">Gerenciamento de Usuários</h2>
+                        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#usuarioModal">
+                            <i class="bi bi-person-plus me-2"></i>Novo Usuário
+                        </button>
+                    </div>
 
                 <div class="card mb-4">
                     <div class="card-header">
@@ -86,7 +86,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE USUÁRIOS</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Usuários</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -67,7 +67,7 @@ body {
 
 h1, .h1, h2, .h2 {
   font-weight: 700;
-  text-transform: uppercase;
+  text-transform: none;
   letter-spacing: 0.5px;
 }
 
@@ -173,12 +173,12 @@ small, .small {
   background-color: #fff;
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
   font-weight: 700;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .card-title {
   font-weight: 700;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .form-label {
@@ -198,7 +198,7 @@ small, .small {
   background-image: none;
   background-color: var(--primary-color);
   border-color: var(--primary-color);
-  text-transform: uppercase;
+  text-transform: none;
   font-weight: 600;
 }
 
@@ -219,7 +219,7 @@ small, .small {
 }
 
 .table > thead {
-  text-transform: uppercase;
+  text-transform: none;
   font-weight: 700;
   font-size: 0.8rem;
   color: #333;
@@ -861,7 +861,7 @@ input, select, textarea {
   background-color: transparent;
   border-bottom: 1px solid #f0f0f0;
   font-weight: 700;
-  text-transform: uppercase;
+  text-transform: none;
   color: #333;
 }
 
@@ -1064,7 +1064,7 @@ input, select, textarea {
 .turno-card { border: 1px solid #e9ecef; margin-bottom: 1.5rem; }
 .turno-card .card-header {
     background-color: #f8f9fa; font-weight: 700;
-    text-transform: uppercase; font-size: 0.9rem;
+    text-transform: none; font-size: 0.9rem;
     color: #00539F;
 }
 .agendamento-item {

--- a/src/static/laboratorios/calendario.html
+++ b/src/static/laboratorios/calendario.html
@@ -65,7 +65,7 @@
                 </div>
                 
                 <div id="agenda-content" class="d-none">
-                    <h2 class="text-uppercase mb-4">Agenda Diária de Laboratórios</h2>
+                    <h2 class="mb-4" style="text-transform: none;">Agenda Diária de Laboratórios</h2>
                     <div class="card mb-4"><div class="card-body">
                         <h6 class="card-subtitle mb-2 text-muted">Selecione um Laboratório</h6>
                         <div id="seletor-laboratorios" class="d-flex flex-wrap gap-2"></div>

--- a/src/static/laboratorios/dashboard.html
+++ b/src/static/laboratorios/dashboard.html
@@ -102,30 +102,30 @@
                 </div>
 
                 <div class="row mb-4">
-                    <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
-                        <div class="card-body"><div class="d-flex justify-content-between align-items-center">
-                            <div><h6 class="kpi-title text-uppercase">Laboratórios Ativos</h6><h2 class="kpi-number" id="totalLabsAtivos">-</h2></div>
-                            <i class="bi bi-display kpi-icon"></i>
-                        </div></div>
-                    </div></div>
-                    <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
-                        <div class="card-body"><div class="d-flex justify-content-between align-items-center">
-                            <div><h6 class="kpi-title text-uppercase">Turmas Ativas</h6><h2 class="kpi-number" id="totalTurmasAtivas">-</h2></div>
-                            <i class="bi bi-people kpi-icon"></i>
-                        </div></div>
-                    </div></div>
-                    <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
-                        <div class="card-body"><div class="d-flex justify-content-between align-items-center">
-                            <div><h6 class="kpi-title text-uppercase">Agendamentos Hoje</h6><h2 class="kpi-number" id="agendamentosHoje">-</h2></div>
-                            <i class="bi bi-calendar-check kpi-icon"></i>
-                        </div></div>
-                    </div></div>
-                    <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
-                        <div class="card-body"><div class="d-flex justify-content-between align-items-center">
-                            <div><h6 class="kpi-title text-uppercase">Esta Semana</h6><h2 class="kpi-number" id="agendamentosSemana">-</h2></div>
-                            <i class="bi bi-calendar-week kpi-icon"></i>
-                        </div></div>
-                    </div></div>
+            <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
+                <div class="card-body"><div class="d-flex justify-content-between align-items-center">
+                    <div><h6 class="kpi-title" style="text-transform: none;">Laboratórios Ativos</h6><h2 class="kpi-number" id="totalLabsAtivos">-</h2></div>
+                    <i class="bi bi-display kpi-icon"></i>
+                </div></div>
+            </div></div>
+            <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
+                <div class="card-body"><div class="d-flex justify-content-between align-items-center">
+                    <div><h6 class="kpi-title" style="text-transform: none;">Turmas Ativas</h6><h2 class="kpi-number" id="totalTurmasAtivas">-</h2></div>
+                    <i class="bi bi-people kpi-icon"></i>
+                </div></div>
+            </div></div>
+            <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
+                <div class="card-body"><div class="d-flex justify-content-between align-items-center">
+                    <div><h6 class="kpi-title" style="text-transform: none;">Agendamentos Hoje</h6><h2 class="kpi-number" id="agendamentosHoje">-</h2></div>
+                    <i class="bi bi-calendar-check kpi-icon"></i>
+                </div></div>
+            </div></div>
+            <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
+                <div class="card-body"><div class="d-flex justify-content-between align-items-center">
+                    <div><h6 class="kpi-title" style="text-transform: none;">Esta Semana</h6><h2 class="kpi-number" id="agendamentosSemana">-</h2></div>
+                    <i class="bi bi-calendar-week kpi-icon"></i>
+                </div></div>
+            </div></div>
                 </div>
 
                 <div class="row">

--- a/src/static/laboratorios/logs.html
+++ b/src/static/laboratorios/logs.html
@@ -78,7 +78,7 @@
         </div>
         <main class="col-lg-9 col-md-12">
             <div class="page-header">
-                <h2 class="mb-0">LOGS DE AGENDAMENTOS</h2>
+                <h2 class="mb-0">Logs de Agendamentos</h2>
                 <button id="btnExportarCsv" class="btn btn-outline-primary"><i class="bi bi-download me-1"></i>Exportar CSV</button>
             </div>
 
@@ -117,20 +117,20 @@
 
             <div class="card">
                 <div class="card-header">
-                    <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>HISTÓRICO DE LOGS</h5>
+                    <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Histórico de Logs</h5>
                 </div>
                 <div class="card-body p-0">
                     <div class="table-responsive">
                         <table class="table table-hover mb-0" id="tabelaLogs">
                             <thead class="table-light">
                                 <tr>
-                                    <th>DATA/HORA</th>
-                                    <th>AÇÃO</th>
-                                    <th>USUÁRIO</th>
-                                    <th>LAB.</th>
-                                    <th>TURNO</th>
-                                    <th>DATA AGEND.</th>
-                                    <th>HORÁRIO</th>
+                                    <th>Data/Hora</th>
+                                    <th>Ação</th>
+                                    <th>Usuário</th>
+                                    <th>Lab.</th>
+                                    <th>Turno</th>
+                                    <th>Data Agend.</th>
+                                    <th>Horário</th>
                                 </tr>
                             </thead>
                             <tbody></tbody>

--- a/src/static/laboratorios/turmas.html
+++ b/src/static/laboratorios/turmas.html
@@ -92,12 +92,12 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <div class="d-flex justify-content-between align-items-center mb-4">
-                    <h2 class="mb-0">Gerenciamento de Laboratórios e Turmas</h2>
-                    <button class="btn btn-primary" onclick="novoLaboratorio()">
-                        <i class="bi bi-plus-circle me-2"></i>NOVO LABORATÓRIO
-                    </button>
-                </div>
+                    <div class="d-flex justify-content-between align-items-center mb-4">
+                        <h2 class="mb-0">Gerenciamento de Laboratórios e Turmas</h2>
+                        <button class="btn btn-primary" onclick="novoLaboratorio()">
+                            <i class="bi bi-plus-circle me-2"></i>Novo Laboratório
+                        </button>
+                    </div>
 
                 <div class="card mb-4">
                     <div class="card-header">
@@ -111,7 +111,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE LABORATÓRIOS</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Laboratórios</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -140,8 +140,8 @@
 
                 <div class="card mt-4">
                     <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE TURMAS</h5>
-                        <button class="btn btn-primary btn-sm" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>NOVA TURMA</button>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Turmas</h5>
+                        <button class="btn btn-primary btn-sm" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>Nova Turma</button>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">

--- a/src/static/ocupacao/dashboard.html
+++ b/src/static/ocupacao/dashboard.html
@@ -118,7 +118,7 @@
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                        <h6 class="kpi-title text-uppercase">Salas Ativas</h6>
+                                          <h6 class="kpi-title" style="text-transform: none;">Salas Ativas</h6>
                                         <h2 class="kpi-number" id="totalSalasAtivas">-</h2>
                                     </div>
                                     <i class="bi bi-building kpi-icon"></i>
@@ -131,7 +131,7 @@
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                        <h6 class="kpi-title text-uppercase">Instrutores Ativos</h6>
+                                          <h6 class="kpi-title" style="text-transform: none;">Instrutores Ativos</h6>
                                         <h2 class="kpi-number" id="totalInstrutoresAtivos">-</h2>
                                     </div>
                                     <i class="bi bi-person-badge kpi-icon"></i>
@@ -144,7 +144,7 @@
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                        <h6 class="kpi-title text-uppercase">Ocupações Hoje</h6>
+                                          <h6 class="kpi-title" style="text-transform: none;">Ocupações Hoje</h6>
                                         <h2 class="kpi-number" id="ocupacoesHoje">-</h2>
                                     </div>
                                     <i class="bi bi-calendar-check kpi-icon"></i>
@@ -157,7 +157,7 @@
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                        <h6 class="kpi-title text-uppercase">Esta Semana</h6>
+                                          <h6 class="kpi-title" style="text-transform: none;">Esta Semana</h6>
                                         <h2 class="kpi-number" id="ocupacoesSemana">-</h2>
                                     </div>
                                     <i class="bi bi-calendar-week kpi-icon"></i>

--- a/src/static/ocupacao/instrutores.html
+++ b/src/static/ocupacao/instrutores.html
@@ -110,12 +110,12 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h2 class="mb-0">Gestão de Corpo Docente</h2>
-                    <button id="btnAdicionarNovo" class="btn btn-primary">
-                        <i class="bi bi-plus-circle me-2"></i>NOVO INSTRUTOR
-                    </button>
-                </div>
+                    <div class="page-header">
+                        <h2 class="mb-0">Gestão de Corpo Docente</h2>
+                        <button id="btnAdicionarNovo" class="btn btn-primary">
+                            <i class="bi bi-plus-circle me-2"></i>Novo Instrutor
+                        </button>
+                    </div>
 
                 <div class="card mb-4">
                     <div class="card-header">
@@ -149,18 +149,18 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE INSTRUTORES</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Instrutores</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
                             <table class="table table-hover mb-0">
                                 <thead class="table-light">
                                     <tr>
-                                        <th scope="col">NOME</th>
-                                        <th scope="col">ÁREA DE ATUAÇÃO</th>
-                                        <th scope="col">STATUS</th>
-                                        <th scope="col">DISPONIBILIDADE</th>
-                                        <th scope="col" class="text-end">AÇÕES</th>
+                                        <th scope="col">Nome</th>
+                                        <th scope="col">Área de Atuação</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Disponibilidade</th>
+                                        <th scope="col" class="text-end">Ações</th>
                                     </tr>
                                 </thead>
                                 <tbody id="tabelaCorpoDocente">

--- a/src/static/ocupacao/salas.html
+++ b/src/static/ocupacao/salas.html
@@ -150,7 +150,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE SALAS</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Salas</h5>
                     </div>
                     <div class="card-body p-0">
                         <div id="loadingSalas" class="text-center py-4">
@@ -165,11 +165,11 @@
                                 <thead class="table-light">
                                     <tr>
                                         <th scope="col">ID</th>
-                                        <th scope="col">NOME</th>
-                                        <th scope="col">RECURSOS DISPONÍVEIS</th>
-                                        <th scope="col">CAPACIDADE</th>
-                                        <th scope="col">STATUS</th>
-                                        <th scope="col">AÇÕES</th>
+                                        <th scope="col">Nome</th>
+                                        <th scope="col">Recursos Disponíveis</th>
+                                        <th scope="col">Capacidade</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Ações</th>
                                     </tr>
                                 </thead>
                                 <tbody id="tabelaSalas">

--- a/src/static/ocupacao/turmas.html
+++ b/src/static/ocupacao/turmas.html
@@ -110,12 +110,12 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h2 class="mb-0">Gerenciar Turmas</h2>
-                    <button class="btn btn-primary" onclick="novaTurma()">
-                        <i class="bi bi-plus-circle me-2"></i>ADICIONAR TURMA
-                    </button>
-                </div>
+    <div class="page-header">
+        <h2 class="mb-0">Gerenciar Turmas</h2>
+        <button class="btn btn-primary" onclick="novaTurma()">
+            <i class="bi bi-plus-circle me-2"></i>Adicionar Turma
+        </button>
+    </div>
 
                 <div class="card mb-4">
                     <div class="card-header">
@@ -143,7 +143,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE TURMAS</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Turmas</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">

--- a/src/static/rateio/config.html
+++ b/src/static/rateio/config.html
@@ -68,12 +68,12 @@
                 </div>
             </div>
             <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h2 class="mb-0">Configurações de Rateio</h2>
-                    <button class="btn btn-primary" onclick="novaConfig()">
-                        <i class="bi bi-plus-circle me-2"></i>NOVA CONFIGURAÇÃO
-                    </button>
-                </div>
+                    <div class="page-header">
+                        <h2 class="mb-0">Configurações de Rateio</h2>
+                        <button class="btn btn-primary" onclick="novaConfig()">
+                            <i class="bi bi-plus-circle me-2"></i>Nova Configuração
+                        </button>
+                    </div>
                 <div class="card mt-4">
                     <div class="card-body p-0">
                         <div class="table-responsive">

--- a/src/static/rateio/instrutores.html
+++ b/src/static/rateio/instrutores.html
@@ -75,9 +75,9 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h2 class="mb-0">Gestão de Instrutores</h2>
-                    <button id="btnAdicionarNovo" class="btn btn-primary">
-                        <i class="bi bi-plus-circle me-2"></i>NOVO INSTRUTOR
-                    </button>
+                      <button id="btnAdicionarNovo" class="btn btn-primary">
+                          <i class="bi bi-plus-circle me-2"></i>Novo Instrutor
+                      </button>
                 </div>
 
                 <div class="card mb-4">
@@ -112,18 +112,18 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>LISTA DE INSTRUTORES</h5>
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Instrutores</h5>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
                             <table class="table table-hover mb-0">
                                 <thead class="table-light">
                                     <tr>
-                                        <th scope="col">NOME</th>
-                                        <th scope="col">ÁREA DE ATUAÇÃO</th>
-                                        <th scope="col">STATUS</th>
-                                        <th scope="col">DISPONIBILIDADE</th>
-                                        <th scope="col" class="text-end">AÇÕES</th>
+                                        <th scope="col">Nome</th>
+                                        <th scope="col">Área de Atuação</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Disponibilidade</th>
+                                        <th scope="col" class="text-end">Ações</th>
                                     </tr>
                                 </thead>
                                 <tbody id="tabelaCorpoDocente">

--- a/src/static/rateio/logs.html
+++ b/src/static/rateio/logs.html
@@ -112,24 +112,24 @@
             </div>
 
             <div class="card mt-4">
-                <div class="card-header">
-                    <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>HISTÓRICO DE LOGS</h5>
-                </div>
+                    <div class="card-header">
+                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Histórico de Logs</h5>
+                    </div>
                 <div class="card-body p-0">
                     <div class="table-responsive">
                         <table class="table table-hover mb-0" id="tabelaLogs">
                             <thead class="table-light">
                                 <tr>
-                                    <th>DATA/HORA</th>
-                                    <th>AÇÃO</th>
-                                    <th>USUÁRIO</th>
-                                    <th>INSTRUTOR</th>
-                                    <th>FILIAL</th>
+                                    <th>Data/Hora</th>
+                                    <th>Ação</th>
+                                    <th>Usuário</th>
+                                    <th>Instrutor</th>
+                                    <th>Filial</th>
                                     <th>UO</th>
                                     <th>CR</th>
-                                    <th>CLASSE DE VALOR</th>
-                                    <th>PERCENTUAL</th>
-                                    <th>OBSERVAÇÕES</th>
+                                    <th>Classe de Valor</th>
+                                    <th>Percentual</th>
+                                    <th>Observações</th>
                                 </tr>
                             </thead>
                             <tbody></tbody>

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -75,10 +75,10 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h2 class="mb-0">Gerenciar Catálogo de Treinamentos</h2>
-                    <button class="btn btn-primary" onclick="novoTreinamento()"><i class="bi bi-plus-circle me-2"></i>NOVO TREINAMENTO</button>
-                </div>
+                    <div class="page-header">
+                        <h2 class="mb-0">Gerenciar Catálogo de Treinamentos</h2>
+                        <button class="btn btn-primary" onclick="novoTreinamento()"><i class="bi bi-plus-circle me-2"></i>Novo Treinamento</button>
+                    </div>
                 
                 <div id="alertContainer" class="mt-3"></div>
 

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -134,7 +134,7 @@
                     <div class="card-body p-0">
                         <div class="d-flex justify-content-end p-3">
                             <button class="btn btn-sm btn-primary me-2" onclick="abrirModalInscricaoAdmin(new URLSearchParams(window.location.search).get('turma'))">
-                                <i class="bi bi-person-plus-fill me-1"></i> ADICIONAR PARTICIPANTE
+                                <i class="bi bi-person-plus-fill me-1"></i> Adicionar Participante
                             </button>
                             <button id="btnSalvarAlteracoes" class="btn btn-sm btn-success">
                                 <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -75,10 +75,10 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h2 class="mb-0">Gerenciar Turmas Futuras</h2>
-                    <button class="btn btn-primary" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>NOVA TURMA</button>
-                </div>
+                    <div class="page-header">
+                        <h2 class="mb-0">Gerenciar Turmas Futuras</h2>
+                        <button class="btn btn-primary" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>Nova Turma</button>
+                    </div>
                 
                 <div id="alertContainer" class="mt-3"></div>
 


### PR DESCRIPTION
## Summary
- remove `text-transform: uppercase` from headings, cards, tables and primary buttons
- convert static UI labels from all caps to title case and drop Bootstrap `text-uppercase`

## Testing
- `pre-commit run --files src/static/admin/login.html src/static/admin/usuarios.html src/static/css/styles.css src/static/laboratorios/calendario.html src/static/laboratorios/dashboard.html src/static/laboratorios/logs.html src/static/laboratorios/turmas.html src/static/ocupacao/dashboard.html src/static/ocupacao/instrutores.html src/static/ocupacao/salas.html src/static/ocupacao/turmas.html src/static/rateio/config.html src/static/rateio/instrutores.html src/static/rateio/logs.html src/static/treinamentos/admin-catalogo.html src/static/treinamentos/admin-inscricoes.html src/static/treinamentos/admin-turmas.html`


------
https://chatgpt.com/codex/tasks/task_e_689779633c4883238cdf99e70c46b0da