### PR TITLE
Padroniza alertas com toasts do Bootstrap

### DIFF
--- a/src/static/admin/login.html
+++ b/src/static/admin/login.html
@@ -27,7 +27,6 @@
                     <h2 class="h3 mb-3 fw-normal">Acesse sua conta</h2>
                     <p class="text-muted mb-4">Bem-vindo de volta! Por favor, insira as suas credenciais.</p>
                     
-                    <div id="alertContainer"></div>
                     
                     <form id="loginForm">
                         <div class="form-floating mb-3">

--- a/src/static/admin/perfil.html
+++ b/src/static/admin/perfil.html
@@ -71,7 +71,6 @@
             <main class="col-lg-9 col-md-12">
                 <h2 class="mb-4">Meu Perfil</h2>
                 
-                <div id="alertContainer"></div>
                 
                 <div class="row">
                     <div class="col-md-8">

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -343,14 +343,20 @@ function formatarHorario(horario) {
 }
 
 /**
- * Exibe uma mensagem de alerta na página
+ * Exibe uma mensagem usando toasts do Bootstrap
  * @param {string} mensagem - Mensagem a ser exibida
- * @param {string} tipo - Tipo de alerta (success, danger, warning, info)
- * @param {string} containerId - ID do container onde o alerta será exibido
+ * @param {string} tipo - Tipo do toast (success, danger, warning, info)
  */
-function exibirAlerta(mensagem, tipo = 'info', containerId = 'alertContainer') {
-    const toastContainer = document.querySelector('.toast-container');
-    if (!toastContainer) return;
+function showToast(mensagem, tipo = 'info') {
+    let toastContainer = document.querySelector('.toast-container');
+
+    // Garante que o container exista
+    if (!toastContainer) {
+        toastContainer = document.createElement('div');
+        toastContainer.className = 'toast-container position-fixed bottom-0 end-0 p-3';
+        toastContainer.style.zIndex = 1100;
+        document.body.appendChild(toastContainer);
+    }
 
     const toastId = `toast-${Date.now()}`;
     const bgColor =
@@ -378,6 +384,11 @@ function exibirAlerta(mensagem, tipo = 'info', containerId = 'alertContainer') {
 
     toast.show();
 }
+
+// Alias para compatibilidade com código existente
+const exibirAlerta = showToast;
+window.showToast = showToast;
+window.exibirAlerta = exibirAlerta;
 
 /**
  * Retorna a classe CSS correspondente ao turno
@@ -721,7 +732,7 @@ async function carregarNotificacoes() {
                     // Recarrega as notificações
                     carregarNotificacoes();
                 } catch (error) {
-                    exibirAlerta('Erro ao marcar notificação como lida', 'danger');
+                    showToast('Não foi possível marcar a notificação como lida.', 'danger');
                 }
             });
         });
@@ -776,7 +787,7 @@ async function exportarDados(endpoint, formato, nomeArquivo) {
         window.URL.revokeObjectURL(url);
     } catch (error) {
         console.error('Erro ao exportar dados:', error);
-        exibirAlerta('Falha ao exportar dados', 'danger');
+        showToast('Não foi possível exportar os dados.', 'danger');
     }
 }
 

--- a/src/static/js/ocupacao/calendario.js
+++ b/src/static/js/ocupacao/calendario.js
@@ -625,7 +625,7 @@ async function confirmarExclusaoOcupacao(modo) {
         const result = await response.json();
         
         if (response.ok) {
-            exibirAlerta('Ocupação excluída com sucesso!', 'success');
+            showToast('Ocupação excluída com sucesso!', 'success');
 
             // Fecha o modal
             const modal = bootstrap.Modal.getInstance(document.getElementById('modalExcluirOcupacao'));
@@ -647,38 +647,11 @@ async function confirmarExclusaoOcupacao(modo) {
         }
     } catch (error) {
         console.error('Erro ao excluir ocupação:', error);
-        exibirAlerta(error.message, 'danger');
+        showToast(`Não foi possível excluir a ocupação: ${error.message}`, 'danger');
     }
 }
 
-// Função para exibir alertas
-function exibirAlerta(mensagem, tipo) {
-    // Remove alertas existentes
-    const alertasExistentes = document.querySelectorAll('.alert-auto-dismiss');
-    alertasExistentes.forEach(alerta => alerta.remove());
-
-    // Cria novo alerta
-    const alerta = document.createElement('div');
-    alerta.className = `alert alert-${tipo} alert-dismissible fade show alert-auto-dismiss`;
-    alerta.textContent = mensagem;
-    const closeBtn = document.createElement('button');
-    closeBtn.type = 'button';
-    closeBtn.className = 'btn-close';
-    closeBtn.setAttribute('data-bs-dismiss', 'alert');
-    closeBtn.setAttribute('aria-label', 'Close');
-    alerta.appendChild(closeBtn);
-    
-    // Insere no início do main
-    const main = document.querySelector('main');
-    main.insertBefore(alerta, main.firstChild);
-    
-    // Remove automaticamente após 5 segundos
-    setTimeout(() => {
-        if (alerta.parentNode) {
-            alerta.remove();
-        }
-    }, 5000);
-}
+// Removido: alertas em linha substituídos por toasts globais
 
 function formatarDataCurta(dataStr) {
     const data = new Date(dataStr + 'T00:00:00');

--- a/src/static/js/ocupacao/corpo-docente.js
+++ b/src/static/js/ocupacao/corpo-docente.js
@@ -109,7 +109,7 @@ class GerenciadorInstrutores {
             this.instrutores = dados;
             this.renderizarTabela();
         } catch (err) {
-            exibirAlerta('Erro ao carregar instrutores', 'danger');
+            showToast('Não foi possível carregar os instrutores.', 'danger');
         }
     }
 
@@ -163,7 +163,7 @@ class GerenciadorInstrutores {
             this.btnSalvar.querySelector('.btn-text').textContent = 'Atualizar';
             this.modalInstrutor.show();
         } catch (e) {
-            exibirAlerta('Erro ao carregar dados do instrutor', 'danger');
+            showToast('Não foi possível carregar os dados do instrutor.', 'danger');
         }
     }
 
@@ -185,7 +185,7 @@ class GerenciadorInstrutores {
     async salvarInstrutor() {
         const dados = this.coletarFormData();
         if (!dados.nome || !dados.email) {
-            exibirAlerta('Preencha nome e e-mail.', 'warning');
+            showToast('Por favor, preencha o nome e o e-mail.', 'warning');
             return;
         }
         const spinner = this.btnSalvar.querySelector('.spinner-border');
@@ -197,11 +197,11 @@ class GerenciadorInstrutores {
         const method = isEdicao ? 'PUT' : 'POST';
         try {
             await chamarAPI(endpoint, method, dados);
-            exibirAlerta(`Instrutor ${isEdicao ? 'atualizado' : 'cadastrado'} com sucesso!`, 'success');
+            showToast(`Instrutor ${isEdicao ? 'atualizado' : 'cadastrado'} com sucesso!`, 'success');
             this.modalInstrutor.hide();
             this.carregarInstrutores();
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(`Não foi possível salvar o instrutor: ${e.message}`, 'danger');
         } finally {
             this.btnSalvar.disabled = false;
             spinner.classList.add('d-none');
@@ -217,11 +217,11 @@ class GerenciadorInstrutores {
     async confirmarExclusao() {
         try {
             await chamarAPI(`/instrutores/${this.instrutorParaExcluir}`, 'DELETE');
-            exibirAlerta('Instrutor excluído com sucesso!', 'success');
+            showToast('Instrutor excluído com sucesso!', 'success');
             this.modalExcluir.hide();
             this.carregarInstrutores();
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(`Não foi possível excluir o instrutor: ${e.message}`, 'danger');
         }
     }
 }

--- a/src/static/js/ocupacao/nova-ocupacao.js
+++ b/src/static/js/ocupacao/nova-ocupacao.js
@@ -188,7 +188,7 @@ async function carregarOcupacaoParaEdicao(id) {
         }
     } catch (error) {
         console.error('Erro ao carregar ocupação para edição:', error);
-        exibirAlerta('Erro ao carregar dados da ocupação.', 'danger');
+        showToast('Não foi possível carregar os dados da ocupação.', 'danger');
     }
 }
 
@@ -302,14 +302,14 @@ async function salvarOcupacao() {
         const resultado = await response.json();
         
         if (response.ok) {
-            exibirAlerta('Ocupação salva com sucesso.', 'success');
+            showToast('Ocupação salva com sucesso!', 'success');
             window.location.href = '/ocupacao/calendario.html';
         } else {
             throw new Error(formatarErros(resultado.erro) || 'Erro ao salvar ocupação');
         }
     } catch (error) {
         console.error('Erro ao salvar ocupação:', error);
-        exibirAlerta(error.message, 'danger');
+        showToast(`Não foi possível salvar a ocupação: ${error.message}`, 'danger');
     }
 }
 
@@ -344,7 +344,7 @@ function validarFormulario() {
     }
     
     if (!valido) {
-        exibirAlerta('Por favor, preencha todos os campos obrigatórios corretamente.', 'warning');
+        showToast('Por favor, preencha todos os campos obrigatórios.', 'warning');
     }
     
     return valido;
@@ -352,34 +352,7 @@ function validarFormulario() {
 
 // Avança para próximo passo
 
-// Função para exibir alertas
-function exibirAlerta(mensagem, tipo) {
-    // Remove alertas existentes
-    const alertasExistentes = document.querySelectorAll('.alert-auto-dismiss');
-    alertasExistentes.forEach(alerta => alerta.remove());
-
-    // Cria novo alerta
-    const alerta = document.createElement('div');
-    alerta.className = `alert alert-${tipo} alert-dismissible fade show alert-auto-dismiss`;
-    alerta.textContent = mensagem;
-    const closeBtn = document.createElement('button');
-    closeBtn.type = 'button';
-    closeBtn.className = 'btn-close';
-    closeBtn.setAttribute('data-bs-dismiss', 'alert');
-    closeBtn.setAttribute('aria-label', 'Close');
-    alerta.appendChild(closeBtn);
-    
-    // Insere no início do main
-    const main = document.querySelector('main');
-    main.insertBefore(alerta, main.firstChild);
-    
-    // Remove automaticamente após 5 segundos
-    setTimeout(() => {
-        if (alerta.parentNode) {
-            alerta.remove();
-        }
-    }, 5000);
-}
+// Removido: alertas em linha substituídos por toasts globais
 
 // Exibe aviso quando "Aula Regular" é selecionada
 function monitorarSelecaoAulaRegular() {

--- a/src/static/js/ocupacao/salas.js
+++ b/src/static/js/ocupacao/salas.js
@@ -111,7 +111,7 @@ class GerenciadorSalas {
         } else {
             mensagem += ` ${error.message}`;
         }
-        exibirAlerta(mensagem, 'danger');
+        showToast(mensagem, 'danger');
     } finally {
         document.getElementById('loadingSalas').style.display = 'none';
     }
@@ -246,7 +246,7 @@ class GerenciadorSalas {
         }
     } catch (error) {
         console.error('Erro ao editar sala:', error);
-        exibirAlerta('Erro ao carregar dados da sala.', 'danger');
+        showToast('Não foi possível carregar os dados da sala.', 'danger');
     }
 }
 
@@ -273,12 +273,12 @@ class GerenciadorSalas {
         
         // Validações
         if (!formData.nome) {
-            exibirAlerta('Nome da sala é obrigatório.', 'warning');
+            showToast('Por favor, informe o nome da sala.', 'warning');
             return;
         }
         
         if (!formData.capacidade || formData.capacidade <= 0) {
-            exibirAlerta('Capacidade deve ser um número maior que zero.', 'warning');
+            showToast('A capacidade deve ser um número maior que zero.', 'warning');
             return;
         }
         
@@ -298,7 +298,7 @@ class GerenciadorSalas {
         const result = await response.json();
         
         if (response.ok) {
-            exibirAlerta(`Sala ${isEdicao ? 'atualizada' : 'criada'} com sucesso!`, 'success');
+            showToast(`Sala ${isEdicao ? 'atualizada' : 'criada'} com sucesso!`, 'success');
 
             // Fecha o modal
             const modal = bootstrap.Modal.getInstance(document.getElementById('modalSala'));
@@ -332,7 +332,7 @@ class GerenciadorSalas {
         }
     } catch (error) {
         console.error('Erro ao salvar sala:', error);
-        exibirAlerta(error.message, 'danger');
+        showToast(`Não foi possível salvar a sala: ${error.message}`, 'danger');
     } finally {
         if (btn && spinner) {
             btn.disabled = false;
@@ -364,7 +364,7 @@ class GerenciadorSalas {
         const result = await response.json();
         
         if (response.ok) {
-            exibirAlerta('Sala excluída com sucesso!', 'success');
+            showToast('Sala excluída com sucesso!', 'success');
             
             // Fecha o modal
             const modal = bootstrap.Modal.getInstance(document.getElementById('modalExcluirSala'));
@@ -377,7 +377,7 @@ class GerenciadorSalas {
         }
     } catch (error) {
         console.error('Erro ao excluir sala:', error);
-        exibirAlerta(error.message, 'danger');
+        showToast(`Não foi possível excluir a sala: ${error.message}`, 'danger');
     }
 }
 
@@ -389,34 +389,7 @@ class GerenciadorSalas {
 
 }
 
-// Função para exibir alertas
-function exibirAlerta(mensagem, tipo) {
-    // Remove alertas existentes
-    const alertasExistentes = document.querySelectorAll('.alert-auto-dismiss');
-    alertasExistentes.forEach(alerta => alerta.remove());
-
-    // Cria novo alerta
-    const alerta = document.createElement('div');
-    alerta.className = `alert alert-${tipo} alert-dismissible fade show alert-auto-dismiss`;
-    alerta.textContent = mensagem;
-    const closeBtn = document.createElement('button');
-    closeBtn.type = 'button';
-    closeBtn.className = 'btn-close';
-    closeBtn.setAttribute('data-bs-dismiss', 'alert');
-    closeBtn.setAttribute('aria-label', 'Close');
-    alerta.appendChild(closeBtn);
-    
-    // Insere no início do main
-    const main = document.querySelector('main');
-    main.insertBefore(alerta, main.firstChild);
-    
-    // Remove automaticamente após 5 segundos
-    setTimeout(() => {
-        if (alerta.parentNode) {
-            alerta.remove();
-        }
-    }, 5000);
-}
+// Removido: alertas em linha substituídos por toasts globais
 
 // Instancia o gerenciador de salas e o torna global para acesso inline
 window.gerenciadorSalas = new GerenciadorSalas();

--- a/src/static/js/ocupacao/turmas.js
+++ b/src/static/js/ocupacao/turmas.js
@@ -96,17 +96,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const nome = document.getElementById('nomeTurma').value;
 
         if (!nome) {
-            exibirAlerta('O nome da turma é obrigatório.', 'danger');
+            showToast('Por favor, informe o nome da turma.', 'warning');
             return;
         }
 
         try {
             if (id) {
                 await chamarAPI(`/turmas/${id}`, 'PUT', { nome });
-                exibirAlerta('Turma atualizada com sucesso!', 'success');
+                showToast('Turma atualizada com sucesso!', 'success');
             } else {
                 await chamarAPI('/turmas', 'POST', { nome });
-                exibirAlerta('Turma cadastrada com sucesso!', 'success');
+                showToast('Turma cadastrada com sucesso!', 'success');
             }
 
             document.getElementById('turmaForm').reset();
@@ -115,7 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
             turmaModal.hide();
             carregarTurmas();
         } catch (error) {
-            exibirAlerta(`Erro ao salvar turma: ${error.message}`, 'danger');
+            showToast(`Não foi possível salvar a turma: ${error.message}`, 'danger');
         } finally {
             if (btn && spinner) {
                 btn.disabled = false;
@@ -151,10 +151,10 @@ document.addEventListener('DOMContentLoaded', () => {
     async function excluirTurma(id) {
         try {
             await chamarAPI(`/turmas/${id}`, 'DELETE');
-            exibirAlerta('Turma excluída com sucesso!', 'success');
+            showToast('Turma excluída com sucesso!', 'success');
             carregarTurmas();
         } catch (error) {
-            exibirAlerta(`Erro ao excluir turma: ${error.message}`, 'danger');
+            showToast(`Não foi possível excluir a turma: ${error.message}`, 'danger');
         }
     }
 

--- a/src/static/laboratorios/agendamento.html
+++ b/src/static/laboratorios/agendamento.html
@@ -94,7 +94,6 @@
             <main class="col-lg-9 col-md-12">
                 <h2 id="pageTitle" class="mb-4">Novo Agendamento</h2>
                 
-                <div id="alertContainer"></div>
                 
                 <div class="card">
                     <div class="card-body">

--- a/src/static/laboratorios/perfil.html
+++ b/src/static/laboratorios/perfil.html
@@ -94,7 +94,6 @@
             <main class="col-lg-9 col-md-12">
                 <h2 class="mb-4">Meu Perfil</h2>
                 
-                <div id="alertContainer"></div>
                 
                 <div class="row">
                     <div class="col-md-8">

--- a/src/static/laboratorios/turmas.html
+++ b/src/static/laboratorios/turmas.html
@@ -107,7 +107,6 @@
                     </div>
                 </div>
 
-                <div id="alertContainer"></div>
 
                 <div class="card mt-4">
                     <div class="card-header">

--- a/src/static/ocupacao/calendario.html
+++ b/src/static/ocupacao/calendario.html
@@ -134,7 +134,6 @@
             <main class="col-lg-9 col-md-12">
                 <h2 class="mb-4">Calendário de Ocupações</h2>
 
-                <div id="alertContainer"></div>
 
                 <div class="d-lg-none mb-4">
                     <div class="card">

--- a/src/static/ocupacao/perfil.html
+++ b/src/static/ocupacao/perfil.html
@@ -111,7 +111,6 @@
             <main class="col-lg-9 col-md-12">
                 <h2 class="mb-4">Meu Perfil</h2>
                 
-                <div id="alertContainer"></div>
                 
                 <div class="row">
                     <div class="col-md-8">

--- a/src/static/ocupacao/salas.html
+++ b/src/static/ocupacao/salas.html
@@ -289,7 +289,7 @@
             // Verifica se é administrador
             const usuario = getUsuarioLogado();
             if (!isAdmin()) {
-                alert('Acesso negado. Apenas administradores podem gerenciar salas.');
+                showToast('Acesso negado. Somente administradores podem gerenciar salas.', 'danger');
                 window.location.href = '/ocupacao/dashboard.html';
                 return;
             }

--- a/src/static/ocupacao/turmas.html
+++ b/src/static/ocupacao/turmas.html
@@ -138,7 +138,6 @@
                     </div>
                 </div>
 
-                <div id="alertContainer"></div>
 
                 <div class="card mt-4">
                     <div class="card-header">

--- a/src/static/rateio/perfil.html
+++ b/src/static/rateio/perfil.html
@@ -78,7 +78,6 @@
 
                 <div class="card mt-4">
                     <div class="card-body">
-                        <div id="alertContainer"></div>
 
                         <div class="row">
                             <div class="col-md-5">

--- a/src/static/register.html
+++ b/src/static/register.html
@@ -20,7 +20,6 @@
                             <p class="text-muted">Preencha os dados para se registrar no sistema</p>
                         </div>
                         
-                        <div id="alertContainer"></div>
                         
                         <form id="registerForm" method="POST" action="/api/registrar">
                             <div class="mb-3">

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -80,7 +80,6 @@
                         <button class="btn btn-primary" onclick="novoTreinamento()"><i class="bi bi-plus-circle me-2"></i>Novo Treinamento</button>
                     </div>
                 
-                <div id="alertContainer" class="mt-3"></div>
 
                 <div class="card mt-4">
                     <div class="card-body p-0">
@@ -174,6 +173,9 @@
             }
         });
     </script>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-historico-passado.html
+++ b/src/static/treinamentos/admin-historico-passado.html
@@ -79,7 +79,6 @@
                     <h2 class="mb-0">Turmas Encerradas</h2>
                 </div>
                 
-                <div id="alertContainer" class="mt-3"></div>
 
                 <div class="card mt-4">
                     <div class="card-body p-0">
@@ -230,6 +229,9 @@
                 </div>
             </div>
         </div>
+    </div>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
     </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/treinamentos/admin-historico-turmas.html
+++ b/src/static/treinamentos/admin-historico-turmas.html
@@ -79,7 +79,6 @@
                     <h2 class="mb-0">Turmas em Andamento</h2>
                 </div>
                 
-                <div id="alertContainer" class="mt-3"></div>
 
                 <div class="card mt-4">
                     <div class="card-body p-0">
@@ -230,6 +229,9 @@
                 </div>
             </div>
         </div>
+    </div>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
     </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -251,6 +251,9 @@
             }
         });
     </script>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-logs.html
+++ b/src/static/treinamentos/admin-logs.html
@@ -79,7 +79,6 @@
                     <h2 class="mb-0">Logs de Atividades</h2>
                 </div>
                 
-                <div id="alertContainer" class="mt-3"></div>
 
                 <div class="card mt-4">
                     <div class="card-body p-0">
@@ -105,6 +104,9 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/treinamentos/logs.js"></script>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -80,7 +80,6 @@
                         <button class="btn btn-primary" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>Nova Turma</button>
                     </div>
                 
-                <div id="alertContainer" class="mt-3"></div>
 
                 <div class="card mt-4">
                     <div class="card-body p-0">
@@ -238,6 +237,9 @@
                 </div>
             </div>
         </div>
+    </div>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
     </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -79,7 +79,6 @@
                     <h2 class="mb-0">Cursos Disponíveis</h2>
                 </div>
                 
-                <div id="alertContainer" class="mt-3"></div>
 
                 <div id="cursos-disponiveis-cards-container" class="row row-cols-1 row-cols-lg-2 g-4 mt-3">
                 </div>
@@ -166,6 +165,9 @@
             }
         });
     </script>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -79,7 +79,6 @@
                     <h2 class="mb-0">Meus Cursos</h2>
                 </div>
 
-                <div id="alertContainer" class="mt-3"></div>
                 
                 <h4 class="mt-4">Em Andamento</h4>
                 <hr>
@@ -156,6 +155,9 @@
             }
         });
     </script>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/perfil.html
+++ b/src/static/treinamentos/perfil.html
@@ -63,7 +63,6 @@
 
             <main class="col-lg-9 col-md-12">
                 <h2 class="mb-4">Meu Perfil</h2>
-                <div id="alertContainer"></div>
                 <div class="row">
                     <div class="col-md-8">
                         <div class="card">
@@ -104,6 +103,9 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/perfil.js"></script>
+    <div aria-live="polite" aria-atomic="true" class="position-relative">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
+    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>


### PR DESCRIPTION
## Summary
- Adiciona utilitário global `showToast` para gerar toasts e remove funções de alerta inline
- Atualiza módulos de ocupação para usar `showToast` com mensagens mais empáticas
- Elimina containers de alerta e inclui `toast-container` nas páginas

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689791c264a4832384554981dfc669e5