### PR TITLE
Atualiza paleta de cores para padrão FIEMG

### DIFF
--- a/src/models/ocupacao.py
+++ b/src/models/ocupacao.py
@@ -125,13 +125,13 @@ class Ocupacao(db.Model):
         Retorna a cor associada ao tipo de ocupação.
         """
         cores = {
-            'aula_regular': '#4CAF50',      # Verde
-            'evento_especial': '#FF9800',   # Laranja
-            'reuniao': '#2196F3',           # Azul
-            'manutencao': '#F44336',        # Vermelho
+            'aula_regular': '#006837',      # Verde FIEMG
+            'evento_especial': '#FFB612',   # Amarelo FIEMG
+            'reuniao': '#00539F',           # Azul FIEMG
+            'manutencao': '#D50032',        # Vermelho FIEMG
             'reserva_especial': '#9C27B0'   # Roxo
         }
-        return cores.get(self.tipo_ocupacao, '#607D8B')  # Cinza como padrão
+        return cores.get(self.tipo_ocupacao, '#888888')  # Cinza como padrão
     
     def to_dict(self, include_relations=True):
         """

--- a/src/routes/laboratorios/agendamento.py
+++ b/src/routes/laboratorios/agendamento.py
@@ -189,11 +189,11 @@ def agendamentos_calendario_periodo():
     def cor_turno(t):
         """Retorna a cor correspondente ao turno."""
         cores = {
-            'Manhã': '#F3B54E',
-            'Tarde': '#FFC107',
-            'Noite': '#164194'
+            'Manhã': '#FDD835',
+            'Tarde': '#00539F',
+            'Noite': '#512DA8'
         }
-        return cores.get(t, '#607D8B')
+        return cores.get(t, '#888888')
 
     eventos = []
     for a in agendamentos:

--- a/src/routes/ocupacao/ocupacao.py
+++ b/src/routes/ocupacao/ocupacao.py
@@ -592,11 +592,11 @@ def obter_ocupacoes_calendario():
     def cor_turno(t):
         """Retorna a cor associada ao turno."""
         cores = {
-            'Manhã': '#FFEB3B',
-            'Tarde': '#03A9F4',
-            'Noite': '#673AB7'
+            'Manhã': '#FDD835',
+            'Tarde': '#00539F',
+            'Noite': '#512DA8'
         }
-        return cores.get(t, '#607D8B')
+        return cores.get(t, '#888888')
 
     eventos_calendario = []
     for ocupacao in ocupacoes:
@@ -719,10 +719,10 @@ def listar_tipos_ocupacao():
         return jsonify({'erro': 'Não autenticado'}), 401
     
     tipos = [
-        {'valor': 'aula_regular', 'nome': 'Aula Regular', 'cor': '#4CAF50'},
-        {'valor': 'evento_especial', 'nome': 'Evento Especial', 'cor': '#FF9800'},
-        {'valor': 'reuniao', 'nome': 'Reunião', 'cor': '#2196F3'},
-        {'valor': 'manutencao', 'nome': 'Manutenção', 'cor': '#F44336'},
+        {'valor': 'aula_regular', 'nome': 'Aula Regular', 'cor': '#006837'},
+        {'valor': 'evento_especial', 'nome': 'Evento Especial', 'cor': '#FFB612'},
+        {'valor': 'reuniao', 'nome': 'Reunião', 'cor': '#00539F'},
+        {'valor': 'manutencao', 'nome': 'Manutenção', 'cor': '#D50032'},
         {'valor': 'reserva_especial', 'nome': 'Reserva Especial', 'cor': '#9C27B0'}
     ]
     

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -20,19 +20,19 @@
   --primary-color: #164194;
   --accent-color: #008BD2;
   --secondary-color: #e6f4ff;
-  --success-color: #52c41a;
-  --danger-color: #ff4d4f;
-  --warning-color: #ffc107;
-  --info-color: #0dcaf0;
+  --success-color: #006837;
+  --danger-color: #D50032;
+  --warning-color: #FFB612;
+  --info-color: #00539F;
   --light-color: #f8f9fa;
   --dark-color: #212529;
   --text-color: #333333;
   --muted-color: #888888;
   --background-color: #f7f9fc;
 
-  --turno-manha-color: #FFEB3B;
-  --turno-tarde-color: #03A9F4;
-  --turno-noite-color: #673AB7;
+  --turno-manha-color: #FDD835;
+  --turno-tarde-color: #00539F;
+  --turno-noite-color: #512DA8;
 }
 
 body {
@@ -354,20 +354,21 @@ small, .small {
 
 .agendamento-manha {
   background-color: var(--turno-manha-color);
-  border-left: 3px solid #FDD835;
+  border-left: 3px solid var(--turno-manha-color);
+  color: #000;
 }
 
 
 .agendamento-tarde {
   background-color: var(--turno-tarde-color);
-  border-left: 3px solid #0288D1;
+  border-left: 3px solid var(--turno-tarde-color);
   color: #fff;
 }
 
 
 .agendamento-noite {
   background-color: var(--turno-noite-color);
-  border-left: 3px solid #512DA8;
+  border-left: 3px solid var(--turno-noite-color);
   color: #fff;
 }
 
@@ -394,17 +395,17 @@ small, .small {
 
 .legenda-cor-manha {
   background-color: var(--turno-manha-color);
-  border-left: 3px solid #FDD835;
+  border-left: 3px solid var(--turno-manha-color);
 }
 
 .legenda-cor-tarde {
   background-color: var(--turno-tarde-color);
-  border-left: 3px solid #0288D1;
+  border-left: 3px solid var(--turno-tarde-color);
 }
 
 .legenda-cor-noite {
   background-color: var(--turno-noite-color);
-  border-left: 3px solid #512DA8;
+  border-left: 3px solid var(--turno-noite-color);
 }
 
 /* ======================================================= */
@@ -428,28 +429,29 @@ small, .small {
 /* ESTILO LIVRE (0% Ocupado) */
 .turno-livre {
     background-color: #f8f9fa;
-    color: #6c757d;
+    color: var(--muted-color);
     border-color: #dee2e6;
 }
 
 /* ESTILO PARCIAL (1-99% Ocupado) - CORREÇÃO */
 .turno-parcial {
-    background-color: #FF8A00 !important; /* Laranja SENAI. O !important força a prioridade. */
-    color: #FFFFFF;
-    border-color: #E67B00;
-    font-weight: 600;
+  background-color: var(--warning-color) !important;
+  color: #000;
+  border-color: var(--warning-color);
+  font-weight: 600;
 }
 
 /* ESTILO CHEIO (100% Ocupado) - CORREÇÃO */
 .turno-cheio {
-    background-color: #164194 !important; /* Azul SENAI. O !important força a prioridade. */
-    color: #FFFFFF;
-    border-color: #00407d;
-    font-weight: 600;
+  background-color: var(--primary-color) !important;
+  color: #FFFFFF;
+  border-color: #00407d;
+  font-weight: 600;
 }
 
 .resumo-card-manha {
   background-color: var(--turno-manha-color);
+  color: #000;
 }
 
 .resumo-card-tarde {
@@ -673,21 +675,21 @@ footer {
   height: 300px;
 }
 .ocupacao-item {
-  border-left: 4px solid #007bff;
+  border-left: 4px solid var(--primary-color);
   padding-left: 12px;
   margin-bottom: 10px;
 }
 .ocupacao-item.aula_regular {
-  border-left-color: #4CAF50;
+  border-left-color: var(--success-color);
 }
 .ocupacao-item.evento_especial {
-  border-left-color: #FF9800;
+  border-left-color: var(--warning-color);
 }
 .ocupacao-item.reuniao {
-  border-left-color: #2196F3;
+  border-left-color: var(--info-color);
 }
 .ocupacao-item.manutencao {
-  border-left-color: #F44336;
+  border-left-color: var(--danger-color);
 }
 .ocupacao-item.reserva_especial {
   border-left-color: #9C27B0;
@@ -728,7 +730,7 @@ footer {
   background-color: #FFFFFF;
 }
 .fc-daygrid-day.fc-day-today {
-  border: 1px solid #00539F;
+  border: 1px solid var(--turno-tarde-color);
 }
 .fc-daygrid-day.fc-day-other {
   opacity: 0.6;
@@ -737,20 +739,20 @@ footer {
   border-radius: 3px;
 }
 .ocupacao-aula_regular {
-  background-color: #4CAF50 !important;
-  border-color: #4CAF50 !important;
+  background-color: var(--success-color) !important;
+  border-color: var(--success-color) !important;
 }
 .ocupacao-evento_especial {
-  background-color: #FF9800 !important;
-  border-color: #FF9800 !important;
+  background-color: var(--warning-color) !important;
+  border-color: var(--warning-color) !important;
 }
 .ocupacao-reuniao {
-  background-color: #2196F3 !important;
-  border-color: #2196F3 !important;
+  background-color: var(--info-color) !important;
+  border-color: var(--info-color) !important;
 }
 .ocupacao-manutencao {
-  background-color: #F44336 !important;
-  border-color: #F44336 !important;
+  background-color: var(--danger-color) !important;
+  border-color: var(--danger-color) !important;
 }
 .ocupacao-reserva_especial {
   background-color: #9C27B0 !important;
@@ -771,15 +773,15 @@ footer {
   transition: all 0.3s;
 }
 .disponibilidade-check.disponivel {
-  border-color: #28a745;
+  border-color: var(--success-color);
   background-color: #f8fff9;
 }
 .disponibilidade-check.indisponivel {
-  border-color: #dc3545;
+  border-color: var(--danger-color);
   background-color: #fff8f8;
 }
 .disponibilidade-check.verificando {
-  border-color: #ffc107;
+  border-color: var(--warning-color);
   background-color: #fffdf5;
 }
 .conflito-item {
@@ -804,7 +806,7 @@ footer {
   height: 30px;
   border-radius: 50%;
   background-color: #e9ecef;
-  color: #6c757d;
+  color: var(--muted-color);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -812,11 +814,11 @@ footer {
   margin-right: 8px;
 }
 .step.active .step-number {
-  background-color: #007bff;
+  background-color: var(--primary-color);
   color: #fff;
 }
 .step.completed .step-number {
-  background-color: #28a745;
+  background-color: var(--success-color);
   color: #fff;
 }
 .step-line {
@@ -826,7 +828,7 @@ footer {
   margin: 0 10px;
 }
 .step.completed + .step-line {
-  background-color: #28a745;
+  background-color: var(--success-color);
 }
 
 footer.bg-dark {
@@ -904,7 +906,7 @@ input, select, textarea {
 }
 .action-tile:hover {
   color: #FFFFFF;
-  border-color: #00539F;
+  border-color: var(--turno-tarde-color);
 }
 .action-tile i {
   font-size: 2.5rem;
@@ -946,21 +948,21 @@ input, select, textarea {
 /* ESTILO LIVRE (0% Ocupado) */
 .turno-livre {
     background-color: #f8f9fa;
-    color: #6c757d;
+    color: var(--muted-color);
     border-color: #dee2e6;
 }
 
 /* ESTILO PARCIAL (1-99% Ocupado) - CORREÇÃO */
 .turno-parcial {
-    background-color: #FF8A00 !important; /* Laranja SENAI. O !important força a prioridade. */
-    color: #FFFFFF;
-    border-color: #E67B00;
+    background-color: var(--warning-color) !important;
+    color: #000;
+    border-color: var(--warning-color);
     font-weight: 600;
 }
 
 /* ESTILO CHEIO (100% Ocupado) - CORREÇÃO */
 .turno-cheio {
-    background-color: #164194 !important; /* Azul SENAI. O !important força a prioridade. */
+    background-color: var(--primary-color) !important;
     color: #FFFFFF;
     border-color: #00407d;
     font-weight: 600;
@@ -1045,7 +1047,7 @@ input, select, textarea {
 }
 
 #seletor-laboratorios .lab-icon.active {
-    background-color: #00539F;
+    background-color: var(--turno-tarde-color);
     color: #fff;
     border-color: #00407d;
     transform: translateY(-2px);
@@ -1071,7 +1073,7 @@ input, select, textarea {
 .turno-card .card-header {
     background-color: #f8f9fa; font-weight: 700;
     text-transform: none; font-size: 0.9rem;
-    color: #00539F;
+    color: var(--turno-tarde-color);
 }
 .agendamento-item {
     display: flex; justify-content: space-between; align-items: center;
@@ -1079,7 +1081,7 @@ input, select, textarea {
 }
 .agendamento-item:last-child { border-bottom: none; }
 .agendamento-info strong { color: #333; }
-.agendamento-info span { font-size: 0.9em; color: #6c757d; }
+.agendamento-info span { font-size: 0.9em; color: var(--muted-color); }
 .btn-novo-agendamento-turno { font-weight: 500; }
 
 

--- a/src/static/js/laboratorios/dashboard.js
+++ b/src/static/js/laboratorios/dashboard.js
@@ -1,3 +1,5 @@
+const rootStyle = getComputedStyle(document.documentElement);
+
 async function carregarKpis() {
     try {
         const dados = await chamarAPI('/dashboard/laboratorios/kpis');
@@ -47,7 +49,7 @@ async function carregarLabsMaisUtilizados() {
         const valores = dados.map(d => d.total);
         new Chart(ctx, {
             type: 'bar',
-            data: { labels, datasets: [{ data: valores, backgroundColor: '#0d6efd' }] },
+            data: { labels, datasets: [{ data: valores, backgroundColor: rootStyle.getPropertyValue('--primary-color').trim() }] },
             options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } }
         });
     } catch (error) {
@@ -66,7 +68,7 @@ async function carregarTendenciaMensal() {
             type: 'line',
             data: {
                 labels,
-                datasets: [{ label: 'Agendamentos', data: valores, borderColor: '#0d6efd', tension: 0.3 }]
+                datasets: [{ label: 'Agendamentos', data: valores, borderColor: rootStyle.getPropertyValue('--primary-color').trim(), tension: 0.3 }]
             },
             options: { scales: { y: { beginAtZero: true } } }
         });

--- a/src/static/js/ocupacao/calendario.js
+++ b/src/static/js/ocupacao/calendario.js
@@ -9,6 +9,8 @@ let tiposOcupacao = [];
 let resumoOcupacoes = {};
 let diaResumoAtual = null;
 
+const rootStyle = getComputedStyle(document.documentElement);
+
 // Converte o nome do turno em um identificador CSS sem acentos
 function slugifyTurno(turno) {
     return turno
@@ -525,7 +527,7 @@ function mostrarDetalhesOcupacao(ocupacao) {
 // Retorna cor do tipo por valor
 function getTipoCorPorValor(valor) {
     const tipo = tiposOcupacao.find(t => t.valor === valor);
-    return tipo ? tipo.cor : '#6c757d';
+    return tipo ? tipo.cor : rootStyle.getPropertyValue('--muted-color').trim();
 }
 
 // Retorna classe do badge de status

--- a/src/static/js/ocupacao/dashboard.js
+++ b/src/static/js/ocupacao/dashboard.js
@@ -5,6 +5,15 @@ let estatisticasGerais = {};
 let proximasOcupacoes = [];
 let relatorioMensal = {};
 
+const rootStyle = getComputedStyle(document.documentElement);
+const coresOcorrencia = {
+    'aula_regular': rootStyle.getPropertyValue('--success-color').trim(),
+    'evento_especial': rootStyle.getPropertyValue('--warning-color').trim(),
+    'reuniao': rootStyle.getPropertyValue('--info-color').trim(),
+    'manutencao': rootStyle.getPropertyValue('--danger-color').trim(),
+    'reserva_especial': '#9C27B0'
+};
+
 // Carrega indicadores de salas por mês
 async function carregarIndicadoresMensais() {
     try {
@@ -347,14 +356,6 @@ function renderizarOcupacoesPorTipo() {
     
     container.innerHTML = '';
     
-    const cores = {
-        'aula_regular': '#4CAF50',
-        'evento_especial': '#FF9800',
-        'reuniao': '#2196F3',
-        'manutencao': '#F44336',
-        'reserva_especial': '#9C27B0'
-    };
-    
     const nomes = {
         'aula_regular': 'Aula Regular',
         'evento_especial': 'Evento Especial',
@@ -367,7 +368,7 @@ function renderizarOcupacoesPorTipo() {
     
     relatorioMensal.ocupacoes_por_tipo.forEach(item => {
         const porcentagem = Math.round((item.total / total) * 100);
-        const cor = cores[item.tipo] || '#6c757d';
+        const cor = coresOcorrencia[item.tipo] || rootStyle.getPropertyValue('--muted-color').trim();
         const nome = nomes[item.tipo] || item.tipo;
         
         const div = document.createElement('div');
@@ -402,14 +403,6 @@ function renderizarOcupacoesPorTipoBasico(tipos) {
     
     container.innerHTML = '';
     
-    const cores = {
-        'aula_regular': '#4CAF50',
-        'evento_especial': '#FF9800',
-        'reuniao': '#2196F3',
-        'manutencao': '#F44336',
-        'reserva_especial': '#9C27B0'
-    };
-    
     const nomes = {
         'aula_regular': 'Aula Regular',
         'evento_especial': 'Evento Especial',
@@ -422,7 +415,7 @@ function renderizarOcupacoesPorTipoBasico(tipos) {
     
     tipos.forEach(item => {
         const porcentagem = Math.round((item.total / total) * 100);
-        const cor = cores[item.tipo] || '#6c757d';
+        const cor = coresOcorrencia[item.tipo] || rootStyle.getPropertyValue('--muted-color').trim();
         const nome = nomes[item.tipo] || item.tipo;
         
         const div = document.createElement('div');
@@ -501,7 +494,7 @@ function renderizarGraficoTendencia(dados) {
             datasets: [{
                 label: 'Ocupações',
                 data: valores,
-                borderColor: '#0d6efd',
+                borderColor: rootStyle.getPropertyValue('--primary-color').trim(),
                 tension: 0.3
             }]
         },

--- a/src/static/laboratorios/calendario.html
+++ b/src/static/laboratorios/calendario.html
@@ -83,7 +83,7 @@
                 </div>
 
                 <div id="empty-state-container" class="text-center p-5 border rounded bg-light d-none">
-                    <i class="bi bi-box-seam" style="font-size: 4rem; color: #6c757d;"></i>
+                    <i class="bi bi-box-seam" style="font-size: 4rem; color: var(--muted-color);"></i>
                     <h4 class="mt-3">Nenhum Laboratório Cadastrado</h4>
                     <p class="text-muted">Para começar a usar a agenda diária, você precisa de cadastrar pelo menos um laboratório.</p>
                     <a href="/laboratorios/turmas.html" class="btn btn-primary mt-3"><i class="bi bi-plus-lg"></i> Cadastrar Primeiro Laboratório</a>

--- a/tests/test_ocupacao.py
+++ b/tests/test_ocupacao.py
@@ -243,8 +243,8 @@ def test_calendario_ocupacoes_cor_por_turno(client, app):
     eventos = resp_cal.get_json()
     assert len(eventos) == 1
     evento = eventos[0]
-    assert evento['backgroundColor'] == '#673AB7'
-    assert evento['borderColor'] == '#673AB7'
+    assert evento['backgroundColor'] == '#512DA8'
+    assert evento['borderColor'] == '#512DA8'
     assert evento['extendedProps']['turno'] == 'Noite'
 
 


### PR DESCRIPTION
## Summary
- replace success, danger, warning and turno colors with FIEMG palette
- centralize color usage in CSS/JS/HTML and backend endpoints
- adjust tests for updated color codes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979a0292848323b987c987c1208a10