### PR TITLE
Replace alerts with Bootstrap toasts

### DIFF
--- a/src/static/admin/login.html
+++ b/src/static/admin/login.html
@@ -67,7 +67,7 @@
                     document.head.appendChild(s);
                 }
             } catch (e) {
-                console.error('Erro ao carregar site key:', e);
+                console.error('Não foi possível carregar site key:', e);
             }
 
             const loginForm = document.getElementById('loginForm');
@@ -90,14 +90,14 @@
                                 });
                             });
                         } catch (err) {
-                            console.error('Erro ao obter token reCAPTCHA:', err);
+                            console.error('Não foi possível obter token reCAPTCHA:', err);
                         }
                     }
 
                     try {
                         await realizarLogin(email, senha, token);
                     } catch (error) {
-                        exibirAlerta(error.message, 'danger');
+                        showToast(error.message, 'danger');
                         btn.disabled = false;
                         btn.innerHTML = 'Entrar';
                     }
@@ -105,9 +105,6 @@
             }
         });
     </script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/admin/perfil.html
+++ b/src/static/admin/perfil.html
@@ -207,9 +207,9 @@
                     // Atualiza o nome na navbar
                     document.getElementById('userName').textContent = dadosAtualizacao.nome;
                     
-                    exibirAlerta('Perfil atualizado com sucesso!', 'success');
+                    showToast('Perfil atualizado com sucesso!', 'success');
                 } catch (error) {
-                    exibirAlerta(`Erro ao atualizar perfil: ${error.message}`, 'danger');
+                    showToast(`Não foi possível atualizar perfil: ${error.message}`, 'danger');
                 }
             });
             
@@ -223,7 +223,7 @@
                 
                 // Validação básica
                 if (novaSenha !== confirmarSenha) {
-                    exibirAlerta('As senhas não coincidem', 'warning');
+                    showToast('As senhas não coincidem. Por favor, verifique.', 'warning');
                     return;
                 }
                 
@@ -235,12 +235,12 @@
                         senha_atual: senhaAtual
                     });
                     
-                    exibirAlerta('Senha alterada com sucesso!', 'success');
+                    showToast('Senha alterada com sucesso!', 'success');
                     
                     // Limpa o formulário
                     document.getElementById('senhaForm').reset();
                 } catch (error) {
-                    exibirAlerta(`Erro ao alterar senha: ${error.message}`, 'danger');
+                    showToast(`Não foi possível alterar senha: ${error.message}`, 'danger');
                 }
             });
         });
@@ -270,13 +270,10 @@
                 // Exibe a data de criação
                 document.getElementById('membroDesde').textContent = formatarData(dadosUsuario.data_criacao);
             } catch (error) {
-                exibirAlerta(`Erro ao carregar dados do usuário: ${error.message}`, 'danger');
+                showToast(`Não foi possível carregar dados do usuário: ${error.message}`, 'danger');
             }
         }
         
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/admin/usuarios.html
+++ b/src/static/admin/usuarios.html
@@ -194,8 +194,5 @@
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/admin/usuarios.js"></script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/js/admin/usuarios.js
+++ b/src/static/js/admin/usuarios.js
@@ -19,10 +19,10 @@ document.addEventListener('DOMContentLoaded', function() {
             try {
                 await chamarAPI(`/usuarios/${usuarioIdParaExcluir}`, 'DELETE');
                 confirmacaoModal.hide();
-                exibirAlerta('Usuário excluído com sucesso!', 'success');
+                showToast('Usuário excluído com sucesso!', 'success');
                 carregarUsuarios(paginaAtual);
             } catch (error) {
-                exibirAlerta(`Erro ao excluir usuário: ${error.message}`, 'danger');
+                showToast(`Não foi possível excluir usuário: ${error.message}`, 'danger');
             }
         }
     });
@@ -67,8 +67,8 @@ document.addEventListener('DOMContentLoaded', function() {
             paginaAtual = resp.page;
             atualizarPaginacao(resp.pages);
         } catch (error) {
-            document.getElementById('usuariosTableBody').innerHTML = '<tr><td colspan="5" class="text-center text-danger">Erro ao carregar usuários.</td></tr>';
-            console.error('Erro ao carregar usuários:', error);
+            document.getElementById('usuariosTableBody').innerHTML = '<tr><td colspan="5" class="text-center text-danger">Não foi possível carregar usuários.</td></tr>';
+            console.error('Não foi possível carregar usuários:', error);
         }
     }
 
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const tipo = document.getElementById('tipo').value;
 
         if (!nome || !email || (!usuarioId && !senha)) {
-            exibirAlerta('Preencha todos os campos obrigatórios', 'warning');
+            showToast('Preencha todos os campos obrigatórios', 'warning');
             return;
         }
 
@@ -116,10 +116,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
             if (usuarioId) {
                 await chamarAPI(`/usuarios/${usuarioId}`, 'PUT', dadosUsuario);
-                exibirAlerta('Usuário atualizado com sucesso!', 'success');
+                showToast('Usuário atualizado com sucesso!', 'success');
             } else {
                 await chamarAPI('/usuarios', 'POST', dadosUsuario);
-                exibirAlerta('Usuário criado com sucesso!', 'success');
+                showToast('Usuário criado com sucesso!', 'success');
             }
 
             usuarioModal.hide();
@@ -128,7 +128,7 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('usuarioForm').reset();
             document.getElementById('usuarioId').value = '';
         } catch (error) {
-            exibirAlerta(`Erro ao salvar usuário: ${error.message}`, 'danger');
+            showToast(`Não foi possível salvar usuário: ${error.message}`, 'danger');
         }
     }
 
@@ -144,7 +144,7 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('senhaHelp').style.display = 'block';
             usuarioModal.show();
         } catch (error) {
-            exibirAlerta(`Erro ao carregar dados do usuário: ${error.message}`, 'danger');
+            showToast(`Não foi possível carregar dados do usuário: ${error.message}`, 'danger');
         }
     };
 

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -244,7 +244,7 @@ async function verificarPermissaoAdmin() {
 
     // Passo 3: Se NÃO for a página de seleção, continue com a verificação de admin.
     if (!isAdmin()) {
-        alert('Acesso não autorizado');
+        showToast('Acesso não autorizado. Redirecionando...', 'warning');
         window.location.href = '/selecao-sistema.html'; // Redireciona para um local seguro
         return false;
     }
@@ -401,17 +401,20 @@ function showToast(mensagem, tipo = 'info') {
     }
 
     const toastId = `toast-${Date.now()}`;
+    const baseTextColor = tipo === 'warning' ? 'text-dark' : 'text-white';
     const bgColor =
         tipo === 'danger' ? 'bg-danger' :
-        (tipo === 'success' ? 'bg-success' : 'bg-primary');
+        (tipo === 'success' ? 'bg-success' :
+        (tipo === 'warning' ? 'bg-warning' : 'bg-primary'));
+    const closeBtnClass = tipo === 'warning' ? '' : 'btn-close-white';
 
     const toastHtml = `
-        <div id="${toastId}" class="toast text-white ${bgColor}" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="5000">
+        <div id="${toastId}" class="toast ${baseTextColor} ${bgColor}" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="5000">
             <div class="d-flex">
                 <div class="toast-body">
                     ${escapeHTML(mensagem)}
                 </div>
-                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+                <button type="button" class="btn-close ${closeBtnClass} me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
             </div>
         </div>`;
 
@@ -427,10 +430,7 @@ function showToast(mensagem, tipo = 'info') {
     toast.show();
 }
 
-// Alias para compatibilidade com código existente
-const exibirAlerta = showToast;
 window.showToast = showToast;
-window.exibirAlerta = exibirAlerta;
 
 /**
  * Retorna a classe CSS correspondente ao turno

--- a/src/static/js/laboratorios/agenda-diaria.js
+++ b/src/static/js/laboratorios/agenda-diaria.js
@@ -67,7 +67,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }).join('');
             }
         } catch (error) {
-            exibirAlerta('Erro ao carregar laboratórios.', 'danger');
+            showToast('Não foi possível carregar laboratórios.', 'danger');
         }
     };
 
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         } catch (error) {
             console.error("Erro detalhado ao carregar agenda:", error);
-            exibirAlerta('Erro ao carregar agenda diária.', 'danger');
+            showToast('Não foi possível carregar agenda diária.', 'danger');
             agendaContainer.innerHTML = '<p class="text-danger text-center">Não foi possível carregar os agendamentos.</p>';
         }
     };
@@ -198,7 +198,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             `;
             detalhesModal.show();
         } catch (error) {
-            exibirAlerta('Erro ao carregar detalhes da reserva', 'danger');
+            showToast('Não foi possível carregar detalhes da reserva', 'danger');
         }
     };
     
@@ -207,10 +207,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         try {
             await chamarAPI(`/agendamentos/${agendamentoParaExcluirId}`, 'DELETE');
-            exibirAlerta('Agendamento excluído com sucesso!', 'success');
+            showToast('Agendamento excluído com sucesso!', 'success');
             await carregarAgendaDiaria();
         } catch (error) {
-            exibirAlerta(`Erro ao excluir agendamento: ${error.message}`, 'danger');
+            showToast(`Não foi possível excluir agendamento: ${error.message}`, 'danger');
         } finally {
             agendamentoParaExcluirId = null;
             confirmacaoModal.hide();

--- a/src/static/js/laboratorios/calendario-labs.js
+++ b/src/static/js/laboratorios/calendario-labs.js
@@ -69,7 +69,7 @@ async function carregarLaboratoriosParaFiltro() {
             select.innerHTML += `<option value="${lab.nome}">${lab.nome}</option>`;
         });
     } catch (error) {
-        console.error('Erro ao carregar laboratórios:', error);
+        console.error('Não foi possível carregar laboratórios:', error);
     }
 }
 
@@ -109,8 +109,8 @@ async function aplicarFiltrosCalendario() {
         }
         
     } catch (error) {
-        console.error("Erro ao aplicar filtros e buscar resumo:", error);
-        exibirAlerta("Não foi possível carregar os dados do calendário.", "danger");
+        console.error("Não foi possível aplicar filtros e buscar resumo:", error);
+        showToast("Não foi possível carregar os dados do calendário.", "danger");
     } finally {
         if(loadingEl) loadingEl.style.display = 'none';
     }

--- a/src/static/js/perfil.js
+++ b/src/static/js/perfil.js
@@ -45,7 +45,7 @@ async function carregarDadosUsuario() {
         document.getElementById('userName').textContent = dadosUsuario.nome;
         
     } catch (error) {
-        exibirAlerta(`Erro ao carregar dados do usuário: ${error.message}`, 'danger');
+        showToast(`Não foi possível carregar dados do usuário: ${error.message}`, 'danger');
     }
 }
 
@@ -70,9 +70,9 @@ async function salvarDadosPerfil(e) {
             localStorage.setItem('usuario', JSON.stringify(usuario));
             
             document.getElementById('userName').textContent = dadosAtualizacao.nome;
-            exibirAlerta('Perfil atualizado com sucesso!', 'success');
+            showToast('Perfil atualizado com sucesso!', 'success');
         } catch (error) {
-            exibirAlerta(`Erro ao atualizar perfil: ${error.message}`, 'danger');
+            showToast(`Não foi possível atualizar perfil: ${error.message}`, 'danger');
             throw error;
         }
     });
@@ -88,7 +88,7 @@ async function salvarNovaSenha(e) {
         const confirmarSenha = document.getElementById('confirmarSenha').value;
         
         if (novaSenha !== confirmarSenha) {
-            exibirAlerta('As senhas não coincidem', 'warning');
+            showToast('As senhas não coincidem. Por favor, verifique.', 'warning');
             return;
         }
         
@@ -99,10 +99,10 @@ async function salvarNovaSenha(e) {
                 senha_atual: senhaAtual
             });
             
-            exibirAlerta('Senha alterada com sucesso!', 'success');
+            showToast('Senha alterada com sucesso!', 'success');
             e.target.reset();
         } catch (error) {
-            exibirAlerta(`Erro ao alterar senha: ${error.message}`, 'danger');
+            showToast(`Não foi possível alterar senha: ${error.message}`, 'danger');
             throw error;
         }
     });

--- a/src/static/js/rateio/config.js
+++ b/src/static/js/rateio/config.js
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 tableBody.appendChild(tr);
             });
         } catch (error) {
-            exibirAlerta(`Erro ao carregar configurações: ${error.message}`, 'danger');
+            showToast(`Não foi possível carregar configurações: ${error.message}`, 'danger');
         }
     }
 
@@ -98,15 +98,15 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             if (configEmEdicaoId) {
                 await chamarAPI(`/rateio-configs/${configEmEdicaoId}`, 'PUT', dados);
-                exibirAlerta('Configuração atualizada com sucesso!', 'success');
+                showToast('Configuração atualizada com sucesso!', 'success');
             } else {
                 await chamarAPI('/rateio-configs', 'POST', dados);
-                exibirAlerta('Configuração criada com sucesso!', 'success');
+                showToast('Configuração criada com sucesso!', 'success');
             }
             window.configModal.hide();
             carregarConfiguracoes();
         } catch (error) {
-            exibirAlerta(`Erro ao salvar: ${error.message}`, 'danger');
+            showToast(`Não foi possível salvar: ${error.message}`, 'danger');
         }
     });
 
@@ -133,10 +133,10 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!configParaExcluirId) return;
         try {
             await chamarAPI(`/rateio-configs/${configParaExcluirId}`, 'DELETE');
-            exibirAlerta('Configuração excluída com sucesso!', 'success');
+            showToast('Configuração excluída com sucesso!', 'success');
             carregarConfiguracoes();
         } catch (error) {
-            exibirAlerta(`Erro ao excluir: ${error.message}`, 'danger');
+            showToast(`Não foi possível excluir: ${error.message}`, 'danger');
         } finally {
             confirmacaoModal.hide();
             configParaExcluirId = null;

--- a/src/static/js/rateio/instrutores.js
+++ b/src/static/js/rateio/instrutores.js
@@ -62,7 +62,7 @@ class GerenciadorInstrutores {
                 select.appendChild(opt);
             });
         } catch (e) {
-            console.error('Erro ao carregar áreas', e);
+            console.error('Não foi possível carregar áreas', e);
         }
     }
 
@@ -101,7 +101,7 @@ class GerenciadorInstrutores {
             this.instrutores = dados;
             this.renderizarTabela();
         } catch (err) {
-            exibirAlerta('Erro ao carregar instrutores', 'danger');
+            showToast('Não foi possível carregar instrutores', 'danger');
         }
     }
 
@@ -155,7 +155,7 @@ class GerenciadorInstrutores {
             this.btnSalvar.querySelector('.btn-text').textContent = 'Atualizar';
             this.modalInstrutor.show();
         } catch (e) {
-            exibirAlerta('Erro ao carregar dados do instrutor', 'danger');
+            showToast('Não foi possível carregar dados do instrutor', 'danger');
         }
     }
 
@@ -177,7 +177,7 @@ class GerenciadorInstrutores {
     async salvarInstrutor() {
         const dados = this.coletarFormData();
         if (!dados.nome || !dados.email) {
-            exibirAlerta('Preencha nome e e-mail.', 'warning');
+            showToast('Preencha nome e e-mail.', 'warning');
             return;
         }
         const spinner = this.btnSalvar.querySelector('.spinner-border');
@@ -189,11 +189,11 @@ class GerenciadorInstrutores {
         const method = isEdicao ? 'PUT' : 'POST';
         try {
             await chamarAPI(endpoint, method, dados);
-            exibirAlerta(`Instrutor ${isEdicao ? 'atualizado' : 'cadastrado'} com sucesso!`, 'success');
+            showToast(`Instrutor ${isEdicao ? 'atualizado' : 'cadastrado'} com sucesso!`, 'success');
             this.modalInstrutor.hide();
             this.carregarInstrutores();
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(e.message, 'danger');
         } finally {
             this.btnSalvar.disabled = false;
             spinner.classList.add('d-none');
@@ -209,11 +209,11 @@ class GerenciadorInstrutores {
     async confirmarExclusao() {
         try {
             await chamarAPI(`/instrutores/${this.instrutorParaExcluir}`, 'DELETE');
-            exibirAlerta('Instrutor excluído com sucesso!', 'success');
+            showToast('Instrutor excluído com sucesso!', 'success');
             this.modalExcluir.hide();
             this.carregarInstrutores();
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(e.message, 'danger');
         }
     }
 }

--- a/src/static/js/rateio/lancamentos.js
+++ b/src/static/js/rateio/lancamentos.js
@@ -37,7 +37,7 @@ class LancamentosApp {
             this.selectInstrutor.innerHTML = '<option value="">Selecione</option>' +
                 instrutores.map(i => `<option value="${i.id}">${escapeHTML(i.nome)}</option>`).join('');
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(e.message, 'danger');
         }
     }
 
@@ -56,7 +56,7 @@ class LancamentosApp {
             this.selectConfig.innerHTML = '<option value="">Selecione</option>' +
                 configs.map(c => `<option value="${c.id}">${escapeHTML(c.classe_valor)}</option>`).join('');
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(e.message, 'danger');
         }
     }
 
@@ -68,7 +68,7 @@ class LancamentosApp {
             this.dadosAno = await chamarAPI(`/rateio/lancamentos-ano?instrutor_id=${instrutorId}&ano=${ano}`);
             this.renderizarGrid();
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(e.message, 'danger');
         }
     }
 
@@ -177,9 +177,9 @@ class LancamentosApp {
             this.dadosAno[mes] = atualizados;
             this.atualizarCard(mes);
             this.modal.hide();
-            exibirAlerta('Lançamentos salvos!', 'success');
+            showToast('Lançamentos salvos!', 'success');
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(e.message, 'danger');
         }
     }
 

--- a/src/static/js/treinamentos/admin.js
+++ b/src/static/js/treinamentos/admin.js
@@ -42,7 +42,7 @@ async function carregarCatalogo() {
             tbody.appendChild(tr);
         }
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }
 
@@ -67,7 +67,7 @@ async function salvarTreinamento() {
         bootstrap.Modal.getInstance(document.getElementById('treinamentoModal')).hide();
         carregarCatalogo();
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }
 
@@ -86,7 +86,7 @@ async function editarTreinamento(id) {
         document.getElementById('linksTrein').value = (t.links_materiais || []).join('\n');
         new bootstrap.Modal(document.getElementById('treinamentoModal')).show();
     } catch(e) {
-        exibirAlerta(`Erro ao carregar dados para edição: ${e.message}`, 'danger');
+        showToast(`Não foi possível carregar dados para edição: ${e.message}`, 'danger');
     }
 }
 
@@ -97,7 +97,7 @@ async function excluirTreinamento(id) {
         await chamarAPI(`/treinamentos/catalogo/${id}`, 'DELETE');
         carregarCatalogo();
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }
 
@@ -135,11 +135,11 @@ async function enviarInscricaoAdmin() {
 
         try {
             await chamarAPI(`/treinamentos/turmas/${turmaId}/inscricoes/admin`, 'POST', body);
-            exibirAlerta('Participante inscrito com sucesso!', 'success');
+            showToast('Participante inscrito com sucesso!', 'success');
             const modal = bootstrap.Modal.getInstance(document.getElementById('adminInscricaoModal'));
             modal.hide();
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(e.message, 'danger');
             throw e;
         }
     });
@@ -177,7 +177,7 @@ async function carregarTurmas() {
             tbody.appendChild(tr);
         }
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }
 
@@ -197,10 +197,10 @@ async function executarExclusao() {
 
     try {
         await chamarAPI(`/treinamentos/turmas/${turmaParaExcluirId}`, 'DELETE');
-        exibirAlerta('Turma excluída com sucesso!', 'success');
+        showToast('Turma excluída com sucesso!', 'success');
         carregarTurmas();
     } catch (e) {
-        exibirAlerta(`Erro ao excluir: ${e.message}`, 'danger');
+        showToast(`Não foi possível excluir: ${e.message}`, 'danger');
     } finally {
         if (modal) {
             modal.hide();
@@ -265,7 +265,7 @@ async function abrirModalTurma(id = null) {
             document.getElementById('horario').value = t.horario || '';
 
         } catch(e) {
-            exibirAlerta(`Erro ao carregar dados da turma: ${e.message}`, 'danger');
+            showToast(`Não foi possível carregar dados da turma: ${e.message}`, 'danger');
             return; // Não abre o modal se houver erro
         }
     } else {
@@ -300,7 +300,7 @@ async function salvarTurma() {
     };
 
     if (!body.treinamento_id || !body.data_inicio || !body.data_fim) {
-        exibirAlerta("Por favor, preencha todos os campos obrigatórios.", "warning");
+        showToast("Por favor, preencha todos os campos obrigatórios.", "warning");
         return;
     }
 
@@ -311,7 +311,7 @@ async function salvarTurma() {
         bootstrap.Modal.getInstance(document.getElementById('turmaModal')).hide();
         carregarTurmas();
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }
 
@@ -374,7 +374,7 @@ async function carregarDetalhesDaTurma(turmaId) {
         }
         return temPratica;
     } catch (e) {
-        exibirAlerta(`Erro ao carregar detalhes da turma: ${e.message}`, 'danger');
+        showToast(`Não foi possível carregar detalhes da turma: ${e.message}`, 'danger');
         return false;
     }
 }
@@ -437,7 +437,7 @@ async function carregarInscricoes(turmaId) {
             tbody.appendChild(tr);
         }
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }
 
@@ -452,14 +452,14 @@ function confirmarExclusaoParticipante(inscricaoId, nome) {
 async function executarExclusaoParticipante(inscricaoId) {
     try {
         await chamarAPI(`/treinamentos/inscricoes/${inscricaoId}`, 'DELETE');
-        exibirAlerta('Participante removido com sucesso!', 'success');
+        showToast('Participante removido com sucesso!', 'success');
 
         const linhaParaRemover = document.querySelector(`#inscricoesTableBody tr[data-id='${inscricaoId}']`);
         if (linhaParaRemover) {
             linhaParaRemover.remove();
         }
     } catch (e) {
-        exibirAlerta(`Erro ao remover participante: ${e.message}`, 'danger');
+        showToast(`Não foi possível remover participante: ${e.message}`, 'danger');
     }
 }
 
@@ -492,9 +492,9 @@ async function salvarAlteracoesInscricoes() {
 
         try {
             await Promise.all(promessas);
-            exibirAlerta('Todas as alterações foram salvas com sucesso!', 'success');
+            showToast('Todas as alterações foram salvas com sucesso!', 'success');
         } catch (e) {
-            console.error("Erro ao salvar alterações:", e);
+            console.error("Não foi possível salvar alterações:", e);
             throw e;
         }
     });
@@ -553,7 +553,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const handleExport = async (formato, btn) => {
             if (!turmaId) {
-                exibirAlerta('ID da turma não encontrado.', 'danger');
+                showToast('ID da turma não encontrado.', 'danger');
                 return;
             }
             const endpoint = `/treinamentos/turmas/${turmaId}/inscricoes/export`;

--- a/src/static/js/treinamentos/cursos.js
+++ b/src/static/js/treinamentos/cursos.js
@@ -202,7 +202,7 @@ async function carregarTreinamentos() {
         iniciarContadores();
 
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
         container.innerHTML = '<p class="text-center text-danger w-100">Falha ao carregar os cursos.</p>';
     }
 }
@@ -299,7 +299,7 @@ async function carregarMeusCursos() {
         renderizarGrupoCursos(grupos.concluidos, containers.concluidos, 'concluido', 'Concluído');
 
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
         Object.values(containers).forEach(c => c.innerHTML = '<p class="text-center text-danger">Falha ao carregar seus cursos.</p>');
     }
 }
@@ -455,13 +455,13 @@ async function enviarInscricaoPropria() {
     };
 
     if (!body.nome || !body.email || !body.cpf) {
-        exibirAlerta('Nome, Email e CPF são obrigatórios.', 'warning');
+        showToast('Nome, Email e CPF são obrigatórios.', 'warning');
         return;
     }
 
     try {
         await chamarAPI(`/treinamentos/${turmaId}/inscricoes`, 'POST', body);
-        exibirAlerta('Inscrição realizada com sucesso!', 'success');
+        showToast('Inscrição realizada com sucesso!', 'success');
         bootstrap.Modal.getInstance(document.getElementById('inscricaoModal')).hide();
         
         await carregarTreinamentos();
@@ -469,7 +469,7 @@ async function enviarInscricaoPropria() {
             carregarMeusCursos();
         }
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }
 
@@ -487,15 +487,15 @@ async function enviarInscricaoExterna() {
     };
 
     if (!body.nome || !body.email || !body.cpf) {
-        exibirAlerta('Nome, Email e CPF são obrigatórios.', 'warning');
+        showToast('Nome, Email e CPF são obrigatórios.', 'warning');
         return;
     }
 
     try {
         await chamarAPI(`/treinamentos/${turmaId}/inscricoes/externo`, 'POST', body);
-        exibirAlerta('Inscrição para o participante externo realizada com sucesso!', 'success');
+        showToast('Inscrição para o participante externo realizada com sucesso!', 'success');
         bootstrap.Modal.getInstance(document.getElementById('inscricaoModal')).hide();
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }

--- a/src/static/js/treinamentos/historico-passado.js
+++ b/src/static/js/treinamentos/historico-passado.js
@@ -34,6 +34,6 @@ async function carregarHistoricoPassado() {
             tbody.appendChild(tr);
         }
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }

--- a/src/static/js/treinamentos/historico-turmas.js
+++ b/src/static/js/treinamentos/historico-turmas.js
@@ -57,7 +57,7 @@ async function carregarHistorico() {
             tbody.appendChild(tr);
         }
     } catch (e) {
-        exibirAlerta(e.message, 'danger');
+        showToast(e.message, 'danger');
     }
 }
 
@@ -88,11 +88,11 @@ async function enviarInscricaoAdmin() {
 
         try {
             await chamarAPI(`/treinamentos/turmas/${turmaId}/inscricoes/admin`, 'POST', body);
-            exibirAlerta('Participante inscrito com sucesso!', 'success');
+            showToast('Participante inscrito com sucesso!', 'success');
             const modal = bootstrap.Modal.getInstance(document.getElementById('adminInscricaoModal'));
             modal.hide();
         } catch (e) {
-            exibirAlerta(e.message, 'danger');
+            showToast(e.message, 'danger');
             throw e;
         }
     });

--- a/src/static/laboratorios/agendamento.html
+++ b/src/static/laboratorios/agendamento.html
@@ -253,7 +253,7 @@
                 });
                 
                 if (horariosSelecionados.length === 0) {
-                    exibirAlerta('Selecione pelo menos um horário', 'warning');
+                    showToast('Selecione pelo menos um horário', 'warning');
                     return;
                 }
                 
@@ -280,11 +280,11 @@
                     if (modoEdicao) {
                         // Atualiza o agendamento existente
                         await chamarAPI(`/agendamentos/${agendamentoId}`, 'PUT', dadosAgendamento);
-                        exibirAlerta('Agendamento atualizado com sucesso!', 'success');
+                        showToast('Agendamento atualizado com sucesso!', 'success');
                     } else {
                         // Cria um novo agendamento
                         await chamarAPI('/agendamentos', 'POST', dadosAgendamento);
-                        exibirAlerta('Agendamento criado com sucesso!', 'success');
+                        showToast('Agendamento criado com sucesso!', 'success');
                         
                         // Limpa o formulário
                         document.getElementById('agendamentoForm').reset();
@@ -297,9 +297,9 @@
                     }, 2000);
                 } catch (error) {
                     if (error.message.includes('Conflito de horários')) {
-                        exibirAlerta('Existe um conflito de horários. Por favor, escolha outro horário ou data.', 'danger');
+                        showToast('Existe um conflito de horários. Por favor, escolha outro horário ou data.', 'danger');
                     } else {
-                        exibirAlerta(`Erro ao salvar agendamento: ${error.message}`, 'danger');
+                        showToast(`Não foi possível salvar agendamento: ${error.message}`, 'danger');
                     }
                 }
             });
@@ -335,8 +335,8 @@
                         });
                     }
                 } catch (error) {
-                    console.error('Erro ao carregar laboratórios:', error);
-                    exibirAlerta('Erro ao carregar laboratórios. Por favor, tente novamente.', 'danger');
+                    console.error('Não foi possível carregar laboratórios:', error);
+                    showToast('Não foi possível carregar laboratórios. Por favor, tente novamente.', 'danger');
                 }
             }
             
@@ -371,8 +371,8 @@
                         });
                     }
                 } catch (error) {
-                    console.error('Erro ao carregar turmas:', error);
-                    exibirAlerta('Erro ao carregar turmas. Por favor, tente novamente.', 'danger');
+                    console.error('Não foi possível carregar turmas:', error);
+                    showToast('Não foi possível carregar turmas. Por favor, tente novamente.', 'danger');
                 }
             }
             
@@ -413,9 +413,9 @@
                         horariosInfo.textContent = 'Todos os horários estão disponíveis.';
                     }
                 } catch (error) {
-                    console.error('Erro ao verificar disponibilidade:', error);
-                    horariosInfo.textContent = 'Erro ao verificar disponibilidade. Por favor, tente novamente.';
-                    exibirAlerta('Erro ao verificar disponibilidade de horários.', 'danger');
+                    console.error('Não foi possível verificar disponibilidade:', error);
+                    horariosInfo.textContent = 'Não foi possível verificar disponibilidade. Por favor, tente novamente.';
+                    showToast('Não foi possível verificar disponibilidade de horários.', 'danger');
                 }
             }
             
@@ -489,7 +489,7 @@
                         selectUsuario.appendChild(option);
                     });
                 } catch (error) {
-                    console.error('Erro ao carregar usuários:', error);
+                    console.error('Não foi possível carregar usuários:', error);
                 }
             }
             
@@ -533,7 +533,7 @@
                         }
                     }, 500);
                 } catch (error) {
-                    exibirAlerta(`Erro ao carregar agendamento: ${error.message}`, 'danger');
+                    showToast(`Não foi possível carregar agendamento: ${error.message}`, 'danger');
                 }
             }
         });
@@ -569,8 +569,5 @@
     setTimeout(preencherCampos, 500);
 });
 </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/laboratorios/dashboard.html
+++ b/src/static/laboratorios/dashboard.html
@@ -219,8 +219,5 @@
             }
         });
     </script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/laboratorios/perfil.html
+++ b/src/static/laboratorios/perfil.html
@@ -236,9 +236,9 @@
                     // Atualiza o nome na navbar
                     document.getElementById('userName').textContent = dadosAtualizacao.nome;
                     
-                    exibirAlerta('Perfil atualizado com sucesso!', 'success');
+                    showToast('Perfil atualizado com sucesso!', 'success');
                 } catch (error) {
-                    exibirAlerta(`Erro ao atualizar perfil: ${error.message}`, 'danger');
+                    showToast(`Não foi possível atualizar perfil: ${error.message}`, 'danger');
                 }
             });
             
@@ -252,7 +252,7 @@
                 
                 // Validação básica
                 if (novaSenha !== confirmarSenha) {
-                    exibirAlerta('As senhas não coincidem', 'warning');
+                    showToast('As senhas não coincidem. Por favor, verifique.', 'warning');
                     return;
                 }
                 
@@ -264,12 +264,12 @@
                         senha_atual: senhaAtual
                     });
                     
-                    exibirAlerta('Senha alterada com sucesso!', 'success');
+                    showToast('Senha alterada com sucesso!', 'success');
                     
                     // Limpa o formulário
                     document.getElementById('senhaForm').reset();
                 } catch (error) {
-                    exibirAlerta(`Erro ao alterar senha: ${error.message}`, 'danger');
+                    showToast(`Não foi possível alterar senha: ${error.message}`, 'danger');
                 }
             });
         });
@@ -299,7 +299,7 @@
                 // Exibe a data de criação
                 document.getElementById('membroDesde').textContent = formatarData(dadosUsuario.data_criacao);
             } catch (error) {
-                exibirAlerta(`Erro ao carregar dados do usuário: ${error.message}`, 'danger');
+                showToast(`Não foi possível carregar dados do usuário: ${error.message}`, 'danger');
             }
         }
         
@@ -309,12 +309,9 @@
                 const agendamentos = await chamarAPI('/agendamentos');
                 document.getElementById('totalAgendamentos').textContent = agendamentos.length;
             } catch (error) {
-                console.error('Erro ao carregar estatísticas:', error);
+                console.error('Não foi possível carregar estatísticas:', error);
             }
         }
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/laboratorios/turmas.html
+++ b/src/static/laboratorios/turmas.html
@@ -341,8 +341,8 @@
                     tableBody.innerHTML = html;
                 } catch (error) {
                     document.getElementById('laboratoriosTableBody').innerHTML = 
-                        '<tr><td colspan="4" class="text-center text-danger">Erro ao carregar laboratórios.</td></tr>';
-                    console.error('Erro ao carregar laboratórios:', error);
+                        '<tr><td colspan="4" class="text-center text-danger">Não foi possível carregar laboratórios.</td></tr>';
+                    console.error('Não foi possível carregar laboratórios:', error);
                 }
             }
             
@@ -379,8 +379,8 @@
                     tableBody.innerHTML = html;
                 } catch (error) {
                     document.getElementById('turmasTableBody').innerHTML = 
-                        '<tr><td colspan="4" class="text-center text-danger">Erro ao carregar turmas.</td></tr>';
-                    console.error('Erro ao carregar turmas:', error);
+                        '<tr><td colspan="4" class="text-center text-danger">Não foi possível carregar turmas.</td></tr>';
+                    console.error('Não foi possível carregar turmas:', error);
                 }
             }
             
@@ -391,7 +391,7 @@
                 const classeIcone = document.getElementById('classeIconeLaboratorio').value;
                 
                 if (!nome) {
-                    exibirAlerta('O nome do laboratório é obrigatório.', 'danger');
+                    showToast('O nome do laboratório é obrigatório.', 'danger');
                     return;
                 }
                 
@@ -399,11 +399,11 @@
                     if (id) {
                         // Atualização
                         await chamarAPI(`/laboratorios/${id}`, 'PUT', { nome, classe_icone: classeIcone });
-                        exibirAlerta('Laboratório atualizado com sucesso!', 'success');
+                        showToast('Laboratório atualizado com sucesso!', 'success');
                     } else {
                         // Criação
                         await chamarAPI('/laboratorios', 'POST', { nome, classe_icone: classeIcone });
-                        exibirAlerta('Laboratório cadastrado com sucesso!', 'success');
+                        showToast('Laboratório cadastrado com sucesso!', 'success');
                     }
                     
                     // Limpa o formulário e recarrega a lista
@@ -413,7 +413,7 @@
                     laboratorioModal.hide();
                     carregarLaboratorios();
                 } catch (error) {
-                    exibirAlerta(`Erro ao salvar laboratório: ${error.message}`, 'danger');
+                    showToast(`Não foi possível salvar laboratório: ${error.message}`, 'danger');
                 }
             }
             
@@ -423,7 +423,7 @@
                 const nome = document.getElementById('nomeTurma').value;
                 
                 if (!nome) {
-                    exibirAlerta('O nome da turma é obrigatório.', 'danger');
+                    showToast('O nome da turma é obrigatório.', 'danger');
                     return;
                 }
                 
@@ -431,11 +431,11 @@
                     if (id) {
                         // Atualização
                         await chamarAPI(`/turmas/${id}`, 'PUT', { nome });
-                        exibirAlerta('Turma atualizada com sucesso!', 'success');
+                        showToast('Turma atualizada com sucesso!', 'success');
                     } else {
                         // Criação
                         await chamarAPI('/turmas', 'POST', { nome });
-                        exibirAlerta('Turma cadastrada com sucesso!', 'success');
+                        showToast('Turma cadastrada com sucesso!', 'success');
                     }
                     
                     // Limpa o formulário e recarrega a lista
@@ -445,7 +445,7 @@
                     turmaModal.hide();
                     carregarTurmas();
                 } catch (error) {
-                    exibirAlerta(`Erro ao salvar turma: ${error.message}`, 'danger');
+                    showToast(`Não foi possível salvar turma: ${error.message}`, 'danger');
                 }
             }
             
@@ -488,10 +488,10 @@
             async function excluirLaboratorio(id) {
                 try {
                     await chamarAPI(`/laboratorios/${id}`, 'DELETE');
-                    exibirAlerta('Laboratório excluído com sucesso!', 'success');
+                    showToast('Laboratório excluído com sucesso!', 'success');
                     carregarLaboratorios();
                 } catch (error) {
-                    exibirAlerta(`Erro ao excluir laboratório: ${error.message}`, 'danger');
+                    showToast(`Não foi possível excluir laboratório: ${error.message}`, 'danger');
                 }
             }
             
@@ -499,10 +499,10 @@
             async function excluirTurma(id) {
                 try {
                     await chamarAPI(`/turmas/${id}`, 'DELETE');
-                    exibirAlerta('Turma excluída com sucesso!', 'success');
+                    showToast('Turma excluída com sucesso!', 'success');
                     carregarTurmas();
                 } catch (error) {
-                    exibirAlerta(`Erro ao excluir turma: ${error.message}`, 'danger');
+                    showToast(`Não foi possível excluir turma: ${error.message}`, 'danger');
                 }
             }
 
@@ -524,8 +524,5 @@
             }
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/ocupacao/agendamento.html
+++ b/src/static/ocupacao/agendamento.html
@@ -231,9 +231,6 @@
             }
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/ocupacao/calendario.html
+++ b/src/static/ocupacao/calendario.html
@@ -302,9 +302,6 @@
             aplicarFiltrosURL();
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/ocupacao/dashboard.html
+++ b/src/static/ocupacao/dashboard.html
@@ -351,9 +351,6 @@
             carregarTendenciaMensal();
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/ocupacao/instrutores.html
+++ b/src/static/ocupacao/instrutores.html
@@ -276,9 +276,6 @@
             }
         });
     </script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/ocupacao/perfil.html
+++ b/src/static/ocupacao/perfil.html
@@ -253,9 +253,9 @@
                     // Atualiza o nome na navbar
                     document.getElementById('userName').textContent = dadosAtualizacao.nome;
                     
-                    exibirAlerta('Perfil atualizado com sucesso!', 'success');
+                    showToast('Perfil atualizado com sucesso!', 'success');
                 } catch (error) {
-                    exibirAlerta(`Erro ao atualizar perfil: ${error.message}`, 'danger');
+                    showToast(`Não foi possível atualizar perfil: ${error.message}`, 'danger');
                 }
             });
             
@@ -269,7 +269,7 @@
                 
                 // Validação básica
                 if (novaSenha !== confirmarSenha) {
-                    exibirAlerta('As senhas não coincidem', 'warning');
+                    showToast('As senhas não coincidem. Por favor, verifique.', 'warning');
                     return;
                 }
                 
@@ -281,12 +281,12 @@
                         senha_atual: senhaAtual
                     });
                     
-                    exibirAlerta('Senha alterada com sucesso!', 'success');
+                    showToast('Senha alterada com sucesso!', 'success');
                     
                     // Limpa o formulário
                     document.getElementById('senhaForm').reset();
                 } catch (error) {
-                    exibirAlerta(`Erro ao alterar senha: ${error.message}`, 'danger');
+                    showToast(`Não foi possível alterar senha: ${error.message}`, 'danger');
                 }
             });
         });
@@ -316,7 +316,7 @@
                 // Exibe a data de criação
                 document.getElementById('membroDesde').textContent = formatarData(dadosUsuario.data_criacao);
             } catch (error) {
-                exibirAlerta(`Erro ao carregar dados do usuário: ${error.message}`, 'danger');
+                showToast(`Não foi possível carregar dados do usuário: ${error.message}`, 'danger');
             }
         }
         
@@ -326,7 +326,7 @@
                 const agendamentos = await chamarAPI('/agendamentos');
                 document.getElementById('totalAgendamentos').textContent = agendamentos.length;
             } catch (error) {
-                console.error('Erro ao carregar estatísticas:', error);
+                console.error('Não foi possível carregar estatísticas:', error);
             }
         }
     </script>
@@ -337,8 +337,5 @@
             }
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/ocupacao/salas.html
+++ b/src/static/ocupacao/salas.html
@@ -316,9 +316,6 @@
             }
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/ocupacao/turmas.html
+++ b/src/static/ocupacao/turmas.html
@@ -234,8 +234,5 @@
             }
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/rateio/config.html
+++ b/src/static/rateio/config.html
@@ -152,10 +152,6 @@
         </div>
     </div>
 
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
-
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/rateio/config.js"></script>

--- a/src/static/rateio/instrutores.html
+++ b/src/static/rateio/instrutores.html
@@ -239,9 +239,6 @@
             }
         });
     </script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/rateio/perfil.html
+++ b/src/static/rateio/perfil.html
@@ -222,9 +222,9 @@
                     // Atualiza o nome na navbar
                     document.getElementById('userName').textContent = dadosAtualizacao.nome;
                     
-                    exibirAlerta('Perfil atualizado com sucesso!', 'success');
+                    showToast('Perfil atualizado com sucesso!', 'success');
                 } catch (error) {
-                    exibirAlerta(`Erro ao atualizar perfil: ${error.message}`, 'danger');
+                    showToast(`Não foi possível atualizar perfil: ${error.message}`, 'danger');
                 }
             });
             
@@ -238,7 +238,7 @@
                 
                 // Validação básica
                 if (novaSenha !== confirmarSenha) {
-                    exibirAlerta('As senhas não coincidem', 'warning');
+                    showToast('As senhas não coincidem. Por favor, verifique.', 'warning');
                     return;
                 }
                 
@@ -250,12 +250,12 @@
                         senha_atual: senhaAtual
                     });
                     
-                    exibirAlerta('Senha alterada com sucesso!', 'success');
+                    showToast('Senha alterada com sucesso!', 'success');
                     
                     // Limpa o formulário
                     document.getElementById('senhaForm').reset();
                 } catch (error) {
-                    exibirAlerta(`Erro ao alterar senha: ${error.message}`, 'danger');
+                    showToast(`Não foi possível alterar senha: ${error.message}`, 'danger');
                 }
             });
         });
@@ -285,7 +285,7 @@
                 // Exibe a data de criação
                 document.getElementById('membroDesde').textContent = formatarData(dadosUsuario.data_criacao);
             } catch (error) {
-                exibirAlerta(`Erro ao carregar dados do usuário: ${error.message}`, 'danger');
+                showToast(`Não foi possível carregar dados do usuário: ${error.message}`, 'danger');
             }
         }
         
@@ -295,7 +295,7 @@
                 const agendamentos = await chamarAPI('/agendamentos');
                 document.getElementById('totalAgendamentos').textContent = agendamentos.length;
             } catch (error) {
-                console.error('Erro ao carregar estatísticas:', error);
+                console.error('Não foi possível carregar estatísticas:', error);
             }
         }
     </script>
@@ -306,8 +306,5 @@
             }
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/register.html
+++ b/src/static/register.html
@@ -113,20 +113,17 @@
 
                 if (!senhaRegex.test(senha)) {
                     e.preventDefault();
-                    exibirAlerta('A senha não atende aos requisitos de complexidade.', 'danger');
+                    showToast('A senha não atende aos requisitos de complexidade. Por favor, tente novamente.', 'danger');
                     return;
                 }
 
                 if (senha !== confirmarSenha) {
                     e.preventDefault();
-                    exibirAlerta('As senhas não coincidem. Por favor, tente novamente.', 'danger');
+                    showToast('As senhas não coincidem. Por favor, verifique e tente novamente.', 'danger');
                 }
             });
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -157,8 +157,5 @@
             });
         });
     </script>
-<div aria-live="polite" aria-atomic="true" class="position-relative">
-    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-</div>
 </body>
 </html>

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -173,9 +173,6 @@
             }
         });
     </script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-historico-passado.html
+++ b/src/static/treinamentos/admin-historico-passado.html
@@ -230,9 +230,6 @@
             </div>
         </div>
     </div>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-historico-turmas.html
+++ b/src/static/treinamentos/admin-historico-turmas.html
@@ -230,9 +230,6 @@
             </div>
         </div>
     </div>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -251,9 +251,6 @@
             }
         });
     </script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-logs.html
+++ b/src/static/treinamentos/admin-logs.html
@@ -104,9 +104,6 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/treinamentos/logs.js"></script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -238,9 +238,6 @@
             </div>
         </div>
     </div>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -165,9 +165,6 @@
             }
         });
     </script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -155,9 +155,6 @@
             }
         });
     </script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/perfil.html
+++ b/src/static/treinamentos/perfil.html
@@ -103,9 +103,6 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/perfil.js"></script>
-    <div aria-live="polite" aria-atomic="true" class="position-relative">
-        <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1100"></div>
-    </div>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>


### PR DESCRIPTION
## Summary
- switch to Bootstrap toasts for all notifications
- drop inline toast containers from templates and polish message tone

## Testing
- `pre-commit run --files $(git diff --name-only)`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987648a0488323abc00bd25468517a