### PR TITLE
feat: unificar notificações com toasts

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -244,7 +244,7 @@ async function verificarPermissaoAdmin() {
 
     // Passo 3: Se NÃO for a página de seleção, continue com a verificação de admin.
     if (!isAdmin()) {
-        showToast('Acesso não autorizado. Redirecionando...', 'warning');
+        showToast('Desculpe, você não tem permissão para acessar esta página. Vamos redirecioná-lo(a).', 'warning');
         window.location.href = '/selecao-sistema.html'; // Redireciona para um local seguro
         return false;
     }
@@ -385,20 +385,27 @@ function formatarHorario(horario) {
 }
 
 /**
+ * Garante a existência de um container global para toasts
+ * @returns {HTMLElement} - Elemento container
+ */
+function criarToastContainer() {
+    let container = document.querySelector('.toast-container');
+    if (!container) {
+        container = document.createElement('div');
+        container.className = 'toast-container position-fixed bottom-0 end-0 p-3';
+        container.style.zIndex = 1100;
+        document.body.appendChild(container);
+    }
+    return container;
+}
+
+/**
  * Exibe uma mensagem usando toasts do Bootstrap
  * @param {string} mensagem - Mensagem a ser exibida
  * @param {string} tipo - Tipo do toast (success, danger, warning, info)
  */
 function showToast(mensagem, tipo = 'info') {
-    let toastContainer = document.querySelector('.toast-container');
-
-    // Garante que o container exista
-    if (!toastContainer) {
-        toastContainer = document.createElement('div');
-        toastContainer.className = 'toast-container position-fixed bottom-0 end-0 p-3';
-        toastContainer.style.zIndex = 1100;
-        document.body.appendChild(toastContainer);
-    }
+    const toastContainer = criarToastContainer();
 
     const toastId = `toast-${Date.now()}`;
     const baseTextColor = tipo === 'warning' ? 'text-dark' : 'text-white';
@@ -431,6 +438,7 @@ function showToast(mensagem, tipo = 'info') {
 }
 
 window.showToast = showToast;
+document.addEventListener('DOMContentLoaded', criarToastContainer);
 
 /**
  * Retorna a classe CSS correspondente ao turno
@@ -840,7 +848,7 @@ async function carregarNotificacoes() {
                     // Recarrega as notificações
                     carregarNotificacoes();
                 } catch (error) {
-                    showToast('Não foi possível marcar a notificação como lida.', 'danger');
+                    showToast('Não conseguimos marcar a notificação como lida.', 'danger');
                 }
             });
         });
@@ -895,7 +903,7 @@ async function exportarDados(endpoint, formato, nomeArquivo) {
         window.URL.revokeObjectURL(url);
     } catch (error) {
         console.error('Erro ao exportar dados:', error);
-        showToast('Não foi possível exportar os dados.', 'danger');
+        showToast('Não conseguimos exportar os dados.', 'danger');
     }
 }
 

--- a/src/static/js/ocupacao/dashboard.js
+++ b/src/static/js/ocupacao/dashboard.js
@@ -52,6 +52,7 @@ async function carregarIndicadoresMensais() {
         preencher('Seguinte', seguinte, 'linkMesSeguinte');
     } catch (error) {
         console.error('Erro ao carregar indicadores mensais:', error);
+        showToast('Não conseguimos carregar os indicadores. Tente novamente mais tarde.', 'danger');
     }
 }
 
@@ -107,6 +108,7 @@ async function carregarEstatisticasGerais() {
         
     } catch (error) {
         console.error('Erro ao carregar estatísticas gerais:', error);
+        showToast('Não conseguimos carregar as estatísticas. Tente novamente.', 'danger');
     }
 }
 
@@ -137,6 +139,7 @@ async function carregarProximasOcupacoes() {
         }
     } catch (error) {
         console.error('Erro ao carregar próximas ocupações:', error);
+        showToast('Não conseguimos carregar as próximas ocupações. Tente novamente.', 'danger');
     } finally {
         document.getElementById('loadingProximasOcupacoes').style.display = 'none';
     }
@@ -223,6 +226,7 @@ async function carregarRelatorioMensal() {
         }
     } catch (error) {
         console.error('Erro ao carregar relatório mensal:', error);
+        showToast('Não conseguimos carregar o relatório mensal. Tente novamente.', 'danger');
     } finally {
         document.getElementById('loadingSalasMaisUtilizadas').style.display = 'none';
         document.getElementById('loadingOcupacoesPorTipo').style.display = 'none';
@@ -250,6 +254,7 @@ async function carregarDadosBasicos(dataInicio, dataFim) {
         }
     } catch (error) {
         console.error('Erro ao carregar dados básicos:', error);
+        showToast('Não conseguimos carregar os dados solicitados.', 'danger');
     }
 }
 
@@ -477,6 +482,7 @@ async function carregarTendenciaMensal() {
         }
     } catch (error) {
         console.error('Erro ao carregar tendência mensal:', error);
+        showToast('Não conseguimos carregar a tendência mensal. Tente novamente.', 'danger');
     }
 }
 

--- a/src/static/js/ocupacao/salas.js
+++ b/src/static/js/ocupacao/salas.js
@@ -105,7 +105,7 @@ class GerenciadorSalas {
         }
     } catch (error) {
         console.error('Erro ao carregar salas:', error);
-        let mensagem = 'Erro ao carregar salas.';
+        let mensagem = 'Não conseguimos carregar as salas.';
         if (error.message.includes('Failed to fetch')) {
             mensagem += ' Verifique sua conexão e tente novamente.';
         } else {
@@ -273,12 +273,12 @@ class GerenciadorSalas {
         
         // Validações
         if (!formData.nome) {
-            showToast('Por favor, informe o nome da sala.', 'warning');
+            showToast('Informe o nome da sala para continuar.', 'warning');
             return;
         }
         
         if (!formData.capacidade || formData.capacidade <= 0) {
-            showToast('A capacidade deve ser um número maior que zero.', 'warning');
+            showToast('A capacidade precisa ser um número maior que zero.', 'warning');
             return;
         }
         
@@ -332,7 +332,7 @@ class GerenciadorSalas {
         }
     } catch (error) {
         console.error('Erro ao salvar sala:', error);
-        showToast(`Não foi possível salvar a sala: ${error.message}`, 'danger');
+            showToast(`Não conseguimos salvar a sala: ${error.message}`, 'danger');
     } finally {
         if (btn && spinner) {
             btn.disabled = false;
@@ -377,7 +377,7 @@ class GerenciadorSalas {
         }
     } catch (error) {
         console.error('Erro ao excluir sala:', error);
-        showToast(`Não foi possível excluir a sala: ${error.message}`, 'danger');
+        showToast(`Não conseguimos excluir a sala: ${error.message}`, 'danger');
     }
 }
 

--- a/src/static/ocupacao/agendamento.html
+++ b/src/static/ocupacao/agendamento.html
@@ -236,6 +236,7 @@
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
     </div>
 </footer>
+<div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
 </body>
 </html>
 

--- a/src/static/ocupacao/calendario.html
+++ b/src/static/ocupacao/calendario.html
@@ -307,6 +307,7 @@
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
     </div>
 </footer>
+<div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
 </body>
 </html>
 

--- a/src/static/ocupacao/dashboard.html
+++ b/src/static/ocupacao/dashboard.html
@@ -356,6 +356,7 @@
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
     </div>
 </footer>
+<div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
 </body>
 </html>
 

--- a/src/static/ocupacao/instrutores.html
+++ b/src/static/ocupacao/instrutores.html
@@ -281,5 +281,6 @@
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
     </div>
 </footer>
+<div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
 </body>
 </html>

--- a/src/static/ocupacao/perfil.html
+++ b/src/static/ocupacao/perfil.html
@@ -255,7 +255,7 @@
                     
                     showToast('Perfil atualizado com sucesso!', 'success');
                 } catch (error) {
-                    showToast(`Não foi possível atualizar perfil: ${error.message}`, 'danger');
+                    showToast(`Não conseguimos atualizar o perfil: ${error.message}`, 'danger');
                 }
             });
             
@@ -269,7 +269,7 @@
                 
                 // Validação básica
                 if (novaSenha !== confirmarSenha) {
-                    showToast('As senhas não coincidem. Por favor, verifique.', 'warning');
+                    showToast('As senhas não coincidem. Confira e tente novamente.', 'warning');
                     return;
                 }
                 
@@ -282,11 +282,11 @@
                     });
                     
                     showToast('Senha alterada com sucesso!', 'success');
-                    
+
                     // Limpa o formulário
                     document.getElementById('senhaForm').reset();
                 } catch (error) {
-                    showToast(`Não foi possível alterar senha: ${error.message}`, 'danger');
+                    showToast(`Não conseguimos alterar a senha: ${error.message}`, 'danger');
                 }
             });
         });
@@ -316,7 +316,7 @@
                 // Exibe a data de criação
                 document.getElementById('membroDesde').textContent = formatarData(dadosUsuario.data_criacao);
             } catch (error) {
-                showToast(`Não foi possível carregar dados do usuário: ${error.message}`, 'danger');
+                showToast(`Não conseguimos carregar os dados do usuário: ${error.message}`, 'danger');
             }
         }
         
@@ -337,5 +337,6 @@
             }
         });
     </script>
+    <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
 </body>
 </html>

--- a/src/static/ocupacao/salas.html
+++ b/src/static/ocupacao/salas.html
@@ -292,7 +292,7 @@
             // Verifica se é administrador
             const usuario = getUsuarioLogado();
             if (!isAdmin()) {
-                showToast('Acesso negado. Somente administradores podem gerenciar salas.', 'danger');
+                showToast('Desculpe, apenas administradores podem gerenciar salas.', 'danger');
                 window.location.href = '/ocupacao/dashboard.html';
                 return;
             }
@@ -308,8 +308,8 @@
             const modalElem = document.getElementById('modalSala');
             modalElem.addEventListener('hidden.bs.modal', novaSala);
         });
-    </script>
-    <script>
+</script>
+<script>
         document.addEventListener('DOMContentLoaded', () => {
             if (!isUserAdmin()) {
                 document.body.classList.add('read-only');
@@ -321,6 +321,7 @@
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
     </div>
 </footer>
+<div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
 </body>
 </html>
 

--- a/src/static/ocupacao/turmas.html
+++ b/src/static/ocupacao/turmas.html
@@ -234,5 +234,6 @@
             }
         });
     </script>
+    <div class="toast-container position-fixed bottom-0 end-0 p-3"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize toast container and helper
- adopt toasts in ocupação dashboard and salas modules
- add toast container to ocupação templates and refine message tone

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68987be75ec48323806a3445e00e4dac