### PR TITLE
Normalize heading hierarchy in static pages

### DIFF
--- a/src/static/admin/login.html
+++ b/src/static/admin/login.html
@@ -15,7 +15,7 @@
             <div class="col-md-6 login-branding-col d-none d-md-flex align-items-center justify-content-center">
                 <div class="text-center text-white">
                     <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 150px; margin-bottom: 2rem;">
-                    <h1 class="display-4 fw-bold">Conecta SENAI</h1>
+                    <h2 class="display-4 fw-bold">Conecta SENAI</h2>
                     <p class="lead">A sua plataforma integrada de gestão e agendamentos.</p>
                 </div>
             </div>
@@ -25,7 +25,7 @@
                     <div class="text-center mb-5 d-md-none">
                         <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 120px;">
                     </div>
-                    <h2 class="h3 mb-3 fw-normal">Acesse sua conta</h2>
+                    <h1 class="h3 mb-3 fw-normal">Acesse sua conta</h1>
                     <p class="text-muted mb-4">Bem-vindo de volta! Por favor, insira as suas credenciais.</p>
                     
                     

--- a/src/static/admin/perfil.html
+++ b/src/static/admin/perfil.html
@@ -57,7 +57,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/admin/usuarios.html">
                             <i class="bi bi-people-fill"></i> Lista de Usuários
@@ -70,14 +70,14 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4">Meu Perfil</h2>
+                <h1 class="mb-4">Meu Perfil</h1>
                 
                 
                 <div class="row">
                     <div class="col-md-8">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Informações Pessoais</h5>
+                                <h2 class="card-title mb-0">Informações Pessoais</h2>
                             </div>
                             <div class="card-body">
                                 <form id="perfilForm">
@@ -123,7 +123,7 @@
                     <div class="col-md-4">
                         <div class="card mb-4">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Alterar Senha</h5>
+                                <h2 class="card-title mb-0">Alterar Senha</h2>
                             </div>
                             <div class="card-body">
                                 <form id="senhaForm">
@@ -151,11 +151,11 @@
                         
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Estatísticas</h5>
+                                <h2 class="card-title mb-0">Estatísticas</h2>
                             </div>
                             <div class="card-body">
                                 <div class="mb-3">
-                                    <h6>Membro desde</h6>
+                                    <h3>Membro desde</h3>
                                     <p id="membroDesde" class="h4">-</p>
                                 </div>
                             </div>

--- a/src/static/admin/usuarios.html
+++ b/src/static/admin/usuarios.html
@@ -57,7 +57,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link active" href="/admin/usuarios.html">
                             <i class="bi bi-people-fill"></i> Lista de Usuários
@@ -71,7 +71,7 @@
 
             <main class="col-lg-9 col-md-12">
                     <div class="d-flex justify-content-between align-items-center mb-4">
-                        <h2 class="mb-0">Gerenciamento de Usuários</h2>
+                        <h1 class="mb-0">Gerenciamento de Usuários</h1>
                         <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#usuarioModal">
                             <i class="bi bi-person-plus me-2"></i>Novo Usuário
                         </button>
@@ -79,7 +79,7 @@
 
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
                     </div>
                     <div class="card-body">
                     </div>
@@ -87,7 +87,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Usuários</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Usuários</h2>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -131,7 +131,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="usuarioModalLabel">Novo Usuário</h5>
+                    <h2 class="modal-title" id="usuarioModalLabel">Novo Usuário</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body">
@@ -177,7 +177,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/laboratorios/agendamento.html
+++ b/src/static/laboratorios/agendamento.html
@@ -68,7 +68,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/laboratorios/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -93,7 +93,7 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <h2 id="pageTitle" class="mb-4">Novo Agendamento</h2>
+                <h1 id="pageTitle" class="mb-4">Novo Agendamento</h1>
                 
                 
                 <div class="card">

--- a/src/static/laboratorios/calendario.html
+++ b/src/static/laboratorios/calendario.html
@@ -48,7 +48,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/laboratorios/dashboard.html"><i class="bi bi-speedometer2"></i> Dashboard</a>
                         <a class="nav-link active" href="/laboratorios/calendario.html"><i class="bi bi-calendar3"></i> Calendário</a>
@@ -66,15 +66,15 @@
                 </div>
                 
                 <div id="agenda-content" class="d-none">
-                    <h2 class="mb-4" style="text-transform: none;">Agenda Diária de Laboratórios</h2>
+                    <h1 class="mb-4" style="text-transform: none;">Agenda Diária de Laboratórios</h1>
                     <div class="card mb-4"><div class="card-body">
-                        <h6 class="card-subtitle mb-2 text-muted">Selecione um Laboratório</h6>
+                        <h2 class="card-subtitle mb-2 text-muted">Selecione um Laboratório</h2>
                         <div id="seletor-laboratorios" class="d-flex flex-wrap gap-2"></div>
                     </div></div>
                     <div id="agenda-view" class="row">
                         <div class="col-lg-4">
                             <div id="data-destaque" class="text-center mb-3 p-3">
-                                <h1 id="dia-destaque" class="display-1 fw-bold text-primary"></h1>
+                                <p id="dia-destaque" class="display-1 fw-bold text-primary"></p>
                                 <p id="data-extenso-destaque" class="lead"></p>
                             </div>
                             <div class="card"><div class="card-body" id="mini-calendario"></div></div>
@@ -85,7 +85,7 @@
 
                 <div id="empty-state-container" class="text-center p-5 border rounded bg-light d-none">
                     <i class="bi bi-box-seam" style="font-size: 4rem; color: var(--muted-color);"></i>
-                    <h4 class="mt-3">Nenhum Laboratório Cadastrado</h4>
+                    <h2 class="mt-3">Nenhum Laboratório Cadastrado</h2>
                     <p class="text-muted">Para começar a usar a agenda diária, você precisa de cadastrar pelo menos um laboratório.</p>
                     <a href="/laboratorios/turmas.html" class="btn btn-primary mt-3"><i class="bi bi-plus-lg"></i> Cadastrar Primeiro Laboratório</a>
                 </div>
@@ -97,7 +97,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="detalhesReservaLabel">Detalhes da Reserva</h5>
+                    <h2 class="modal-title" id="detalhesReservaLabel">Detalhes da Reserva</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body" id="detalhesReservaContent"></div>
@@ -112,7 +112,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="confirmarExclusaoModalLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="confirmarExclusaoModalLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/laboratorios/dashboard.html
+++ b/src/static/laboratorios/dashboard.html
@@ -68,7 +68,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link active" href="/laboratorios/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -105,25 +105,25 @@
                 <div class="row mb-4">
             <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
                 <div class="card-body"><div class="d-flex justify-content-between align-items-center">
-                    <div><h6 class="kpi-title" style="text-transform: none;">Laboratórios Ativos</h6><h2 class="kpi-number" id="totalLabsAtivos">-</h2></div>
+                    <div><h2 class="kpi-title" style="text-transform: none;">Laboratórios Ativos</h2><h2 class="kpi-number" id="totalLabsAtivos">-</h2></div>
                     <i class="bi bi-display kpi-icon"></i>
                 </div></div>
             </div></div>
             <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
                 <div class="card-body"><div class="d-flex justify-content-between align-items-center">
-                    <div><h6 class="kpi-title" style="text-transform: none;">Turmas Ativas</h6><h2 class="kpi-number" id="totalTurmasAtivas">-</h2></div>
+                    <div><h2 class="kpi-title" style="text-transform: none;">Turmas Ativas</h2><h2 class="kpi-number" id="totalTurmasAtivas">-</h2></div>
                     <i class="bi bi-people kpi-icon"></i>
                 </div></div>
             </div></div>
             <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
                 <div class="card-body"><div class="d-flex justify-content-between align-items-center">
-                    <div><h6 class="kpi-title" style="text-transform: none;">Agendamentos Hoje</h6><h2 class="kpi-number" id="agendamentosHoje">-</h2></div>
+                    <div><h2 class="kpi-title" style="text-transform: none;">Agendamentos Hoje</h2><h2 class="kpi-number" id="agendamentosHoje">-</h2></div>
                     <i class="bi bi-calendar-check kpi-icon"></i>
                 </div></div>
             </div></div>
             <div class="col-lg-3 col-md-6 mb-4"><div class="card kpi-card">
                 <div class="card-body"><div class="d-flex justify-content-between align-items-center">
-                    <div><h6 class="kpi-title" style="text-transform: none;">Esta Semana</h6><h2 class="kpi-number" id="agendamentosSemana">-</h2></div>
+                    <div><h2 class="kpi-title" style="text-transform: none;">Esta Semana</h2><h2 class="kpi-number" id="agendamentosSemana">-</h2></div>
                     <i class="bi bi-calendar-week kpi-icon"></i>
                 </div></div>
             </div></div>
@@ -132,7 +132,7 @@
                 <div class="row">
                     <div class="col-md-6">
                         <div class="card">
-                            <div class="card-header"><h5 class="card-title mb-0"><i class="bi bi-clock me-2"></i>Próximos Agendamentos</h5></div>
+                            <div class="card-header"><h2 class="card-title mb-0"><i class="bi bi-clock me-2"></i>Próximos Agendamentos</h2></div>
                             <div class="card-body" id="proximosAgendamentosContainer">
                                 </div>
                         </div>
@@ -140,7 +140,7 @@
 
                     <div class="col-md-6">
                         <div class="card">
-                            <div class="card-header"><h5 class="card-title mb-0"><i class="bi bi-bar-chart me-2"></i>Laboratórios Mais Utilizados (Este Mês)</h5></div>
+                            <div class="card-header"><h2 class="card-title mb-0"><i class="bi bi-bar-chart me-2"></i>Laboratórios Mais Utilizados (Este Mês)</h2></div>
                             <div class="card-body">
                                 <canvas id="graficoLabsMaisUtilizados" height="200"></canvas>
                             </div>
@@ -151,7 +151,7 @@
                 <div class="row mt-4">
                     <div class="col-12">
                         <div class="card">
-                            <div class="card-header"><h5 class="card-title mb-0"><i class="bi bi-graph-up me-2"></i>Tendência Mensal de Agendamentos</h5></div>
+                            <div class="card-header"><h2 class="card-title mb-0"><i class="bi bi-graph-up me-2"></i>Tendência Mensal de Agendamentos</h2></div>
                             <div class="card-body">
                                 <canvas id="graficoTendenciaMensal" height="100"></canvas>
                             </div>
@@ -172,7 +172,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="agendamentoModalLabel">Detalhes do Agendamento</h5>
+                    <h2 class="modal-title" id="agendamentoModalLabel">Detalhes do Agendamento</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body" id="agendamentoModalBody">
@@ -190,7 +190,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/laboratorios/logs.html
+++ b/src/static/laboratorios/logs.html
@@ -66,7 +66,7 @@
     <div class="row">
         <div class="col-lg-3 d-none d-lg-block">
             <div class="sidebar rounded shadow-sm">
-                <h5 class="mb-3">Menu Principal</h5>
+                <h2 class="mb-3">Menu Principal</h2>
                 <div class="nav flex-column">
                     <a class="nav-link" href="/laboratorios/dashboard.html"><i class="bi bi-speedometer2"></i> Dashboard</a>
                     <a class="nav-link" href="/laboratorios/calendario.html"><i class="bi bi-calendar3"></i> Calendário</a>
@@ -79,13 +79,13 @@
         </div>
         <main class="col-lg-9 col-md-12">
             <div class="page-header">
-                <h2 class="mb-0">Logs de Agendamentos</h2>
+                <h1 class="mb-0">Logs de Agendamentos</h1>
                 <button id="btnExportarCsv" class="btn btn-outline-primary"><i class="bi bi-download me-1"></i>Exportar CSV</button>
             </div>
 
             <div class="card mb-4">
                 <div class="card-header">
-                    <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                    <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
                 </div>
                 <div class="card-body">
                     <div class="row">
@@ -118,7 +118,7 @@
 
             <div class="card">
                 <div class="card-header">
-                    <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Histórico de Logs</h5>
+                    <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Histórico de Logs</h2>
                 </div>
                 <div class="card-body p-0">
                     <div class="table-responsive">

--- a/src/static/laboratorios/perfil.html
+++ b/src/static/laboratorios/perfil.html
@@ -68,7 +68,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/laboratorios/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -93,14 +93,14 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4">Meu Perfil</h2>
+                <h1 class="mb-4">Meu Perfil</h1>
                 
                 
                 <div class="row">
                     <div class="col-md-8">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Informações Pessoais</h5>
+                                <h2 class="card-title mb-0">Informações Pessoais</h2>
                             </div>
                             <div class="card-body">
                                 <form id="perfilForm">
@@ -146,7 +146,7 @@
                     <div class="col-md-4">
                         <div class="card mb-4">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Alterar Senha</h5>
+                                <h2 class="card-title mb-0">Alterar Senha</h2>
                             </div>
                             <div class="card-body">
                                 <form id="senhaForm">
@@ -174,15 +174,15 @@
                         
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Estatísticas</h5>
+                                <h2 class="card-title mb-0">Estatísticas</h2>
                             </div>
                             <div class="card-body">
                                 <div class="mb-3">
-                                    <h6>Total de Agendamentos</h6>
+                                    <h3>Total de Agendamentos</h3>
                                     <p id="totalAgendamentos" class="h4">-</p>
                                 </div>
                                 <div class="mb-3">
-                                    <h6>Membro desde</h6>
+                                    <h3>Membro desde</h3>
                                     <p id="membroDesde" class="h4">-</p>
                                 </div>
                             </div>

--- a/src/static/laboratorios/turmas.html
+++ b/src/static/laboratorios/turmas.html
@@ -68,7 +68,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/laboratorios/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -94,7 +94,7 @@
             
             <main class="col-lg-9 col-md-12">
                     <div class="d-flex justify-content-between align-items-center mb-4">
-                        <h2 class="mb-0">Gerenciamento de Laboratórios e Turmas</h2>
+                        <h1 class="mb-0">Gerenciamento de Laboratórios e Turmas</h1>
                         <button class="btn btn-primary" onclick="novoLaboratorio()">
                             <i class="bi bi-plus-circle me-2"></i>Novo Laboratório
                         </button>
@@ -102,7 +102,7 @@
 
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
                     </div>
                     <div class="card-body">
                     </div>
@@ -111,7 +111,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Laboratórios</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Laboratórios</h2>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -140,7 +140,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Turmas</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Turmas</h2>
                         <button class="btn btn-primary btn-sm" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>Nova Turma</button>
                     </div>
                     <div class="card-body p-0">
@@ -181,7 +181,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body" id="confirmacaoModalBody">
@@ -199,7 +199,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="laboratorioModalLabel">Novo Laboratório</h5>
+                    <h2 class="modal-title" id="laboratorioModalLabel">Novo Laboratório</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body">
@@ -232,7 +232,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="turmaModalLabel">Nova Turma</h5>
+                    <h2 class="modal-title" id="turmaModalLabel">Nova Turma</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/ocupacao/agendamento.html
+++ b/src/static/ocupacao/agendamento.html
@@ -74,7 +74,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/ocupacao/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -117,7 +117,7 @@
                     <div class="card-body">
                         <form id="formNovaOcupacao">
                             <div>
-                                <h5 class="mb-4">Dados da Ocupação</h5>
+                                <h2 class="mb-4">Dados da Ocupação</h2>
                                 
                                 <div class="row">
                                     <div class="col-md-6">

--- a/src/static/ocupacao/calendario.html
+++ b/src/static/ocupacao/calendario.html
@@ -75,7 +75,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/ocupacao/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -102,7 +102,7 @@
 
                     <hr>
 
-                    <h5 class="mb-3">Filtros</h5>
+                    <h2 class="mb-3">Filtros</h2>
                     <form id="filtrosForm">
                         <div class="mb-3">
                             <label for="filtroSala" class="form-label">Sala</label>
@@ -133,13 +133,13 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4">Calendário de Ocupações</h2>
+                <h1 class="mb-4">Calendário de Ocupações</h1>
 
 
                 <div class="d-lg-none mb-4">
                     <div class="card">
                         <div class="card-header">
-                            <h5 class="card-title mb-0">Filtros</h5>
+                            <h2 class="card-title mb-0">Filtros</h2>
                         </div>
                         <div class="card-body">
                             <form id="filtrosMobileForm" class="row g-3">
@@ -176,7 +176,7 @@
 
                 <div class="card mb-3">
                     <div class="card-body">
-                        <h6 class="card-subtitle mb-2 text-muted">Legenda</h6>
+                        <h3 class="card-subtitle mb-2 text-muted">Legenda</h3>
                         <div class="legenda-turnos">
                             <div class="legenda-item">
                                 <div class="pill-turno turno-livre"></div>
@@ -219,7 +219,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalDetalhesOcupacaoLabel">Detalhes da Ocupação</h5>
+                    <h2 class="modal-title" id="modalDetalhesOcupacaoLabel">Detalhes da Ocupação</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -239,7 +239,7 @@
         <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalResumoDiaLabel">Resumo de Ocupação</h5>
+                    <h2 class="modal-title" id="modalResumoDiaLabel">Resumo de Ocupação</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body" id="conteudoResumoDia"></div>
@@ -251,7 +251,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalExcluirOcupacaoLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="modalExcluirOcupacaoLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/ocupacao/dashboard.html
+++ b/src/static/ocupacao/dashboard.html
@@ -74,7 +74,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link active" href="/ocupacao/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -118,7 +118,7 @@
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                          <h6 class="kpi-title" style="text-transform: none;">Salas Ativas</h6>
+                                          <h2 class="kpi-title" style="text-transform: none;">Salas Ativas</h2>
                                         <h2 class="kpi-number" id="totalSalasAtivas">-</h2>
                                     </div>
                                     <i class="bi bi-building kpi-icon"></i>
@@ -131,7 +131,7 @@
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                          <h6 class="kpi-title" style="text-transform: none;">Instrutores Ativos</h6>
+                                          <h2 class="kpi-title" style="text-transform: none;">Instrutores Ativos</h2>
                                         <h2 class="kpi-number" id="totalInstrutoresAtivos">-</h2>
                                     </div>
                                     <i class="bi bi-person-badge kpi-icon"></i>
@@ -144,7 +144,7 @@
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                          <h6 class="kpi-title" style="text-transform: none;">Ocupações Hoje</h6>
+                                          <h2 class="kpi-title" style="text-transform: none;">Ocupações Hoje</h2>
                                         <h2 class="kpi-number" id="ocupacoesHoje">-</h2>
                                     </div>
                                     <i class="bi bi-calendar-check kpi-icon"></i>
@@ -157,7 +157,7 @@
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>
-                                          <h6 class="kpi-title" style="text-transform: none;">Esta Semana</h6>
+                                          <h2 class="kpi-title" style="text-transform: none;">Esta Semana</h2>
                                         <h2 class="kpi-number" id="ocupacoesSemana">-</h2>
                                     </div>
                                     <i class="bi bi-calendar-week kpi-icon"></i>
@@ -173,9 +173,9 @@
                     <div class="col-12">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">
+                                <h2 class="card-title mb-0">
                                     <i class="bi bi-lightning me-2"></i>Ações Rápidas
-                                </h5>
+                                </h2>
                             </div>
                             <div class="card-body">
                                 <div class="row">
@@ -213,9 +213,9 @@
                     <div class="col-md-6">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">
+                                <h2 class="card-title mb-0">
                                     <i class="bi bi-clock me-2"></i>Próximas Ocupações
-                                </h5>
+                                </h2>
                             </div>
                             <div class="card-body">
                                 <div id="loadingProximasOcupacoes" class="text-center py-3">
@@ -247,9 +247,9 @@
                     <div class="col-md-6">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">
+                                <h2 class="card-title mb-0">
                                     <i class="bi bi-bar-chart me-2"></i>Salas Mais Utilizadas (Este Mês)
-                                </h5>
+                                </h2>
                             </div>
                             <div class="card-body">
                                 <div id="loadingSalasMaisUtilizadas" class="text-center py-3">
@@ -275,9 +275,9 @@
                     <div class="col-12">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">
+                                <h2 class="card-title mb-0">
                                     <i class="bi bi-pie-chart me-2"></i>Ocupações por Tipo (Este Mês)
-                                </h5>
+                                </h2>
                             </div>
                             <div class="card-body">
                                 <div id="loadingOcupacoesPorTipo" class="text-center py-3">
@@ -303,9 +303,9 @@
                     <div class="col-12">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">
+                                <h2 class="card-title mb-0">
                                     <i class="bi bi-graph-up me-2"></i>Tendência Mensal de Ocupações
-                                </h5>
+                                </h2>
                             </div>
                             <div class="card-body">
                                 <canvas id="graficoTendenciaMensal" height="100"></canvas>

--- a/src/static/ocupacao/instrutores.html
+++ b/src/static/ocupacao/instrutores.html
@@ -82,7 +82,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/ocupacao/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -111,7 +111,7 @@
 
             <main class="col-lg-9 col-md-12">
                     <div class="page-header">
-                        <h2 class="mb-0">Gestão de Corpo Docente</h2>
+                        <h1 class="mb-0">Gestão de Corpo Docente</h1>
                         <button id="btnAdicionarNovo" class="btn btn-primary">
                             <i class="bi bi-plus-circle me-2"></i>Novo Instrutor
                         </button>
@@ -119,7 +119,7 @@
 
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
                     </div>
                     <div class="card-body">
                         <div class="row g-3 align-items-end">
@@ -149,7 +149,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Instrutores</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Instrutores</h2>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -177,7 +177,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalInstrutorLabel">Novo Instrutor</h5>
+                    <h2 class="modal-title" id="modalInstrutorLabel">Novo Instrutor</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -250,7 +250,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalExcluirInstrutorLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="modalExcluirInstrutorLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/ocupacao/perfil.html
+++ b/src/static/ocupacao/perfil.html
@@ -82,7 +82,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/ocupacao/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -110,14 +110,14 @@
             </div>
             
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4">Meu Perfil</h2>
+                <h1 class="mb-4">Meu Perfil</h1>
                 
                 
                 <div class="row">
                     <div class="col-md-8">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Informações Pessoais</h5>
+                                <h2 class="card-title mb-0">Informações Pessoais</h2>
                             </div>
                             <div class="card-body">
                                 <form id="perfilForm">
@@ -163,7 +163,7 @@
                     <div class="col-md-4">
                         <div class="card mb-4">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Alterar Senha</h5>
+                                <h2 class="card-title mb-0">Alterar Senha</h2>
                             </div>
                             <div class="card-body">
                                 <form id="senhaForm">
@@ -191,15 +191,15 @@
                         
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Estatísticas</h5>
+                                <h2 class="card-title mb-0">Estatísticas</h2>
                             </div>
                             <div class="card-body">
                                 <div class="mb-3">
-                                    <h6>Total de Agendamentos</h6>
+                                    <h3>Total de Agendamentos</h3>
                                     <p id="totalAgendamentos" class="h4">-</p>
                                 </div>
                                 <div class="mb-3">
-                                    <h6>Membro desde</h6>
+                                    <h3>Membro desde</h3>
                                     <p id="membroDesde" class="h4">-</p>
                                 </div>
                             </div>

--- a/src/static/ocupacao/salas.html
+++ b/src/static/ocupacao/salas.html
@@ -74,7 +74,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/ocupacao/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -103,7 +103,7 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Gerenciar Salas</h2>
+                    <h1 class="mb-0">Gerenciar Salas</h1>
                     <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalSala" onclick="novaSala()">
                         <i class="bi bi-plus-circle me-2"></i>Adicionar sala
                     </button>
@@ -111,9 +111,9 @@
 
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0">
+                        <h2 class="card-title mb-0">
                             <i class="bi bi-funnel me-2"></i>Filtros
-                        </h5>
+                        </h2>
                     </div>
                     <div class="card-body">
                         <div class="row">
@@ -150,7 +150,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Salas</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Salas</h2>
                     </div>
                     <div class="card-body p-0">
                         <div id="loadingSalas" class="text-center py-4">
@@ -186,7 +186,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalSalaLabel">Nova Sala</h5>
+                    <h2 class="modal-title" id="modalSalaLabel">Nova Sala</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -264,7 +264,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalExcluirSalaLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="modalExcluirSalaLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/ocupacao/turmas.html
+++ b/src/static/ocupacao/turmas.html
@@ -82,7 +82,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/ocupacao/dashboard.html">
                             <i class="bi bi-speedometer2"></i> Dashboard
@@ -111,7 +111,7 @@
             
             <main class="col-lg-9 col-md-12">
     <div class="page-header">
-        <h2 class="mb-0">Gerenciar Turmas</h2>
+        <h1 class="mb-0">Gerenciar Turmas</h1>
         <button class="btn btn-primary" onclick="novaTurma()">
             <i class="bi bi-plus-circle me-2"></i>Adicionar Turma
         </button>
@@ -119,7 +119,7 @@
 
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
                     </div>
                     <div class="card-body">
                         <div class="row g-3 align-items-end">
@@ -142,7 +142,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Turmas</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Turmas</h2>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -182,7 +182,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body" id="confirmacaoModalBody">
@@ -200,7 +200,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="turmaModalLabel">Nova Turma</h5>
+                    <h2 class="modal-title" id="turmaModalLabel">Nova Turma</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/rateio/config.html
+++ b/src/static/rateio/config.html
@@ -58,7 +58,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link active" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
@@ -70,7 +70,7 @@
             </div>
             <main class="col-lg-9 col-md-12">
                     <div class="page-header">
-                        <h2 class="mb-0">Configurações de Rateio</h2>
+                        <h1 class="mb-0">Configurações de Rateio</h1>
                         <button class="btn btn-primary" onclick="novaConfig()">
                             <i class="bi bi-plus-circle me-2"></i>Nova Configuração
                         </button>
@@ -102,7 +102,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
                 <div class="modal-body" id="confirmacaoModalBody"></div>
@@ -118,7 +118,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalConfigLabel">Nova Configuração de Rateio</h5>
+                    <h2 class="modal-title" id="modalConfigLabel">Nova Configuração de Rateio</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/rateio/dashboard.html
+++ b/src/static/rateio/dashboard.html
@@ -58,7 +58,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link active" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
@@ -70,7 +70,7 @@
             </div>
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Lançamento de Rateio</h2>
+                    <h1 class="mb-0">Lançamento de Rateio</h1>
                 </div>
 
                 <div class="card mt-4">
@@ -95,13 +95,13 @@
                     <div class="modal-dialog modal-lg">
                         <div class="modal-content">
                             <div class="modal-header">
-                                <h5 class="modal-title" id="lancamentoModalLabel">Lançamentos para Mês / Ano</h5>
+                                <h2 class="modal-title" id="lancamentoModalLabel">Lançamentos para Mês / Ano</h2>
                                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                             </div>
                             <div class="modal-body">
                                 <div id="lancamentosAtuaisContainer"></div>
                                 <hr>
-                                <h6>Adicionar Novo Rateio</h6>
+                                <h3>Adicionar Novo Rateio</h3>
                                 <div class="row g-3 align-items-end">
                                     <div class="col-md-6">
                                         <label for="selectConfigModal" class="form-label">Configuração</label>

--- a/src/static/rateio/instrutores.html
+++ b/src/static/rateio/instrutores.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
@@ -74,7 +74,7 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Gestão de Instrutores</h2>
+                    <h1 class="mb-0">Gestão de Instrutores</h1>
                       <button id="btnAdicionarNovo" class="btn btn-primary">
                           <i class="bi bi-plus-circle me-2"></i>Novo Instrutor
                       </button>
@@ -82,7 +82,7 @@
 
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
                     </div>
                     <div class="card-body">
                         <div class="row g-3 align-items-end">
@@ -112,7 +112,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Instrutores</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Instrutores</h2>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -140,7 +140,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalInstrutorLabel">Novo Instrutor</h5>
+                    <h2 class="modal-title" id="modalInstrutorLabel">Novo Instrutor</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -213,7 +213,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="modalExcluirInstrutorLabel">Confirmar Exclusão</h5>
+                    <h2 class="modal-title" id="modalExcluirInstrutorLabel">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/rateio/logs.html
+++ b/src/static/rateio/logs.html
@@ -59,7 +59,7 @@
     <div class="row">
         <div class="col-lg-3 d-none d-lg-block">
             <div class="sidebar rounded shadow-sm">
-                <h5 class="mb-3">Menu Principal</h5>
+                <h2 class="mb-3">Menu Principal</h2>
                 <div class="nav flex-column">
                     <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                     <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
@@ -71,13 +71,13 @@
         </div>
         <main class="col-lg-9 col-md-12">
             <div class="page-header">
-                <h2 class="mb-0">Logs de Rateio</h2>
+                <h1 class="mb-0">Logs de Rateio</h1>
                 <button id="btnExportarCsv" class="btn btn-outline-primary"><i class="bi bi-download me-1"></i>Exportar CSV</button>
             </div>
 
             <div class="card mt-4">
                 <div class="card-header">
-                    <h5 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h5>
+                    <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
                 </div>
                 <div class="card-body">
                     <div class="row">
@@ -114,7 +114,7 @@
 
             <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="card-title mb-0"><i class="bi bi-list me-2"></i>Histórico de Logs</h5>
+                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Histórico de Logs</h2>
                     </div>
                 <div class="card-body p-0">
                     <div class="table-responsive">

--- a/src/static/rateio/perfil.html
+++ b/src/static/rateio/perfil.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
                         <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
@@ -74,7 +74,7 @@
             
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Meu Perfil</h2>
+                    <h1 class="mb-0">Meu Perfil</h1>
                 </div>
 
                 <div class="card mt-4">
@@ -84,7 +84,7 @@
                             <div class="col-md-5">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Informações Pessoais</h5>
+                                <h2 class="card-title mb-0">Informações Pessoais</h2>
                             </div>
                             <div class="card-body">
                                 <form id="perfilForm">
@@ -130,7 +130,7 @@
                     <div class="col-md-7">
                         <div class="card mb-4">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Alterar Senha</h5>
+                                <h2 class="card-title mb-0">Alterar Senha</h2>
                             </div>
                             <div class="card-body">
                                 <form id="senhaForm">
@@ -158,15 +158,15 @@
                         
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Estatísticas</h5>
+                                <h2 class="card-title mb-0">Estatísticas</h2>
                             </div>
                             <div class="card-body">
                                 <div class="mb-3">
-                                    <h6>Total de Agendamentos</h6>
+                                    <h3>Total de Agendamentos</h3>
                                     <p id="totalAgendamentos" class="h4">-</p>
                                 </div>
                                 <div class="mb-3">
-                                    <h6>Membro desde</h6>
+                                    <h3>Membro desde</h3>
                                     <p id="membroDesde" class="h4">-</p>
                                 </div>
                             </div>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -62,7 +62,7 @@
                         <div class="sistema-icon">
                             <i class="bi bi-calendar-check"></i>
                         </div>
-                        <h3 class="card-title">Agenda de Laboratórios</h3>
+                        <h2 class="card-title">Agenda de Laboratórios</h2>
                         <p class="card-text">Sistema para gerenciamento e agendamento de laboratórios, com visualização em calendário.</p>
                         <div class="mt-4">
                             <span class="badge bg-success">Disponível</span>
@@ -77,7 +77,7 @@
                         <div class="sistema-icon">
                             <i class="bi bi-easel2"></i>
                         </div>
-                        <h3 class="card-title">Agenda de Treinamentos</h3>
+                        <h2 class="card-title">Agenda de Treinamentos</h2>
                         <p class="card-text">Módulo para programação e gestão de treinamentos por área técnica.</p>
                         <div class="mt-4">
                             <span class="badge bg-success">Disponível</span>
@@ -92,7 +92,7 @@
                         <div class="sistema-icon">
                             <i class="bi bi-building"></i>
                         </div>
-                        <h3 class="card-title">Controle de Ocupação de Salas de Aula</h3>
+                        <h2 class="card-title">Controle de Ocupação de Salas de Aula</h2>
                         <p class="card-text">Sistema para monitoramento e controle de ocupação das salas de aula, com estatísticas de utilização.</p>
                         <div class="mt-4">
                             <span class="badge bg-success">Disponível</span>
@@ -107,7 +107,7 @@
                         <div class="sistema-icon">
                             <i class="bi bi-coin"></i>
                         </div>
-                        <h3 class="card-title">Controle de Rateio</h3>
+                        <h2 class="card-title">Controle de Rateio</h2>
                         <p class="card-text">Módulo para apuração de horas de instrutores e rateio de custos.</p>
                         <div class="mt-4">
                             <span class="badge bg-success">Disponível</span>
@@ -122,7 +122,7 @@
                         <div class="sistema-icon">
                             <i class="bi bi-person-gear"></i>
                         </div>
-                        <h3 class="card-title">Gerenciamento de Usuários</h3>
+                        <h2 class="card-title">Gerenciamento de Usuários</h2>
                         <p class="card-text">Acesse a área de cadastro, edição e controle de permissões de usuários do sistema.</p>
                         <div class="mt-4">
                             <span class="badge bg-success">Disponível</span>

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -77,7 +77,7 @@
 
             <main class="col-lg-9 col-md-12">
                     <div class="page-header">
-                        <h2 class="mb-0">Gerenciar Catálogo de Treinamentos</h2>
+                        <h1 class="mb-0">Gerenciar Catálogo de Treinamentos</h1>
                         <button class="btn btn-primary" onclick="novoTreinamento()"><i class="bi bi-plus-circle me-2"></i>Novo Treinamento</button>
                     </div>
                 
@@ -110,7 +110,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Treinamento</h5>
+                    <h2 class="modal-title">Treinamento</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/treinamentos/admin-historico-passado.html
+++ b/src/static/treinamentos/admin-historico-passado.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -77,7 +77,7 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Turmas Encerradas</h2>
+                    <h1 class="mb-0">Turmas Encerradas</h1>
                 </div>
                 
 
@@ -101,7 +101,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Turma</h5>
+                    <h2 class="modal-title">Turma</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
@@ -164,7 +164,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Inscrever Novo Participante</h5>
+                    <h2 class="modal-title">Inscrever Novo Participante</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
@@ -218,7 +218,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Confirmar Exclusão</h5>
+                    <h2 class="modal-title">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/treinamentos/admin-historico-turmas.html
+++ b/src/static/treinamentos/admin-historico-turmas.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -77,7 +77,7 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Turmas em Andamento</h2>
+                    <h1 class="mb-0">Turmas em Andamento</h1>
                 </div>
                 
 
@@ -101,7 +101,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Turma</h5>
+                    <h2 class="modal-title">Turma</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
@@ -164,7 +164,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Inscrever Novo Participante</h5>
+                    <h2 class="modal-title">Inscrever Novo Participante</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
@@ -218,7 +218,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Confirmar Exclusão</h5>
+                    <h2 class="modal-title">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -77,7 +77,7 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Lista de Presença e Avaliação</h2>
+                    <h1 class="mb-0">Lista de Presença e Avaliação</h1>
                     <div class="d-flex">
                         <button id="btnExportarInscricoes" class="btn btn-sm btn-outline-secondary me-2">
                             <i class="bi bi-download me-1"></i>
@@ -92,7 +92,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h5 class="mb-0">Dados do Treinamento</h5>
+                        <h2 class="mb-0">Dados do Treinamento</h2>
                     </div>
                     <div class="card-body">
                         <div class="row">
@@ -170,7 +170,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="exportarModalLabel">Exportar Inscrições</h5>
+                    <h2 class="modal-title" id="exportarModalLabel">Exportar Inscrições</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -194,7 +194,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Inscrever Novo Participante</h5>
+                    <h2 class="modal-title">Inscrever Novo Participante</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/treinamentos/admin-logs.html
+++ b/src/static/treinamentos/admin-logs.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm" id="sidebar-menu">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -77,7 +77,7 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Logs de Atividades</h2>
+                    <h1 class="mb-0">Logs de Atividades</h1>
                 </div>
                 
 

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -77,7 +77,7 @@
 
             <main class="col-lg-9 col-md-12">
                     <div class="page-header">
-                        <h2 class="mb-0">Gerenciar Turmas Futuras</h2>
+                        <h1 class="mb-0">Gerenciar Turmas Futuras</h1>
                         <button class="btn btn-primary" onclick="novaTurma()"><i class="bi bi-plus-circle me-2"></i>Nova Turma</button>
                     </div>
                 
@@ -102,7 +102,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Turma</h5>
+                    <h2 class="modal-title">Turma</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
@@ -172,7 +172,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Inscrever Novo Participante</h5>
+                    <h2 class="modal-title">Inscrever Novo Participante</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
@@ -226,7 +226,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Confirmar Exclusão</h5>
+                    <h2 class="modal-title">Confirmar Exclusão</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link active" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -77,7 +77,7 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Cursos Disponíveis</h2>
+                    <h1 class="mb-0">Cursos Disponíveis</h1>
                 </div>
                 
 
@@ -91,7 +91,7 @@
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="selecaoInscricaoModalLabel">Para quem é a inscrição?</h5>
+                    <h2 class="modal-title" id="selecaoInscricaoModalLabel">Para quem é a inscrição?</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body text-center">
@@ -113,7 +113,7 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Inscrição</h5>
+                    <h2 class="modal-title">Inscrição</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">

--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -61,7 +61,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link active" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -77,16 +77,16 @@
 
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
-                    <h2 class="mb-0">Meus Cursos</h2>
+                    <h1 class="mb-0">Meus Cursos</h1>
                 </div>
 
                 
-                <h4 class="mt-4">Em Andamento</h4>
+                <h2 class="mt-4">Em Andamento</h2>
                 <hr>
                 <div id="cursos-em-andamento" class="row">
                 </div>
 
-                <h4 class="mt-5">Em Breve</h4>
+                <h2 class="mt-5">Em Breve</h2>
                 <hr>
                 <div id="cursos-em-breve" class="row">
                 </div>
@@ -95,7 +95,7 @@
                     <div class="accordion-item">
                         <h2 class="accordion-header" id="headingConcluidos">
                             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseConcluidos" aria-expanded="false" aria-controls="collapseConcluidos">
-                                <h4>Concluídos</h4>
+                                <h2>Concluídos</h2>
                             </button>
                         </h2>
                         <div id="collapseConcluidos" class="accordion-collapse collapse" aria-labelledby="headingConcluidos" data-bs-parent="#accordionConcluidos">
@@ -114,7 +114,7 @@
         <div class="modal-dialog modal-lg modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="cursoDetalhesModalLabel">Detalhes do Treinamento</h5>
+                    <h2 class="modal-title" id="cursoDetalhesModalLabel">Detalhes do Treinamento</h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -131,10 +131,10 @@
                         </div>
                     </div>
                     <hr>
-                    <h6><strong><i class="bi bi-file-text"></i> Conteúdo Programático:</strong></h6>
+                    <h3><strong><i class="bi bi-file-text"></i> Conteúdo Programático:</strong></h3>
                     <p id="modalConteudo" style="white-space: pre-wrap;"></p>
                     
-                    <h6><strong><i class="bi bi-collection"></i> Materiais e Links:</strong></h6>
+                    <h3><strong><i class="bi bi-collection"></i> Materiais e Links:</strong></h3>
                     <ul id="modalLinks" class="list-group">
                     </ul>
                 </div>

--- a/src/static/treinamentos/perfil.html
+++ b/src/static/treinamentos/perfil.html
@@ -48,7 +48,7 @@
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
-                    <h5 class="mb-3">Menu Principal</h5>
+                    <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
@@ -63,11 +63,11 @@
             </div>
 
             <main class="col-lg-9 col-md-12">
-                <h2 class="mb-4">Meu Perfil</h2>
+                <h1 class="mb-4">Meu Perfil</h1>
                 <div class="row">
                     <div class="col-md-8">
                         <div class="card">
-                            <div class="card-header"><h5 class="card-title mb-0">Informações Pessoais</h5></div>
+                            <div class="card-header"><h2 class="card-title mb-0">Informações Pessoais</h2></div>
                             <div class="card-body">
                                 <form id="perfilForm">
                                     <div class="mb-3"><label for="nome" class="form-label">Nome Completo</label><input type="text" class="form-control" id="nome" name="nome" required></div>
@@ -85,7 +85,7 @@
                     </div>
                     <div class="col-md-4">
                         <div class="card mb-4">
-                            <div class="card-header"><h5 class="card-title mb-0">Alterar Senha</h5></div>
+                            <div class="card-header"><h2 class="card-title mb-0">Alterar Senha</h2></div>
                             <div class="card-body">
                                 <form id="senhaForm">
                                     <div class="mb-3"><label for="senhaAtual" class="form-label">Senha Atual</label><input type="password" class="form-control" id="senhaAtual" name="senhaAtual" required></div>


### PR DESCRIPTION
## Summary
- promote page titles to `<h1>` across static templates and adjust navigation headings
- ensure subsequent sections use `<h2>`/`<h3>` without skipping levels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898af42bba8832386ae0657044c3d11