### PR TITLE
feat: standardize feedback with button spinner and toast helper

### DIFF
--- a/src/static/css/brand.css
+++ b/src/static/css/brand.css
@@ -54,3 +54,6 @@ h3,h4,h5,h6, .subtitle{ font-weight: 500; }
 .modal-header{ background: var(--brand-primary); color:#fff; }
 .modal-title{ font-weight:600; }
 .btn-primary:disabled, .btn:disabled{ opacity:.65; }
+
+/* Spinner padrão em botões */
+.btn .spinner-border{ width:1rem; height:1rem; border-width:.2rem; margin-left:.5rem; }

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -76,6 +76,29 @@ function sanitizeHTML(html) {
     return window.DOMPurify ? DOMPurify.sanitize(html) : html;
 }
 
+/**
+ * Alterna o estado de processamento de um botão, exibindo um spinner.
+ * @param {HTMLElement} btn - Botão alvo
+ * @param {boolean} busy - Se verdadeiro, ativa o estado de espera
+ */
+function setBusy(btn, busy = true) {
+    if (!btn) return;
+
+    if (busy) {
+        if (!btn.dataset.originalHtml) {
+            btn.dataset.originalHtml = btn.innerHTML;
+        }
+        btn.disabled = true;
+        btn.innerHTML = `${btn.dataset.originalHtml}<span class="spinner-border" role="status" aria-hidden="true"></span>`;
+    } else {
+        btn.disabled = false;
+        if (btn.dataset.originalHtml) {
+            btn.innerHTML = btn.dataset.originalHtml;
+            delete btn.dataset.originalHtml;
+        }
+    }
+}
+
 // Mapeia os módulos disponíveis de acordo com o tipo de usuário
 function obterModulosDisponiveis(usuario) {
     const modulos = [];
@@ -475,7 +498,18 @@ function showToast(mensagem, tipo = 'info') {
     toast.show();
 }
 
+/**
+ * Exibe notificação rápida via Toast do Bootstrap.
+ * @param {string} tipo - success|warning|danger|info
+ * @param {string} mensagem - Mensagem a ser exibida
+ */
+function notify(tipo, mensagem) {
+    showToast(mensagem, tipo);
+}
+
 window.showToast = showToast;
+window.notify = notify;
+window.setBusy = setBusy;
 document.addEventListener('DOMContentLoaded', criarToastContainer);
 
 /**


### PR DESCRIPTION
## Summary
- add `setBusy` helper to disable buttons and show a spinner
- introduce `notify` wrapper for Bootstrap toast notifications
- style spinner size within buttons

## Testing
- `pre-commit run --files src/static/js/app.js src/static/css/brand.css`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898bca2577c8323bfb9033cb143055c