### PR TITLE
feat: adopt lucide icons for rateio

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -138,11 +138,14 @@ p, input, textarea {
 
 ## Iconografia
 
-O projeto utiliza os [Bootstrap Icons](https://icons.getbootstrap.com/).
+O projeto utiliza os [Lucide Icons](https://lucide.dev/) para manter um estilo linear consistente.
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-<i class="bi bi-calendar-check"></i>
+<script src="https://unpkg.com/lucide@latest"></script>
+<script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
+<i data-lucide="calendar"></i>
 ```
+
+Os ícones herdam a cor do texto e evitam preenchimentos pesados.
 
 Atualize este documento sempre que novos componentes visuais forem adicionados ao sistema.

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -23,6 +23,13 @@ function criarLoadingOverlay() {
     document.body.appendChild(loadingOverlay);
 }
 
+function refreshIcons() {
+    if (window.lucide) {
+        lucide.createIcons({ attrs: { strokeWidth: 1.75 } });
+    }
+}
+window.refreshIcons = refreshIcons;
+
 function mostrarLoading() {
     criarLoadingOverlay();
     document.body.setAttribute('aria-busy', 'true');
@@ -585,10 +592,10 @@ function adicionarLinkLabTurmas(containerSelector, isNavbar = false) {
         const link = document.createElement('a');
         link.className = 'nav-link';
         link.href = '/laboratorios/turmas.html';
-        link.innerHTML = '<i class="bi bi-building me-1"></i> Laboratórios e Turmas';
+        link.innerHTML = '<i data-lucide="building-2" class="me-1"></i> Laboratórios e Turmas';
         
         navItem.appendChild(link);
-        
+
         // Insere antes do último item (dropdown do usuário)
         const lastItem = container.querySelector('.dropdown');
         if (lastItem) {
@@ -596,12 +603,13 @@ function adicionarLinkLabTurmas(containerSelector, isNavbar = false) {
         } else {
             container.appendChild(navItem);
         }
+        refreshIcons();
     } else {
         // Para sidebar (menu lateral)
         const link = document.createElement('a');
         link.className = 'nav-link admin-only';
         link.href = '/laboratorios/turmas.html';
-        link.innerHTML = '<i class="bi bi-building"></i> Laboratórios e Turmas';
+        link.innerHTML = '<i data-lucide="building-2"></i> Laboratórios e Turmas';
         
         // Insere antes do último item (Meu Perfil)
         const lastItem = container.querySelector('a[href="/laboratorios/perfil.html"], a[href="/ocupacao/perfil.html"], a[href="/admin/perfil.html"]');
@@ -610,6 +618,7 @@ function adicionarLinkLabTurmas(containerSelector, isNavbar = false) {
         } else {
             container.appendChild(link);
         }
+        refreshIcons();
     }
 }
 
@@ -628,7 +637,7 @@ function adicionarLinkLogs(containerSelector, isNavbar = false) {
         const link = document.createElement('a');
         link.className = 'nav-link';
         link.href = '/laboratorios/logs.html';
-        link.innerHTML = '<i class="bi bi-journal-text me-1"></i> Logs';
+        link.innerHTML = '<i data-lucide="book-open-text" class="me-1"></i> Logs';
 
         navItem.appendChild(link);
 
@@ -638,11 +647,12 @@ function adicionarLinkLogs(containerSelector, isNavbar = false) {
         } else {
             container.appendChild(navItem);
         }
+        refreshIcons();
     } else {
         const link = document.createElement('a');
         link.className = 'nav-link admin-only';
         link.href = '/laboratorios/logs.html';
-        link.innerHTML = '<i class="bi bi-journal-text"></i> Logs';
+        link.innerHTML = '<i data-lucide="book-open-text"></i> Logs';
 
         const lastItem = container.querySelector('a[href="/laboratorios/perfil.html"], a[href="/ocupacao/perfil.html"], a[href="/admin/perfil.html"]');
         if (lastItem) {
@@ -650,6 +660,7 @@ function adicionarLinkLogs(containerSelector, isNavbar = false) {
         } else {
             container.appendChild(link);
         }
+        refreshIcons();
     }
 }
 
@@ -669,7 +680,7 @@ function adicionarBotaoSelecaoSistema() {
         const link = document.createElement('a');
         link.className = 'dropdown-item';
         link.href = '/selecao-sistema.html';
-        link.innerHTML = '<i class="bi bi-arrow-return-left me-2"></i> Retornar à tela de seleção de sistema';
+        link.innerHTML = '<i data-lucide="arrow-left" class="me-2"></i> Retornar à tela de seleção de sistema';
         link.addEventListener('click', () => localStorage.removeItem('moduloSelecionado'));
 
         li.appendChild(link);
@@ -680,6 +691,7 @@ function adicionarBotaoSelecaoSistema() {
         } else {
             menu.appendChild(li);
         }
+        refreshIcons();
     });
 }
 

--- a/src/static/js/rateio/config.js
+++ b/src/static/js/rateio/config.js
@@ -53,15 +53,16 @@ document.addEventListener('DOMContentLoaded', function() {
                     <td>${escapeHTML(config.descricao || '')}</td>
                     <td>
                         <button class="btn btn-sm btn-outline-primary me-1 btn-editar" data-id="${config.id}" title="Editar">
-                            <i class="bi bi-pencil"></i>
+                            <i data-lucide="pencil"></i>
                         </button>
                         <button class="btn btn-sm btn-outline-danger btn-excluir" data-id="${config.id}" title="Excluir">
-                            <i class="bi bi-trash"></i>
+                            <i data-lucide="trash"></i>
                         </button>
                     </td>
                 `;
                 tableBody.appendChild(tr);
             });
+            refreshIcons();
         } catch (error) {
             showToast(`Não foi possível carregar configurações: ${error.message}`, 'danger');
         }

--- a/src/static/js/rateio/instrutores.js
+++ b/src/static/js/rateio/instrutores.js
@@ -88,11 +88,12 @@ class GerenciadorInstrutores {
                 <td><span class="badge ${inst.status === 'ativo' ? 'bg-success' : 'bg-secondary'}">${inst.status}</span></td>
                 <td><div class="d-flex gap-1">${this.badgesDisponibilidade(inst.disponibilidade)}</div></td>
                 <td class="text-end">
-                    <button class="btn btn-sm btn-outline-primary btn-editar"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm btn-outline-danger btn-excluir"><i class="bi bi-trash"></i></button>
+                    <button class="btn btn-sm btn-outline-primary btn-editar"><i data-lucide="pencil"></i></button>
+                    <button class="btn btn-sm btn-outline-danger btn-excluir"><i data-lucide="trash"></i></button>
                 </td>`;
             this.tabelaBody.appendChild(row);
         });
+        refreshIcons();
     }
 
     async carregarInstrutores() {

--- a/src/static/js/rateio/lancamentos.js
+++ b/src/static/js/rateio/lancamentos.js
@@ -103,14 +103,15 @@ class LancamentosApp {
                     </div>
                     <div class="card-footer">
                         <button class="btn btn-primary btn-sm w-100" data-mes="${m}">
-                            <i class="bi bi-pencil-square me-1"></i> Gerenciar Lançamentos
+                            <i data-lucide="pencil" class="me-1"></i> Gerenciar Lançamentos
                         </button>
                     </div>
                 </div>`;
             card.querySelector('button').addEventListener('click', () => this.abrirModal(m));
-            this.gridContainer.appendChild(card);
+        this.gridContainer.appendChild(card);
         }
         this.gridContainer.style.display = 'flex';
+        refreshIcons();
     }
 
     nomeMes(m) {
@@ -136,13 +137,14 @@ class LancamentosApp {
         div.innerHTML = `
             <span class="input-group-text flex-grow-1">${escapeHTML(lancamento.rateio_config.classe_valor)}</span>
             <input type="number" class="form-control percentual" value="${lancamento.percentual}" min="0" max="100">
-            <button class="btn btn-outline-danger btn-remover" type="button"><i class="bi bi-trash"></i></button>`;
+            <button class="btn btn-outline-danger btn-remover" type="button"><i data-lucide="trash"></i></button>`;
         div.querySelector('.btn-remover').addEventListener('click', () => {
             div.remove();
             this.atualizarTotal();
         });
         div.querySelector('.percentual').addEventListener('input', () => this.atualizarTotal());
         this.lancamentosContainer.appendChild(div);
+        refreshIcons();
     }
 
     adicionarItem() {
@@ -211,11 +213,12 @@ class LancamentosApp {
                 </div>
                 <div class="card-footer">
                     <button class="btn btn-primary btn-sm w-100" data-mes="${mes}">
-                        <i class="bi bi-pencil-square me-1"></i> Gerenciar Lançamentos
+                        <i data-lucide="pencil" class="me-1"></i> Gerenciar Lançamentos
                     </button>
                 </div>
             </div>`;
         card.querySelector('button').addEventListener('click', () => this.abrirModal(mes));
+        refreshIcons();
     }
 }
 

--- a/src/static/rateio/config.html
+++ b/src/static/rateio/config.html
@@ -5,7 +5,6 @@
     <title>Configurações de Rateio</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/brand.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
 <body>
@@ -21,31 +20,31 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin me-1"></i> Lançamentos</a>
+                        <a class="nav-link" href="/rateio/dashboard.html"><i data-lucide="coins" class="me-1"></i> Lançamentos</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" href="/rateio/config.html"><i class="bi bi-gear-fill me-1"></i> Configurações</a>
+                        <a class="nav-link active" href="/rateio/config.html"><i data-lucide="settings" class="me-1"></i> Configurações</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/rateio/instrutores.html"><i class="bi bi-person-badge me-1"></i> Instrutores</a>
+                        <a class="nav-link" href="/rateio/instrutores.html"><i data-lucide="id-card" class="me-1"></i> Instrutores</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="bi bi-person-circle me-1"></i>
+                            <i data-lucide="user-round" class="me-1"></i>
                             <span id="userName">Usuário</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
                             <li>
                                 <a class="dropdown-item" href="/rateio/perfil.html">
-                                    <i class="bi bi-person me-2"></i>Meu Perfil
+                                    <i data-lucide="user" class="me-2"></i>Meu Perfil
                                 </a>
                             </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="#" onclick="realizarLogout()">
-                                    <i class="bi bi-box-arrow-right me-2"></i>Sair
+                                    <i data-lucide="log-out" class="me-2"></i>Sair
                                 </a>
                             </li>
                         </ul>
@@ -60,11 +59,11 @@
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
-                        <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
-                        <a class="nav-link active" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
-                    <a class="nav-link" href="./rateio/instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                    <a class="nav-link" href="/rateio/logs.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
-                    <a class="nav-link" href="/rateio/perfil.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                        <a class="nav-link" href="/rateio/dashboard.html"><i data-lucide="coins"></i> Lançamentos</a>
+                        <a class="nav-link active" href="/rateio/config.html"><i data-lucide="settings"></i> Configurações</a>
+                    <a class="nav-link" href="./rateio/instrutores.html"><i data-lucide="id-card"></i> Instrutores</a>
+                    <a class="nav-link" href="/rateio/logs.html?modelo=LancamentoRateio"><i data-lucide="book-open-text"></i> Logs</a>
+                    <a class="nav-link" href="/rateio/perfil.html"><i data-lucide="user"></i> Meu Perfil</a>
                 </div>
                 </div>
             </div>
@@ -72,7 +71,7 @@
                     <div class="page-header">
                         <h1 class="mb-0">Configurações de Rateio</h1>
                         <button class="btn btn-primary" onclick="novaConfig()">
-                            <i class="bi bi-plus-circle me-2"></i>Nova Configuração
+                            <i data-lucide="plus-circle" class="me-2"></i>Nova Configuração
                         </button>
                     </div>
                 <div class="card mt-4">
@@ -155,8 +154,10 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
     <script src="/js/app.js"></script>
     <script src="/js/rateio/config.js"></script>
+    <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/rateio/dashboard.html
+++ b/src/static/rateio/dashboard.html
@@ -5,7 +5,6 @@
     <title>Lançamento de Rateio</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/brand.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
 <body>
@@ -21,31 +20,31 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link active" href="/rateio/dashboard.html"><i class="bi bi-cash-coin me-1"></i> Lançamentos</a>
+                        <a class="nav-link active" href="/rateio/dashboard.html"><i data-lucide="coins" class="me-1"></i> Lançamentos</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear-fill me-1"></i> Configurações</a>
+                        <a class="nav-link" href="/rateio/config.html"><i data-lucide="settings" class="me-1"></i> Configurações</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/rateio/instrutores.html"><i class="bi bi-person-badge me-1"></i> Instrutores</a>
+                        <a class="nav-link" href="/rateio/instrutores.html"><i data-lucide="id-card" class="me-1"></i> Instrutores</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="bi bi-person-circle me-1"></i>
+                            <i data-lucide="user-round" class="me-1"></i>
                             <span id="userName">Usuário</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
                             <li>
                                 <a class="dropdown-item" href="/rateio/perfil.html">
-                                    <i class="bi bi-person me-2"></i>Meu Perfil
+                                    <i data-lucide="user" class="me-2"></i>Meu Perfil
                                 </a>
                             </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="#" onclick="realizarLogout()">
-                                    <i class="bi bi-box-arrow-right me-2"></i>Sair
+                                    <i data-lucide="log-out" class="me-2"></i>Sair
                                 </a>
                             </li>
                         </ul>
@@ -60,11 +59,11 @@
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
-                        <a class="nav-link active" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
-                        <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
-                    <a class="nav-link" href="./rateio/instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                    <a class="nav-link" href="/rateio/logs.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
-                    <a class="nav-link" href="/rateio/perfil.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                        <a class="nav-link active" href="/rateio/dashboard.html"><i data-lucide="coins"></i> Lançamentos</a>
+                        <a class="nav-link" href="/rateio/config.html"><i data-lucide="settings"></i> Configurações</a>
+                    <a class="nav-link" href="./rateio/instrutores.html"><i data-lucide="id-card"></i> Instrutores</a>
+                    <a class="nav-link" href="/rateio/logs.html?modelo=LancamentoRateio"><i data-lucide="book-open-text"></i> Logs</a>
+                    <a class="nav-link" href="/rateio/perfil.html"><i data-lucide="user"></i> Meu Perfil</a>
                 </div>
                 </div>
             </div>
@@ -128,7 +127,7 @@
                             <div class="modal-footer">
                                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                                 <button type="button" class="btn btn-success" id="btnSalvarModal">
-                                    <i class="bi bi-save me-1"></i> Salvar Alterações
+                                    <i data-lucide="save" class="me-1"></i> Salvar Alterações
                                 </button>
                             </div>
                         </div>
@@ -139,8 +138,10 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
     <script src="/js/app.js"></script>
     <script src="/js/rateio/lancamentos.js"></script>
+    <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/rateio/instrutores.html
+++ b/src/static/rateio/instrutores.html
@@ -6,7 +6,6 @@
     <title>Gestão de Instrutores - Controle de Rateio</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/brand.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAIEAYAAADIFSHsAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAAAAAAAAPlDu38AAAAHdElNRQfpBgoBOhQj05UdAAADXUlEQVRIx92UbUzUdQDHP7/73zXgyjs6uPA8Kg82BgyYFDLNbt1YuWkOcqvZow8V4pouXYLQA3OSTHCGBBtl6RuaY7nVKtwCshU2EQRbK7BJhweUHOw87gTugfv/f72IttYbhRe59Xn/3b6f74uvsFpdrqam4ccBIK2DWyGRSNAe1Y7LfFjblWdZcQg2VjjrHKcheGGmLFoJ39T19nuq4KX3ntyYHYLwZ9FCNRcGbEMlXiukD6c6zQegs7TH5KkG+6b7ku+RMFY08W1wC/gGAlnhT2B3y7PHVo3AYdtHLT0GKGzLed9mg5ncuReijXCuqzc02giKouwXO27Z/l/4A7oF8c23nYkSQwMiRInB6oac6uXLQHVp3fIcBI7MPhx5HlIqLenGHkh6LfF0wna4kj9S7/saPMnX+wIDkOlytFqC8MzVJ5SMPZC119FniQNzeNlQXB8U3MjOSimGla22kyYV8iYziqz1kLIjadSYD9Yf7+1NMIAMy0xZu1jxv0k0LQxA2W1ndAgEiCThEdXQ++LPRde3grt2fHw6G9JrUucSi8HhsP9iPgOaTyuWd4N6VkuTN0GdVN+UzeCd8uXOlsLkO/7yuQdgnWvVyhWfgjESHzQkgLPpodX29XBjbfBgeBBcwwVj91+Eu07pm3XNIDvp4dpSxf+ps0TkZvbJzyGp3DwSPw0Pltl2m0YhWj7/lrofpk74j83lQNgebYhtg5QSi874FTh+tX9grofAczOm6Hpo93b/4K6BkTf+qAiYYPm2JI8xH7xW31NzVdB6vH3voAKqqtZrJyE+M67SUACzVaEP59uBt0Upa5Y+gH7RCQN6dCDShE+8C2fN5yfcW+DS5cGLE3qIbpiv0Log2DZ7JPI6nM+8/N24EwwX9BVKEELd4bZYB3T6e8qvbYXgyzNfRrbDgZKGNd/ng9KiuMXHMF8Tq9X6YfrKzRMRJwxYhgq9jaBoSp2YgtChyCNqKihduoO6XQC8upQhxF8nKOWikwo6BMhLDDIB8ieZIMtBbGCdcAAdtPA0yC+kX+4E+hnCCxwV+3gMyCNDJIP4XXSwC3DJV2gDeZVR/CBcFJAKwi3a2QkyKrOpBfkbY0yDOMwenCDOiKMUA2EixP7LAf4nLHyAP3Cni9wZYp1/AkYRW5V0uSBfAAAAAElFTkSuQmCC">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
@@ -23,31 +22,31 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
             <li class="nav-item">
-                <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin me-1"></i> Lançamentos</a>
+                <a class="nav-link" href="/rateio/dashboard.html"><i data-lucide="coins" class="me-1"></i> Lançamentos</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear-fill me-1"></i> Configurações</a>
+                <a class="nav-link" href="/rateio/config.html"><i data-lucide="settings" class="me-1"></i> Configurações</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link active" href="./rateio/instrutores.html"><i class="bi bi-person-badge me-1"></i> Instrutores</a>
+                <a class="nav-link active" href="./rateio/instrutores.html"><i data-lucide="id-card" class="me-1"></i> Instrutores</a>
             </li>
         </ul>
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="bi bi-person-circle me-1"></i>
+                            <i data-lucide="user-round" class="me-1"></i>
                             <span id="userName">Usuário</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
                             <li>
                                 <a class="dropdown-item" href="/ocupacao/perfil.html">
-                                    <i class="bi bi-person me-2"></i>Meu Perfil
+                                    <i data-lucide="user" class="me-2"></i>Meu Perfil
                                 </a>
                             </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="#" onclick="realizarLogout()">
-                                    <i class="bi bi-box-arrow-right me-2"></i>Sair
+                                    <i data-lucide="log-out" class="me-2"></i>Sair
                                 </a>
                             </li>
                         </ul>
@@ -63,11 +62,11 @@
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
-                        <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
-                        <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
-                        <a class="nav-link active" href="./rateio/instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                        <a class="nav-link" href="/rateio/logs.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
-                        <a class="nav-link" href="/rateio/perfil.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                        <a class="nav-link" href="/rateio/dashboard.html"><i data-lucide="coins"></i> Lançamentos</a>
+                        <a class="nav-link" href="/rateio/config.html"><i data-lucide="settings"></i> Configurações</a>
+                        <a class="nav-link active" href="./rateio/instrutores.html"><i data-lucide="id-card"></i> Instrutores</a>
+                        <a class="nav-link" href="/rateio/logs.html?modelo=LancamentoRateio"><i data-lucide="book-open-text"></i> Logs</a>
+                        <a class="nav-link" href="/rateio/perfil.html"><i data-lucide="user"></i> Meu Perfil</a>
                 </div>
                 </div>
             </div>
@@ -76,13 +75,13 @@
                 <div class="page-header">
                     <h1 class="mb-0">Gestão de Instrutores</h1>
                       <button id="btnAdicionarNovo" class="btn btn-primary">
-                          <i class="bi bi-plus-circle me-2"></i>Novo Instrutor
+                          <i data-lucide="plus-circle" class="me-2"></i>Novo Instrutor
                       </button>
                 </div>
 
                 <div class="card mb-4">
                     <div class="card-header">
-                        <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
+                        <h2 class="card-title mb-0"><i data-lucide="filter" class="me-2"></i>Filtros</h2>
                     </div>
                     <div class="card-body">
                         <div class="row g-3 align-items-end">
@@ -100,10 +99,10 @@
                             </div>
                             <div class="col-md-5 text-end">
                                 <button id="btnAplicarFiltros" type="button" class="btn btn-primary me-2">
-                                    <i class="bi bi-search me-1"></i>Filtrar
+                                    <i data-lucide="search" class="me-1"></i>Filtrar
                                 </button>
                                 <button id="btnLimparFiltros" type="button" class="btn btn-outline-secondary">
-                                    <i class="bi bi-x-circle me-1"></i>Limpar
+                                    <i data-lucide="x-circle" class="me-1"></i>Limpar
                                 </button>
                             </div>
                         </div>
@@ -112,7 +111,7 @@
 
                 <div class="card mt-4">
                     <div class="card-header">
-                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Lista de Instrutores</h2>
+                        <h2 class="card-title mb-0"><i data-lucide="list" class="me-2"></i>Lista de Instrutores</h2>
                     </div>
                     <div class="card-body p-0">
                         <div class="table-responsive">
@@ -203,7 +202,7 @@
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                     <button type="submit" form="formInstrutor" class="btn btn-primary" id="btnSalvarInstrutor">
                         <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
-                        <span class="btn-text"><i class="bi bi-check-circle me-1"></i>Salvar</span>
+                        <span class="btn-text"><i data-lucide="check-circle" class="me-1"></i>Salvar</span>
                     </button>
                 </div>
             </div>
@@ -223,7 +222,7 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                     <button type="button" id="confirmarExcluirInstrutor" class="btn btn-danger">
-                        <i class="bi bi-trash me-1"></i>Excluir
+                        <i data-lucide="trash" class="me-1"></i>Excluir
                     </button>
                 </div>
             </div>
@@ -231,9 +230,11 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/rateio/instrutores.js"></script>
+    <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             if (!isUserAdmin()) {

--- a/src/static/rateio/logs.html
+++ b/src/static/rateio/logs.html
@@ -6,7 +6,6 @@
     <title>Logs de Rateio</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/brand.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
 <body>
@@ -22,31 +21,31 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin me-1"></i> Lançamentos</a>
+                        <a class="nav-link" href="/rateio/dashboard.html"><i data-lucide="coins" class="me-1"></i> Lançamentos</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear-fill me-1"></i> Configurações</a>
+                        <a class="nav-link" href="/rateio/config.html"><i data-lucide="settings" class="me-1"></i> Configurações</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/rateio/instrutores.html"><i class="bi bi-person-badge me-1"></i> Instrutores</a>
+                        <a class="nav-link" href="/rateio/instrutores.html"><i data-lucide="id-card" class="me-1"></i> Instrutores</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="bi bi-person-circle me-1"></i>
+                            <i data-lucide="user-round" class="me-1"></i>
                             <span id="userName">Usuário</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
                             <li>
                                 <a class="dropdown-item" href="/rateio/perfil.html">
-                                    <i class="bi bi-person me-2"></i>Meu Perfil
+                                    <i data-lucide="user" class="me-2"></i>Meu Perfil
                                 </a>
                             </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="#" onclick="realizarLogout()">
-                                    <i class="bi bi-box-arrow-right me-2"></i>Sair
+                                    <i data-lucide="log-out" class="me-2"></i>Sair
                                 </a>
                             </li>
                         </ul>
@@ -61,23 +60,23 @@
             <div class="sidebar rounded shadow-sm">
                 <h2 class="mb-3">Menu Principal</h2>
                 <div class="nav flex-column">
-                    <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
-                    <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
-                    <a class="nav-link" href="/rateio/instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                    <a class="nav-link active" href="/rateio/logs.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
-                    <a class="nav-link" href="/rateio/perfil.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                    <a class="nav-link" href="/rateio/dashboard.html"><i data-lucide="coins"></i> Lançamentos</a>
+                    <a class="nav-link" href="/rateio/config.html"><i data-lucide="settings"></i> Configurações</a>
+                    <a class="nav-link" href="/rateio/instrutores.html"><i data-lucide="id-card"></i> Instrutores</a>
+                    <a class="nav-link active" href="/rateio/logs.html?modelo=LancamentoRateio"><i data-lucide="book-open-text"></i> Logs</a>
+                    <a class="nav-link" href="/rateio/perfil.html"><i data-lucide="user"></i> Meu Perfil</a>
                 </div>
             </div>
         </div>
         <main class="col-lg-9 col-md-12">
             <div class="page-header">
                 <h1 class="mb-0">Logs de Rateio</h1>
-                <button id="btnExportarCsv" class="btn btn-outline-primary"><i class="bi bi-download me-1"></i>Exportar CSV</button>
+                <button id="btnExportarCsv" class="btn btn-outline-primary"><i data-lucide="download" class="me-1"></i>Exportar CSV</button>
             </div>
 
             <div class="card mt-4">
                 <div class="card-header">
-                    <h2 class="card-title mb-0"><i class="bi bi-funnel me-2"></i>Filtros</h2>
+                    <h2 class="card-title mb-0"><i data-lucide="filter" class="me-2"></i>Filtros</h2>
                 </div>
                 <div class="card-body">
                     <div class="row">
@@ -105,8 +104,8 @@
                     </div>
                     <div class="row mt-3">
                         <div class="col-12">
-                            <button type="button" class="btn btn-primary me-2" id="btnAplicarFiltros"><i class="bi bi-search me-1"></i>Filtrar</button>
-                            <button type="button" class="btn btn-outline-secondary" id="btnLimparFiltros"><i class="bi bi-x-circle me-1"></i>Limpar</button>
+                            <button type="button" class="btn btn-primary me-2" id="btnAplicarFiltros"><i data-lucide="search" class="me-1"></i>Filtrar</button>
+                            <button type="button" class="btn btn-outline-secondary" id="btnLimparFiltros"><i data-lucide="x-circle" class="me-1"></i>Limpar</button>
                         </div>
                     </div>
                 </div>
@@ -114,7 +113,7 @@
 
             <div class="card mt-4">
                     <div class="card-header">
-                        <h2 class="card-title mb-0"><i class="bi bi-list me-2"></i>Histórico de Logs</h2>
+                        <h2 class="card-title mb-0"><i data-lucide="list" class="me-2"></i>Histórico de Logs</h2>
                     </div>
                 <div class="card-body p-0">
                     <div class="table-responsive">
@@ -147,9 +146,11 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://unpkg.com/lucide@latest"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
 <script src="/js/app.js"></script>
 <script src="/js/rateio/logs.js"></script>
+<script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/rateio/perfil.html
+++ b/src/static/rateio/perfil.html
@@ -6,7 +6,6 @@
     <title>Meu Perfil - Controle de Rateio</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/brand.css">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAIEAYAAADIFSHsAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAAAAAAAAPlDu38AAAAHdElNRQfpBgoBOhQj05UdAAADXUlEQVRIx92UbUzUdQDHP7/73zXgyjs6uPA8Kg82BgyYFDLNbt1YuWkOcqvZow8V4pouXYLQA3OSTHCGBBtl6RuaY7nVKtwCshU2EQRbK7BJhweUHOw87gTugfv/f72IttYbhRe59Xn/3b6f74uvsFpdrqam4ccBIK2DWyGRSNAe1Y7LfFjblWdZcQg2VjjrHKcheGGmLFoJ39T19nuq4KX3ntyYHYLwZ9FCNRcGbEMlXiukD6c6zQegs7TH5KkG+6b7ku+RMFY08W1wC/gGAlnhT2B3y7PHVo3AYdtHLT0GKGzLed9mg5ncuReijXCuqzc02giKouwXO27Z/l/4A7oF8c23nYkSQwMiRInB6oac6uXLQHVp3fIcBI7MPhx5HlIqLenGHkh6LfF0wna4kj9S7/saPMnX+wIDkOlytFqC8MzVJ5SMPZC119FniQNzeNlQXB8U3MjOSimGla22kyYV8iYziqz1kLIjadSYD9Yf7+1NMIAMy0xZu1jxv0k0LQxA2W1ndAgEiCThEdXQ++LPRde3grt2fHw6G9JrUucSi8HhsP9iPgOaTyuWd4N6VkuTN0GdVN+UzeCd8uXOlsLkO/7yuQdgnWvVyhWfgjESHzQkgLPpodX29XBjbfBgeBBcwwVj91+Eu07pm3XNIDvp4dpSxf+ps0TkZvbJzyGp3DwSPw0Pltl2m0YhWj7/lrofpk74j83lQNgebYhtg5QSi874FTh+tX9grofAczOm6Hpo93b/4K6BkTf+qAiYYPm2JI8xH7xW31NzVdB6vH3voAKqqtZrJyE+M67SUACzVaEP59uBt0Upa5Y+gH7RCQN6dCDShE+8C2fN5yfcW+DS5cGLE3qIbpiv0Log2DZ7JPI6nM+8/N24EwwX9BVKEELd4bZYB3T6e8qvbYXgyzNfRrbDgZKGNd/ng9KiuMXHMF8Tq9X6YfrKzRMRJwxYhgq9jaBoSp2YgtChyCNqKihduo6XQC8upQhxF8nKOWikwo6BMhLDDIB8ieZIMtBbGCdcAAdtPA0yC+kX+4E+hnCCxwV+3gMyCNDJIP4XXSwC3DJV2gDeZVR/CBcFJAKwi3a2QkyKrOpBfkbY0yDOMwenCDOiKMUA2EixP7LAf4nLHyAP3Cni9wZYp1/AkYRW5V0uSBfAAAAAElFTkSuQmCC">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
@@ -23,31 +22,31 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
             <li class="nav-item">
-                <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin me-1"></i> Lançamentos</a>
+                <a class="nav-link" href="/rateio/dashboard.html"><i data-lucide="coins" class="me-1"></i> Lançamentos</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear-fill me-1"></i> Configurações</a>
+                <a class="nav-link" href="/rateio/config.html"><i data-lucide="settings" class="me-1"></i> Configurações</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="./rateio/instrutores.html"><i class="bi bi-person-badge me-1"></i> Instrutores</a>
+                <a class="nav-link" href="./rateio/instrutores.html"><i data-lucide="id-card" class="me-1"></i> Instrutores</a>
             </li>
         </ul>
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="bi bi-person-circle me-1"></i>
+                            <i data-lucide="user-round" class="me-1"></i>
                             <span id="userName">Usuário</span>
                         </a>
                         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
                             <li>
                                 <a class="dropdown-item active" href="/ocupacao/perfil.html">
-                                    <i class="bi bi-person me-2"></i> Meu Perfil
+                                    <i data-lucide="user" class="me-2"></i> Meu Perfil
                                 </a>
                             </li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <a class="dropdown-item" href="#" id="btnLogout">
-                                    <i class="bi bi-box-arrow-right me-2"></i> Sair
+                                    <i data-lucide="log-out" class="me-2"></i> Sair
                                 </a>
                             </li>
                         </ul>
@@ -63,11 +62,11 @@
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
                     <div class="nav flex-column">
-                        <a class="nav-link" href="/rateio/dashboard.html"><i class="bi bi-cash-coin"></i> Lançamentos</a>
-                        <a class="nav-link" href="/rateio/config.html"><i class="bi bi-gear"></i> Configurações</a>
-                        <a class="nav-link" href="./rateio/instrutores.html"><i class="bi bi-person-badge"></i> Instrutores</a>
-                        <a class="nav-link" href="/rateio/logs.html?modelo=LancamentoRateio"><i class="bi bi-journal-text"></i> Logs</a>
-                        <a class="nav-link active" href="/rateio/perfil.html"><i class="bi bi-person"></i> Meu Perfil</a>
+                        <a class="nav-link" href="/rateio/dashboard.html"><i data-lucide="coins"></i> Lançamentos</a>
+                        <a class="nav-link" href="/rateio/config.html"><i data-lucide="settings"></i> Configurações</a>
+                        <a class="nav-link" href="./rateio/instrutores.html"><i data-lucide="id-card"></i> Instrutores</a>
+                        <a class="nav-link" href="/rateio/logs.html?modelo=LancamentoRateio"><i data-lucide="book-open-text"></i> Logs</a>
+                        <a class="nav-link active" href="/rateio/perfil.html"><i data-lucide="user"></i> Meu Perfil</a>
                 </div>
                 </div>
             </div>
@@ -120,7 +119,7 @@
                                     </div>
                                     
                                     <button type="submit" class="btn btn-primary">
-                                        <i class="bi bi-save me-2"></i>Salvar Alterações
+                                        <i data-lucide="save" class="me-2"></i>Salvar Alterações
                                     </button>
                                 </form>
                             </div>
@@ -150,7 +149,7 @@
                                     </div>
                                     
                                     <button type="submit" class="btn btn-primary">
-                                        <i class="bi bi-lock me-2"></i>Alterar Senha
+                                        <i data-lucide="lock" class="me-2"></i>Alterar Senha
                                     </button>
                                 </form>
                             </div>
@@ -186,8 +185,10 @@
 </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="/js/app.js"></script>
+    <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Verifica autenticação


### PR DESCRIPTION
## Summary
- standardize design system to use Lucide Icons
- swap Bootstrap Icons for Lucide across Rateio pages
- render dynamic icons with refreshIcons helper

## Testing
- `pre-commit run --files docs/design-system.md src/static/js/app.js src/static/js/rateio/config.js src/static/js/rateio/instrutores.js src/static/js/rateio/lancamentos.js src/static/rateio/config.html src/static/rateio/dashboard.html src/static/rateio/instrutores.html src/static/rateio/logs.html src/static/rateio/perfil.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c266ad348323802ffea49df2487e