### PR TITLE
feat: enhance focus and link styling

### DIFF
--- a/src/static/css/brand.css
+++ b/src/static/css/brand.css
@@ -60,3 +60,5 @@ h3,h4,h5,h6, .subtitle{ font-weight: 500; }
 
 .brand-gradient{ background: linear-gradient(135deg, #164194 0%, #008BD2 100%); }
 .brand-shear{ transform: skewY(-9.19deg); }
+:focus-visible{ outline: 3px solid #f3c258; outline-offset: 2px; } /* amarelo da paleta */
+a:not(.btn){ text-decoration-thickness: .12em; text-underline-offset: .2em; }


### PR DESCRIPTION
## Summary
- add visible focus outline using brand yellow
- thicken and offset link text decoration

## Testing
- `pre-commit run --files src/static/css/brand.css`

------
https://chatgpt.com/codex/tasks/task_e_6898e09daef08323b1b0b2e6015f3f2a