### PR TITLE
Add planejamento blueprint with routes and assets

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,7 @@
+from flask import Flask
+from app.planejamento import bp as planejamento_bp
+
+app = Flask(__name__, static_folder="static", template_folder="templates")
+app.register_blueprint(planejamento_bp, url_prefix="/planejamento")
+
+__all__ = ["app"]

--- a/app/planejamento/__init__.py
+++ b/app/planejamento/__init__.py
@@ -1,0 +1,6 @@
+"""Blueprint do módulo de planejamento."""
+from flask import Blueprint
+
+bp = Blueprint("planejamento", __name__)
+
+from app.planejamento import routes, api  # noqa: F401,E402

--- a/app/planejamento/api.py
+++ b/app/planejamento/api.py
@@ -1,0 +1,10 @@
+"""Endpoints de API para o módulo de planejamento."""
+from flask import jsonify
+
+from app.planejamento import bp
+
+
+@bp.route("/status")
+def status():
+    """Endpoint simples de status."""
+    return jsonify({"status": "ok"})

--- a/app/planejamento/forms.py
+++ b/app/planejamento/forms.py
@@ -1,0 +1,8 @@
+"""Formulários para o módulo de planejamento."""
+from flask_wtf import FlaskForm
+from wtforms import StringField
+from wtforms.validators import DataRequired
+
+
+class PlanejamentoForm(FlaskForm):
+    nome = StringField("Nome", validators=[DataRequired()])

--- a/app/planejamento/models.py
+++ b/app/planejamento/models.py
@@ -1,0 +1,13 @@
+"""Modelos para o módulo de planejamento."""
+from flask_sqlalchemy import SQLAlchemy
+
+# Inicializa um objeto SQLAlchemy para ser associado à aplicação.
+db = SQLAlchemy()
+
+
+class Planejamento(db.Model):
+    """Representa um planejamento simples."""
+    __tablename__ = "planejamentos"
+
+    id = db.Column(db.Integer, primary_key=True)
+    nome = db.Column(db.String(120), nullable=False)

--- a/app/planejamento/routes.py
+++ b/app/planejamento/routes.py
@@ -1,0 +1,10 @@
+"""Rotas web para o módulo de planejamento."""
+from flask import render_template
+
+from app.planejamento import bp
+
+
+@bp.route("/")
+def index():
+    """Página inicial do módulo de planejamento."""
+    return render_template("planejamento/index.html")

--- a/app/static/js/planejamento.js
+++ b/app/static/js/planejamento.js
@@ -1,0 +1,1 @@
+console.log('Planejamento module loaded');

--- a/app/templates/planejamento/index.html
+++ b/app/templates/planejamento/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <title>Planejamento</title>
+    <script src="{{ url_for('static', filename='js/planejamento.js') }}"></script>
+</head>
+<body>
+    <h1>Módulo de Planejamento</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold planejamento module with model, routes, forms and API
- add template and static JS for planejamento
- register planejamento blueprint in app factory

## Testing
- `pre-commit run --files app/__init__.py app/planejamento/__init__.py app/planejamento/models.py app/planejamento/routes.py app/planejamento/api.py app/planejamento/forms.py app/templates/planejamento/index.html app/static/js/planejamento.js` *(fails: bandit)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de44a1c8483239322971de33afe49