### PR TITLE
Handle missing planejamento module in models initialization

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -13,7 +13,16 @@ from .treinamento import (  # noqa: E402
     TurmaTreinamento,
     InscricaoTreinamento,
 )  # noqa: E402
-from app.planejamento.models import Planejamento  # noqa: E402
+
+# Planejamento é um módulo opcional localizado fora do pacote ``src``.
+# Em alguns ambientes ele pode não estar instalado no ``PYTHONPATH``,
+# o que fazia o Gunicorn falhar ao inicializar.  Realizamos a importação
+# de forma defensiva para que a ausência do módulo não interrompa o
+# carregamento dos demais modelos.
+try:  # pragma: no cover - caminho simples já testado nos imports
+    from app.planejamento.models import Planejamento  # noqa: E402
+except ImportError:  # pragma: no cover - módulo ausente é aceitável
+    Planejamento = None
 
 __all__ = [
     "db",
@@ -26,5 +35,7 @@ __all__ = [
     "Treinamento",
     "TurmaTreinamento",
     "InscricaoTreinamento",
-    "Planejamento",
 ]
+
+if Planejamento is not None:
+    __all__.append("Planejamento")


### PR DESCRIPTION
## Summary
- avoid server crash when optional planejamento module is absent

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689df9a322c0832383e3ad30782eb715