### PR TITLE
Add spreadsheet import and export for planning

### DIFF
--- a/app/planejamento/api.py
+++ b/app/planejamento/api.py
@@ -1,13 +1,26 @@
 """Endpoints de API para o módulo de planejamento."""
-from datetime import date
+from datetime import date, datetime
+import io
 
-from flask import jsonify, request, abort
+from flask import jsonify, request, abort, send_file
 from sqlalchemy import extract
+from openpyxl import load_workbook, Workbook
 
 from app.auth import require_roles, ROLE_ADMIN, ROLE_GESTOR, ROLE_USER
 from app.extensions import db
 from app.planejamento import bp
 from app.planejamento.models import Planejamento
+from src.models.instrutor import Instrutor
+
+
+def get_or_create_instrutor(nome: str) -> Instrutor:
+    """Obtém um instrutor pelo nome ou cria um novo caso não exista."""
+    instrutor = Instrutor.query.filter_by(nome=nome).first()
+    if not instrutor:
+        instrutor = Instrutor(nome=nome)
+        db.session.add(instrutor)
+        db.session.flush()
+    return instrutor
 
 
 @bp.get("/api/planejamento")
@@ -100,3 +113,105 @@ def api_delete(pid: int):
     db.session.delete(p)
     db.session.commit()
     return jsonify({"ok": True})
+
+
+@bp.post("/api/planejamento/import")
+@require_roles(ROLE_ADMIN, ROLE_GESTOR)
+def api_import():
+    # Aceitar arquivo .xlsx com 2 formatos:
+    # (A) Lista com colunas: DATA, SEMANA, TURNO, CARGA, MODALIDADE, TREINAMENTO, INSTRUTOR, LOCAL, CLIENTE, OBS
+    # (B) Matriz (Data x Instrutores): célula contém o nome do treinamento; turno vem de coluna dedicada
+    f = request.files["file"]
+    wb = load_workbook(filename=io.BytesIO(f.read()), data_only=True)
+    ws = wb.active
+    headers = [
+        str((ws.cell(row=1, column=i).value or "")).strip().upper()
+        for i in range(1, ws.max_column + 1)
+    ]
+
+    def col(name):
+        return headers.index(name) + 1 if name in headers else None
+
+    if col("DATA") and col("TURNO") and col("TREINAMENTO") and col("INSTRUTOR"):
+        for r in range(2, ws.max_row + 1):
+            d = ws.cell(r, col("DATA")).value
+            if not d:
+                continue
+            data = d.date() if hasattr(d, "date") else datetime.strptime(str(d), "%d/%m/%Y").date()
+            turno = (
+                (ws.cell(r, col("TURNO")).value or "")
+                .upper()[:5]
+                .replace("Ã", "A")
+                .replace("Â", "A")
+            )
+            instrutor_nome = str(ws.cell(r, col("INSTRUTOR")).value or "").strip()
+            instrutor = get_or_create_instrutor(instrutor_nome)
+            p = Planejamento(
+                data=data,
+                turno=turno,
+                carga_horas=ws.cell(r, col("CARGA")).value if col("CARGA") else None,
+                modalidade=ws.cell(r, col("MODALIDADE")).value if col("MODALIDADE") else None,
+                treinamento=ws.cell(r, col("TREINAMENTO")).value,
+                instrutor_id=instrutor.id,
+                local=ws.cell(r, col("LOCAL")).value if col("LOCAL") else None,
+                cliente=ws.cell(r, col("CLIENTE")).value if col("CLIENTE") else None,
+                observacao=ws.cell(r, col("OBS")).value if col("OBS") else None,
+                origem="Importado",
+            )
+            db.session.add(p)
+        db.session.commit()
+        return jsonify({"ok": True})
+    # TODO: tratar formato B (matriz) — mapear cabeçalho como instrutores e varrer linhas por data/turno.
+    abort(400, "Formato de planilha não reconhecido")
+
+
+@bp.get("/api/planejamento/export")
+@require_roles(ROLE_ADMIN, ROLE_GESTOR, ROLE_USER)
+def api_export():
+    mes = request.args.get("mes")
+    y, m = [int(x) for x in mes.split("-")]
+    q = Planejamento.query.filter(
+        extract("year", Planejamento.data) == y,
+        extract("month", Planejamento.data) == m,
+    ).all()
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Planejamento"
+    ws.append([
+        "DATA",
+        "SEMANA",
+        "TURNO",
+        "CARGA",
+        "MODALIDADE",
+        "TREINAMENTO",
+        "INSTRUTOR",
+        "LOCAL",
+        "CLIENTE",
+        "STATUS",
+        "OBSERVACAO",
+    ])
+    for p in q:
+        d = p.data
+        ws.append([
+            d.strftime("%d/%m/%Y"),
+            ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"][d.weekday()],
+            p.turno,
+            p.carga_horas,
+            p.modalidade,
+            p.treinamento,
+            p.instrutor.nome if p.instrutor else "",
+            p.local,
+            p.cliente,
+            p.status,
+            p.observacao or "",
+        ])
+    stream = io.BytesIO()
+    wb.save(stream)
+    stream.seek(0)
+    filename = f"planejamento_{mes}.xlsx"
+    return send_file(
+        stream,
+        as_attachment=True,
+        download_name=filename,
+        mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from src.routes.ocupacao import sala_bp, instrutor_bp, ocupacao_bp
 from src.routes.treinamentos import turma_bp, treinamento_bp
 from src.routes.laboratorios import agendamento_bp, laboratorio_bp
 from src.routes.rateio.rateio import rateio_bp
+from app.planejamento import bp as planejamento_bp
 
 @pytest.fixture
 def app():
@@ -45,6 +46,7 @@ def app():
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
     app.register_blueprint(laboratorio_bp, url_prefix='/api')
     app.register_blueprint(rateio_bp, url_prefix='/api')
+    app.register_blueprint(planejamento_bp)
 
     with app.app_context():
         db.create_all()

--- a/tests/test_planejamento_api.py
+++ b/tests/test_planejamento_api.py
@@ -1,0 +1,84 @@
+import io
+from datetime import date
+
+from openpyxl import Workbook, load_workbook
+
+from app.planejamento.models import Planejamento
+from src.models import db
+from src.models.instrutor import Instrutor
+
+
+def test_api_planejamento_export(client):
+    with client.application.app_context():
+        instr = Instrutor(nome="Instrutor Teste")
+        db.session.add(instr)
+        db.session.flush()
+        p = Planejamento(
+            data=date(2024, 1, 5),
+            turno="MANHA",
+            carga_horas=8,
+            modalidade="Presencial",
+            treinamento="Curso X",
+            instrutor_id=instr.id,
+            local="Sala 1",
+            cliente="Cliente",
+            status="Planejado",
+            origem="Manual",
+        )
+        db.session.add(p)
+        db.session.commit()
+    resp = client.get("/api/planejamento/export?mes=2024-01", headers={"X-Role": "ROLE_USER"})
+    assert resp.status_code == 200
+    wb = load_workbook(filename=io.BytesIO(resp.data))
+    ws = wb.active
+    assert ws.title == "Planejamento"
+    assert ws.cell(row=2, column=1).value == "05/01/2024"
+    assert ws.cell(row=2, column=7).value == "Instrutor Teste"
+
+
+def test_api_planejamento_import(client):
+    wb = Workbook()
+    ws = wb.active
+    ws.append([
+        "DATA",
+        "SEMANA",
+        "TURNO",
+        "CARGA",
+        "MODALIDADE",
+        "TREINAMENTO",
+        "INSTRUTOR",
+        "LOCAL",
+        "CLIENTE",
+        "OBS",
+    ])
+    ws.append([
+        "05/01/2024",
+        "Sex",
+        "MANHA",
+        8,
+        "Presencial",
+        "Curso Y",
+        "Instrutor Novo",
+        "Sala",
+        "Cliente",
+        "Observacao",
+    ])
+    stream = io.BytesIO()
+    wb.save(stream)
+    stream.seek(0)
+    data = {"file": (stream, "import.xlsx")}
+    resp = client.post(
+        "/api/planejamento/import",
+        data=data,
+        content_type="multipart/form-data",
+        headers={"X-Role": "ROLE_ADMIN"},
+    )
+    assert resp.status_code == 200
+    assert resp.json["ok"] is True
+    with client.application.app_context():
+        itens = Planejamento.query.all()
+        assert len(itens) == 1
+        p = itens[0]
+        assert p.treinamento == "Curso Y"
+        instrutor = Instrutor.query.get(p.instrutor_id)
+        assert instrutor.nome == "Instrutor Novo"


### PR DESCRIPTION
## Summary
- implement XLSX import and export routes for planning module
- add helper for instructor creation and register blueprint in tests
- cover planning import/export with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e11fd90cc83238fef219a7dafb050