### PR TITLE
Add planning conflict checks and accessibility improvements

### DIFF
--- a/app/planejamento/api.py
+++ b/app/planejamento/api.py
@@ -63,6 +63,13 @@ def api_list():
 def api_create():
     """Cria um novo item de planejamento."""
     data = request.get_json() or {}
+    exists = Planejamento.query.filter_by(
+        data=data["data"],
+        turno=data["turno"],
+        instrutor_id=data["instrutor_id"],
+    ).first()
+    if exists:
+        return jsonify({"error": "Conflito de agenda"}), 409
     p = Planejamento(
         data=data["data"],
         turno=data["turno"],
@@ -87,6 +94,14 @@ def api_update(pid: int):
     """Atualiza um item de planejamento existente."""
     p = Planejamento.query.get_or_404(pid)
     data = request.get_json() or {}
+    new_data = data.get("data", p.data)
+    new_turno = data.get("turno", p.turno)
+    new_instrutor = data.get("instrutor_id", p.instrutor_id)
+    exists = Planejamento.query.filter_by(
+        data=new_data, turno=new_turno, instrutor_id=new_instrutor
+    ).first()
+    if exists and exists.id != pid:
+        return jsonify({"error": "Conflito de agenda"}), 409
     for f in [
         "data",
         "turno",

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,17 +5,28 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Conecta SENAI{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
 </head>
 <body>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
     <div class="container-fluid">
       <a class="navbar-brand" href="{{ url_for('planejamento.index') }}">Conecta SENAI</a>
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('planejamento.index') }}">
+            <i class="bi bi-calendar2-week" aria-hidden="true"></i> Planejamento
+          </a>
+        </li>
+      </ul>
     </div>
   </nav>
   <main class="container">
     {% block content %}{% endblock %}
   </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    window.userCanEdit = {{ 'true' if user_role in ('ADMIN','GESTOR') else 'false' }};
+  </script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app/templates/planejamento/matriz.html
+++ b/app/templates/planejamento/matriz.html
@@ -37,45 +37,45 @@
 <div class="modal fade" id="mdlSlot" tabindex="-1">
   <div class="modal-dialog modal-lg"><div class="modal-content">
     <div class="modal-header bg-primary text-white"><h5 class="modal-title">Editar Slot</h5>
-      <button class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+      <button class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fechar"></button>
     </div>
     <div class="modal-body">
       <form id="formSlot" class="row g-3">
         <input type="hidden" id="slotId">
         <div class="col-md-4">
-          <label class="form-label">Treinamento</label>
-          <input id="treinamento" class="form-control" required>
+          <label for="treinamento" class="form-label">Treinamento</label>
+          <input id="treinamento" class="form-control" required aria-label="Treinamento" autofocus>
         </div>
         <div class="col-md-3">
-          <label class="form-label">Modalidade</label>
-          <select id="modalidade" class="form-select">
+          <label for="modalidade" class="form-label">Modalidade</label>
+          <select id="modalidade" class="form-select" aria-label="Modalidade">
             <option>Presencial</option><option>Online</option>
           </select>
         </div>
         <div class="col-md-2">
-          <label class="form-label">Carga (h)</label>
-          <input id="carga" type="number" class="form-control" min="1">
+          <label for="carga" class="form-label">Carga (h)</label>
+          <input id="carga" type="number" class="form-control" min="1" aria-label="Carga horária">
         </div>
         <div class="col-md-3">
-          <label class="form-label">Status</label>
-          <select id="status" class="form-select">
+          <label for="status" class="form-label">Status</label>
+          <select id="status" class="form-select" aria-label="Status">
             <option>Planejado</option><option>Confirmado</option><option>Cancelado</option>
           </select>
         </div>
         <div class="col-md-6">
-          <label class="form-label">Local</label><input id="local" class="form-control">
+          <label for="local" class="form-label">Local</label><input id="local" class="form-control" aria-label="Local">
         </div>
         <div class="col-md-6">
-          <label class="form-label">Cliente</label><input id="cliente" class="form-control" placeholder="CMD / SAG / SIB ...">
+          <label for="cliente" class="form-label">Cliente</label><input id="cliente" class="form-control" placeholder="CMD / SAG / SIB ..." aria-label="Cliente">
         </div>
         <div class="col-12">
-          <label class="form-label">Observação</label><textarea id="obs" class="form-control"></textarea>
+          <label for="obs" class="form-label">Observação</label><textarea id="obs" class="form-control" aria-label="Observação"></textarea>
         </div>
       </form>
     </div>
     <div class="modal-footer">
-      <button class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
-      <button id="btnSalvarSlot" class="btn btn-primary">Salvar</button>
+      <button class="btn btn-secondary" data-bs-dismiss="modal" accesskey="f">Fechar</button>
+      <button id="btnSalvarSlot" class="btn btn-primary" accesskey="s">Salvar</button>
     </div>
   </div></div>
 </div>

--- a/scripts/seed_planejamento.py
+++ b/scripts/seed_planejamento.py
@@ -1,0 +1,26 @@
+from datetime import date
+
+from app import app
+from app.extensions import db
+from app.planejamento.models import Planejamento
+from src.models.instrutor import Instrutor
+
+
+def run():
+    """Cria registros de exemplo para o módulo de planejamento."""
+    with app.app_context():
+        instrutor = Instrutor(nome="Instrutor Demo")
+        db.session.add(instrutor)
+        db.session.flush()
+        itens = [
+            Planejamento(data=date(2024, 1, 10), turno="MANHA", treinamento="Curso A", instrutor_id=instrutor.id),
+            Planejamento(data=date(2024, 1, 11), turno="TARDE", treinamento="Curso B", instrutor_id=instrutor.id),
+            Planejamento(data=date(2024, 1, 12), turno="NOITE", treinamento="Curso C", instrutor_id=instrutor.id),
+        ]
+        db.session.add_all(itens)
+        db.session.commit()
+        print("Planejamentos de exemplo criados.")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_planejamento_api.py
+++ b/tests/test_planejamento_api.py
@@ -35,7 +35,6 @@ def test_api_planejamento_export(client):
     assert ws.cell(row=2, column=1).value == "05/01/2024"
     assert ws.cell(row=2, column=7).value == "Instrutor Teste"
 
-
 def test_api_planejamento_import(client):
     wb = Workbook()
     ws = wb.active
@@ -82,3 +81,43 @@ def test_api_planejamento_import(client):
         assert p.treinamento == "Curso Y"
         instrutor = Instrutor.query.get(p.instrutor_id)
         assert instrutor.nome == "Instrutor Novo"
+
+
+def test_api_planejamento_conflict(client):
+    with client.application.app_context():
+        instr = Instrutor(nome="Instrutor Conflito")
+        db.session.add(instr)
+        db.session.flush()
+        instr_id = instr.id
+        p1 = Planejamento(
+            data=date(2024, 1, 1),
+            turno="MANHA",
+            treinamento="Curso 1",
+            instrutor_id=instr_id,
+        )
+        p2 = Planejamento(
+            data=date(2024, 1, 2),
+            turno="TARDE",
+            treinamento="Curso 2",
+            instrutor_id=instr_id,
+        )
+        db.session.add_all([p1, p2])
+        db.session.commit()
+        pid2 = p2.id
+    resp = client.post(
+        "/api/planejamento",
+        json={
+            "data": "2024-01-01",
+            "turno": "MANHA",
+            "treinamento": "Curso X",
+            "instrutor_id": instr_id,
+        },
+        headers={"X-Role": "ROLE_ADMIN"},
+    )
+    assert resp.status_code == 409
+    resp2 = client.put(
+        f"/api/planejamento/{pid2}",
+        json={"data": "2024-01-01", "turno": "MANHA"},
+        headers={"X-Role": "ROLE_ADMIN"},
+    )
+    assert resp2.status_code == 409


### PR DESCRIPTION
## Summary
- add navigation link for Planejamento and expose user edit permissions
- enforce backend schedule conflict detection with 409 responses
- improve planning modal accessibility and add seed data script
- test duplicate scheduling scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1667e44883238e0bbdf7dd50ee1b