### PR TITLE
Add planning module card to system selection page

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -111,6 +111,7 @@ function obterModulosDisponiveis(usuario) {
     const modulos = [
         '/laboratorios/dashboard.html',
         '/treinamentos/index.html',
+        '/planejamento/',
         '/ocupacao/dashboard.html'
     ];
 

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -87,6 +87,21 @@
             </div>
 
             <div class="col-md-5 mb-4">
+                <div class="card sistema-card h-100" data-url="/planejamento/">
+                    <div class="card-body text-center p-5">
+                        <div class="sistema-icon">
+                            <i class="bi bi-graph-up"></i>
+                        </div>
+                        <h2 class="card-title">Planejamento de Treinamentos</h2>
+                        <p class="card-text">Ferramenta para planejamento e análise de treinamentos.</p>
+                        <div class="mt-4">
+                            <span class="badge bg-success">Disponível</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-5 mb-4">
                 <div class="card sistema-card h-100" data-url="/ocupacao/dashboard.html">
                     <div class="card-body text-center p-5">
                         <div class="sistema-icon">


### PR DESCRIPTION
## Summary
- Add card for Planejamento de Treinamentos with graph icon and description
- Include new module in available modules list for login redirection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e214776a88323b35c02b630afc161