### PR TITLE
Add static pages for training planning module

### DIFF
--- a/src/static/planejamento-instrutores.html
+++ b/src/static/planejamento-instrutores.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Planejamento por Instrutores - Sistema FIEMG</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/static/css/brand.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Planejamento de Treinamentos">Sistema FIEMG | Planejamento de Treinamentos</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-person-circle me-1"></i>
+                            <span id="userName">Usuário</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                            <li><a class="dropdown-item" href="#" id="btnLogout"><i class="bi bi-box-arrow-right me-2"></i>Sair</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container-fluid py-4">
+        <main>
+            <div class="page-header">
+                <h1 class="mb-0">Planejamento por Instrutores</h1>
+            </div>
+            </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/planejamento-treinamentos.html
+++ b/src/static/planejamento-treinamentos.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Planejamento de Treinamentos - Sistema FIEMG</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/static/css/brand.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Planejamento de Treinamentos">Sistema FIEMG | Planejamento de Treinamentos</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link active" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-person-circle me-1"></i>
+                            <span id="userName">Usuário</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                            <li><a class="dropdown-item" href="#" id="btnLogout"><i class="bi bi-box-arrow-right me-2"></i>Sair</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container-fluid py-4">
+        <main>
+            <div class="page-header">
+                <h1 class="mb-0">Treinamentos Disponíveis</h1>
+            </div>
+            </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Planejamento Trimestral - Sistema FIEMG</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/static/css/brand.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
+        <div class="container-fluid">
+            <a class="navbar-brand d-flex align-items-center" href="/selecao-sistema.html">
+                <img src="/img/senai-logo.png" alt="SENAI" height="28" class="me-2">
+                <span class="navbar-brand-text" title="Planejamento de Treinamentos">Sistema FIEMG | Planejamento de Treinamentos</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav">
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-person-circle me-1"></i>
+                            <span id="userName">Usuário</span>
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                            <li><a class="dropdown-item" href="#" id="btnLogout"><i class="bi bi-box-arrow-right me-2"></i>Sair</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container-fluid py-4">
+        <main>
+            <div class="page-header">
+                <h1 class="mb-0">Planejamento Trimestral</h1>
+            </div>
+            </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -100,15 +100,14 @@
                     </div>
                 </div>
             </div>
-
             <div class="col-md-5 mb-4">
-                <div class="card sistema-card h-100" data-url="/planejamento/">
+                <div class="card sistema-card h-100" data-url="/static/planejamento-treinamentos.html">
                     <div class="card-body text-center p-5">
                         <div class="sistema-icon">
-                            <i class="bi bi-graph-up"></i>
+                            <i class="bi bi-calendar-week"></i>
                         </div>
                         <h2 class="card-title">Planejamento de Treinamentos</h2>
-                        <p class="card-text">Visualize e organize o planejamento mensal por instrutor ou em lista detalhada.</p>
+                        <p class="card-text">Módulo para planejar e visualizar os treinamentos de forma trimestral e por instrutor.</p>
                         <div class="mt-4">
                             <span class="badge bg-success">Disponível</span>
                         </div>


### PR DESCRIPTION
## Summary
- add main training planning page and navigation for quarterly and instructor views
- link new training planning module from system selection page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f156cb7208323bcf579a25aea303f