### PR TITLE
feat: include planning trainings module

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -111,7 +111,8 @@ function obterModulosDisponiveis(usuario) {
     const modulos = [
         '/laboratorios/dashboard.html',
         '/treinamentos/index.html',
-        '/ocupacao/dashboard.html'
+        '/ocupacao/dashboard.html',
+        '/static/planejamento-treinamentos.html'
     ];
 
     if (usuario.tipo === 'admin') {


### PR DESCRIPTION
## Summary
- include training planning module in module selection

## Testing
- `pre-commit run --files src/static/js/app.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f218e20108323954bde3681d06562