### PR TITLE
Fix planning module navigation paths

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -112,7 +112,7 @@ function obterModulosDisponiveis(usuario) {
         '/laboratorios/dashboard.html',
         '/treinamentos/index.html',
         '/ocupacao/dashboard.html',
-        '/static/planejamento-treinamentos.html' // Adiciona módulo de planejamento
+        '/planejamento-treinamentos.html' // Adiciona módulo de planejamento
     ];
 
     if (usuario.tipo === 'admin') {

--- a/src/static/planejamento-instrutores.html
+++ b/src/static/planejamento-instrutores.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Planejamento por Instrutores - Sistema FIEMG</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="/static/css/brand.css">
+    <link rel="stylesheet" href="/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
@@ -22,13 +22,13 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
+                        <a class="nav-link" href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
+                        <a class="nav-link" href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
+                        <a class="nav-link active" href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/planejamento-treinamentos.html
+++ b/src/static/planejamento-treinamentos.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Planejamento de Treinamentos - Sistema FIEMG</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="/static/css/brand.css">
+    <link rel="stylesheet" href="/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
@@ -22,13 +22,13 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link active" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
+                        <a class="nav-link active" href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
+                        <a class="nav-link" href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
+                        <a class="nav-link" href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Planejamento Trimestral - Sistema FIEMG</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="/static/css/brand.css">
+    <link rel="stylesheet" href="/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
@@ -22,13 +22,13 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
+                        <a class="nav-link" href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-1"></i> Treinamentos Disponíveis</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
+                        <a class="nav-link active" href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-1"></i> Planejamento Trimestral</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
+                        <a class="nav-link" href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-1"></i> Planejamento por Instrutor</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">


### PR DESCRIPTION
## Summary
- ensure planning module card is visible by correcting module URL
- remove `/static/` prefix from planning pages navigation and styles

## Testing
- `pytest` *(hangs after `tests/test_user_routes.py`, see log)*
- `pytest tests/test_password_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f270ff14c8323bc4b559d37af3692