### PR TITLE
Adiciona sidebar de planejamento nas páginas estáticas

### DIFF
--- a/src/static/planejamento-instrutores.html
+++ b/src/static/planejamento-instrutores.html
@@ -47,11 +47,23 @@
     </nav>
 
     <div class="container-fluid py-4">
-        <main>
-            <div class="page-header">
-                <h1 class="mb-0">Planejamento por Instrutores</h1>
+        <div class="row">
+            <div class="col-lg-3 d-none d-lg-block">
+                <div class="sidebar rounded shadow-sm">
+                    <h2 class="mb-3">Menu de Planejamento</h2>
+                    <div class="nav flex-column">
+                        <a class="nav-link" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos Disponíveis</a>
+                        <a class="nav-link" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a>
+                        <a class="nav-link active" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a>
+                    </div>
+                </div>
             </div>
+            <main class="col-lg-9 col-md-12">
+                <div class="page-header">
+                    <h1 class="mb-0">Planejamento por Instrutores</h1>
+                </div>
             </main>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/src/static/planejamento-treinamentos.html
+++ b/src/static/planejamento-treinamentos.html
@@ -47,11 +47,23 @@
     </nav>
 
     <div class="container-fluid py-4">
-        <main>
-            <div class="page-header">
-                <h1 class="mb-0">Treinamentos Disponíveis</h1>
+        <div class="row">
+            <div class="col-lg-3 d-none d-lg-block">
+                <div class="sidebar rounded shadow-sm">
+                    <h2 class="mb-3">Menu de Planejamento</h2>
+                    <div class="nav flex-column">
+                        <a class="nav-link active" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos Disponíveis</a>
+                        <a class="nav-link" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a>
+                        <a class="nav-link" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a>
+                    </div>
+                </div>
             </div>
+            <main class="col-lg-9 col-md-12">
+                <div class="page-header">
+                    <h1 class="mb-0">Treinamentos Disponíveis</h1>
+                </div>
             </main>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -47,11 +47,23 @@
     </nav>
 
     <div class="container-fluid py-4">
-        <main>
-            <div class="page-header">
-                <h1 class="mb-0">Planejamento Trimestral</h1>
+        <div class="row">
+            <div class="col-lg-3 d-none d-lg-block">
+                <div class="sidebar rounded shadow-sm">
+                    <h2 class="mb-3">Menu de Planejamento</h2>
+                    <div class="nav flex-column">
+                        <a class="nav-link" href="/static/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos Disponíveis</a>
+                        <a class="nav-link active" href="/static/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a>
+                        <a class="nav-link" href="/static/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a>
+                    </div>
+                </div>
             </div>
+            <main class="col-lg-9 col-md-12">
+                <div class="page-header">
+                    <h1 class="mb-0">Planejamento Trimestral</h1>
+                </div>
             </main>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Resumo
- Inclui sidebar de planejamento com links para treinamentos, trimestral e instrutores
- Ajusta estrutura das páginas para acomodar o menu lateral

## Testes
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f434016008323a6301e8a408e7a74