### PR TITLE
Implement email-based password reset flow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ Flask-Limiter==3.12
 Flask-Migrate==4.0.5
 Flask-JWT-Extended==4.6.0
 Flask-WTF==1.2.1
+Flask-Mail==0.9.1
+itsdangerous==2.2.0
 requests==2.32.4
 APScheduler==3.10.4
 flasgger==0.9.7.1

--- a/src/blueprints/auth_reset.py
+++ b/src/blueprints/auth_reset.py
@@ -1,0 +1,103 @@
+import logging
+import re
+import time
+from flask import Blueprint, render_template, request, flash, redirect, url_for, current_app
+from flask_mail import Message
+from email_validator import validate_email, EmailNotValidError
+from werkzeug.security import generate_password_hash
+from flask_wtf.csrf import generate_csrf, validate_csrf, CSRFError
+
+from src.repositories.user_repository import UserRepository
+from src.utils.tokens import generate_reset_token, confirm_reset_token
+from src.extensions import mail
+
+auth_reset_bp = Blueprint('auth_reset', __name__)
+
+PASSWORD_RE = re.compile(r'^(?=.*[A-Za-z])(?=.*\d).{8,}$')
+
+
+def _validate_password(password: str) -> bool:
+    return bool(PASSWORD_RE.match(password))
+
+
+@auth_reset_bp.get('/forgot')
+def forgot_get():
+    csrf_token = generate_csrf()
+    return render_template('admin/forgot_password.html', csrf_token=csrf_token)
+
+
+@auth_reset_bp.post('/forgot')
+def forgot_post():
+    time.sleep(1)
+    try:
+        validate_csrf(request.form.get('csrf_token'))
+    except CSRFError:
+        flash('Token CSRF inválido.', 'error')
+        return redirect(url_for('auth_reset.forgot_get'))
+
+    email = request.form.get('email', '').strip().lower()
+    if email:
+        try:
+            validate_email(email)
+            user = UserRepository.get_by_email(email)
+        except EmailNotValidError:
+            user = None
+        if user:
+            token = generate_reset_token(email)
+            reset_url = f"{current_app.config['FRONTEND_BASE_URL']}/reset?token={token}"
+            msg = Message(
+                subject="Conecta SENAI - Redefinição de Senha",
+                sender=current_app.config.get('MAIL_USERNAME'),
+                recipients=[email]
+            )
+            msg.body = render_template('emails/reset_password.txt', reset_url=reset_url)
+            msg.html = render_template('emails/reset_password.html', reset_url=reset_url)
+            try:
+                mail.send(msg)
+            except Exception as e:  # pragma: no cover - envio de email
+                current_app.logger.error('Falha ao enviar e-mail de redefinição: %s', e)
+    flash('Se o e-mail existir em nossa base, você receberá as instruções para redefinir sua senha.', 'info')
+    return redirect(url_for('auth_reset.forgot_get'))
+
+
+@auth_reset_bp.get('/reset')
+def reset_get():
+    token = request.args.get('token', '')
+    email = confirm_reset_token(token)
+    if not email:
+        flash('Link inválido ou expirado. Solicite uma nova redefinição.', 'error')
+        return redirect(url_for('auth_reset.forgot_get'))
+    csrf_token = generate_csrf()
+    return render_template('admin/reset_password.html', token=token, csrf_token=csrf_token)
+
+
+@auth_reset_bp.post('/reset')
+def reset_post():
+    try:
+        validate_csrf(request.form.get('csrf_token'))
+    except CSRFError:
+        flash('Token CSRF inválido.', 'error')
+        return redirect(url_for('auth_reset.forgot_get'))
+
+    token = request.form.get('token', '')
+    email = confirm_reset_token(token)
+    if not email:
+        flash('Link inválido ou expirado. Solicite uma nova redefinição.', 'error')
+        return redirect(url_for('auth_reset.forgot_get'))
+
+    password = request.form.get('password', '')
+    confirm = request.form.get('confirm_password', '')
+    if password != confirm or not _validate_password(password):
+        flash('Senha inválida. Verifique os requisitos.', 'error')
+        return redirect(url_for('auth_reset.reset_get', token=token))
+
+    user = UserRepository.get_by_email(email)
+    if not user:
+        flash('Link inválido ou expirado. Solicite uma nova redefinição.', 'error')
+        return redirect(url_for('auth_reset.forgot_get'))
+
+    user.senha_hash = generate_password_hash(password, method='pbkdf2:sha256', salt_length=16)
+    UserRepository.commit()
+    logging.info('Senha redefinida para usuário %s a partir do IP %s', user.id, request.remote_addr)
+    flash('Senha redefinida com sucesso. Faça login novamente.', 'success')
+    return redirect('/admin/login.html')

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 class BaseConfig:
     """Base configuration with default settings."""
@@ -6,6 +7,14 @@ class BaseConfig:
     TESTING = False
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     LOG_LEVEL = logging.INFO
+
+    MAIL_SERVER = os.environ.get('MAIL_SERVER', 'smtp.gmail.com')
+    MAIL_PORT = int(os.environ.get('MAIL_PORT', 587))
+    MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS', 'True').lower() in {'true', '1', 't'}
+    MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
+    MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
+    SECURITY_PASSWORD_SALT = os.environ.get('SECURITY_PASSWORD_SALT', 'change-me')
+    FRONTEND_BASE_URL = os.environ.get('FRONTEND_BASE_URL', 'http://localhost:5000')
 
 
 class DevConfig(BaseConfig):

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -1,0 +1,3 @@
+from flask_mail import Mail
+
+mail = Mail()

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from src.limiter import limiter
 from src.redis_client import init_redis
 from src.config import DevConfig, ProdConfig, TestConfig
 from src.repositories.user_repository import UserRepository
+from src.extensions import mail
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO,
                     format='%(asctime)s - %(levelname)s - %(message)s')
@@ -24,6 +25,7 @@ from src.routes.ocupacao import ocupacao_bp, sala_bp, instrutor_bp
 from src.routes.user import user_bp
 from src.routes.rateio import rateio_bp
 from src.routes.treinamentos import treinamento_bp, turma_bp
+from src.blueprints.auth_reset import auth_reset_bp
 from apscheduler.schedulers.background import BackgroundScheduler
 from src.services.notificacao_service import criar_notificacoes_agendamentos_proximos
 
@@ -170,6 +172,7 @@ def create_app():
     limiter.init_app(app)
     app.config['WTF_CSRF_CHECK_DEFAULT'] = False
     csrf.init_app(app)
+    mail.init_app(app)
 
     app.config['SWAGGER'] = {
         'title': 'Conecta SENAI API',
@@ -208,6 +211,7 @@ def create_app():
     app.register_blueprint(ocupacao_bp, url_prefix='/api')
     app.register_blueprint(rateio_bp, url_prefix='/api')
     app.register_blueprint(treinamento_bp, url_prefix='/api')
+    app.register_blueprint(auth_reset_bp)
 
     # Inicia scheduler para notificações
     iniciar_scheduler(app)

--- a/src/static/admin/login.html
+++ b/src/static/admin/login.html
@@ -43,7 +43,7 @@
                         </div>
                         <div id="senha-help" class="form-text">Digite sua senha de acesso.</div>
                         <div class="d-flex justify-content-between align-items-center mb-4">
-                            <a href="#" class="text-muted small">Esqueceu-se da senha?</a>
+                            <a href="/forgot" class="text-muted small">Esqueceu-se da senha?</a>
                         </div>
                         <div class="d-grid">
                         <button class="btn btn-primary btn-lg" type="submit" id="btnLogin">Entrar</button>

--- a/src/templates/admin/forgot_password.html
+++ b/src/templates/admin/forgot_password.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <title>Recuperar Senha</title>
+</head>
+<body>
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <ul>
+            {% for message in messages %}
+                <li>{{ message }}</li>
+            {% endfor %}
+            </ul>
+        {% endif %}
+    {% endwith %}
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <label for="email">E-mail</label>
+        <input type="email" id="email" name="email" required>
+        <button type="submit">Enviar instruções</button>
+    </form>
+    <p><a href="{{ url_for('static', filename='admin/login.html') }}">Voltar ao login</a></p>
+</body>
+</html>

--- a/src/templates/admin/reset_password.html
+++ b/src/templates/admin/reset_password.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <title>Redefinir Senha</title>
+</head>
+<body>
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <ul>
+            {% for message in messages %}
+                <li>{{ message }}</li>
+            {% endfor %}
+            </ul>
+        {% endif %}
+    {% endwith %}
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <input type="hidden" name="token" value="{{ token }}">
+        <label for="password">Nova senha</label>
+        <input type="password" id="password" name="password" required>
+        <label for="confirm_password">Confirmar senha</label>
+        <input type="password" id="confirm_password" name="confirm_password" required>
+        <button type="submit">Definir nova senha</button>
+    </form>
+</body>
+</html>

--- a/src/templates/emails/reset_password.html
+++ b/src/templates/emails/reset_password.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="pt-BR">
+<body>
+    <p>Olá,</p>
+    <p>Recebemos uma solicitação para redefinir sua senha.</p>
+    <p><a href="{{ reset_url }}">Redefinir Senha</a></p>
+    <p>O link é válido por 1 hora.</p>
+    <p>Se você não solicitou, ignore este e-mail.</p>
+    <p>Equipe Conecta SENAI</p>
+</body>
+</html>

--- a/src/templates/emails/reset_password.txt
+++ b/src/templates/emails/reset_password.txt
@@ -1,0 +1,10 @@
+Olá,
+
+Recebemos uma solicitação para redefinir sua senha.
+Acesse o link abaixo (válido por 1 hora):
+
+{{ reset_url }}
+
+Se você não solicitou, ignore este e-mail.
+
+Equipe Conecta SENAI

--- a/src/utils/tokens.py
+++ b/src/utils/tokens.py
@@ -1,0 +1,15 @@
+from itsdangerous import URLSafeTimedSerializer
+from flask import current_app
+
+
+def generate_reset_token(email: str) -> str:
+    s = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    return s.dumps(email, salt=current_app.config['SECURITY_PASSWORD_SALT'])
+
+
+def confirm_reset_token(token: str, max_age: int = 3600) -> str | None:
+    s = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    try:
+        return s.loads(token, salt=current_app.config['SECURITY_PASSWORD_SALT'], max_age=max_age)
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- configure Flask-Mail and environment-driven settings
- add token utilities and password reset blueprint with email templates
- link login page to new forgot password flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f9e957d708323af56af05fb65845b