### PR TITLE
Serve register page via Flask with CSRF

### DIFF
--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, render_template
+
+auth_bp = Blueprint("auth", __name__)
+
+
+@auth_bp.get("/register")
+def register_page():
+    """Renderiza a página de registro."""
+    return render_template("admin/register.html")

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from src.routes.user import user_bp
 from src.routes.rateio import rateio_bp
 from src.routes.treinamentos import treinamento_bp, turma_bp
 from src.blueprints.auth_reset import auth_reset_bp
+from src.blueprints.auth import auth_bp
 from apscheduler.schedulers.background import BackgroundScheduler
 from src.services.notificacao_service import criar_notificacoes_agendamentos_proximos
 
@@ -165,6 +166,11 @@ def create_app():
             "SECRET_KEY environment variable must be set to a secure value for JWT signing"
         )
     app.config['SECRET_KEY'] = secret_key
+    app.config.update(
+        SESSION_COOKIE_SAMESITE="Lax",
+        SESSION_COOKIE_SECURE=not app.config.get('DEBUG', False),
+        WTF_CSRF_TIME_LIMIT=3600,
+    )
 
     db.init_app(app)
     Migrate(app, db, directory=migrations_dir)
@@ -212,6 +218,7 @@ def create_app():
     app.register_blueprint(rateio_bp, url_prefix='/api')
     app.register_blueprint(treinamento_bp, url_prefix='/api')
     app.register_blueprint(auth_reset_bp)
+    app.register_blueprint(auth_bp)
 
     # Inicia scheduler para notificações
     iniciar_scheduler(app)

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -281,13 +281,14 @@ def criar_usuario():
 
 @user_bp.route("/registrar", methods=["POST"])
 def registrar_usuario():
-    """Registra um usuário a partir de um formulário HTML."""
+    """Registra um usuário a partir de um formulário HTML ou JSON."""
+    origem = request.get_json() if request.is_json else request.form
     dados = {
-        "nome": request.form.get("nome", "").strip(),
-        "email": request.form.get("email", "").strip(),
-        "senha": request.form.get("senha"),
-        "confirmarSenha": request.form.get("confirmarSenha"),
-        "username": request.form.get("username"),
+        "nome": (origem.get("nome") or "").strip(),
+        "email": (origem.get("email") or "").strip(),
+        "senha": origem.get("senha"),
+        "confirmarSenha": origem.get("confirmarSenha"),
+        "username": origem.get("username"),
     }
 
     try:

--- a/src/static/admin/login.html
+++ b/src/static/admin/login.html
@@ -50,7 +50,7 @@
                         </div>
                     </form>
                     <div class="text-center mt-4">
-                        <p class="text-muted">Não tem uma conta? <a href="/register.html">Registre-se</a></p>
+                        <p class="text-muted">Não tem uma conta? <a href="/register">Registre-se</a></p>
                     </div>
                 </div>
             </div>

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -321,7 +321,7 @@ async function verificarPermissaoAdmin() {
 // evitando loops na página de login ou registro.
 (async function() {
     const currentPage = window.location.pathname;
-    const paginasPublicas = ['/admin/login.html', '/register.html'];
+    const paginasPublicas = ['/admin/login.html', '/register'];
 
     // Se a página não for pública, valida a sessão no servidor
     if (!paginasPublicas.includes(currentPage)) {
@@ -755,7 +755,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         });
     }
     
-    if (paginaAtual === '/admin/login.html' || paginaAtual === '/register.html') {
+    if (paginaAtual === '/admin/login.html' || paginaAtual === '/register') {
         return;
     }
     

--- a/src/templates/admin/register.html
+++ b/src/templates/admin/register.html
@@ -7,6 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAIEAYAAADIFSHsAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAAAAAAAAPlDu38AAAAHdElNRQfpBgoBOhQj05UdAAADXUlEQVRIx92UbUzUdQDHP7/73zXgyjs6uPA8Kg82BgyYFDLNbt1YuWkOcqvZow8V4pouXYLQA3OSTHCGBBtl6RuaY7nVKtwCshU2EQRbK7BJhweUHOw87gTugfv/f72IttYbhRe59Xn/3b6f74uvsFpdrqam4ccBIK2DWyGRSNAe1Y7LfFjblWdZcQg2VjjrHKcheGGmLFoJ39T19nuq4KX3ntyYHYLwZ9FCNRcGbEMlXiukD6c6zQegs7TH5KkG+6b7ku+RMFY08W1wC/gGAlnhT2B3y7PHVo3AYdtHLT0GKGzLed9mg5ncuReijXCuqzc02giKouwXO27Z/l/4A7oF8c23nYkSQwMiRInB6oac6uXLQHVp3fIcBI7MPhx5HlIqLenGHkh6LfF0wna4kj9S7/saPMnX+wIDkOlytFqC8MzVJ5SMPZC119FniQNzeNlQXB8U3MjOSimGla22kyYV8iYziqz1kLIjadSYD9Yf7+1NMIAMy0xZu1jxv0k0LQxA2W1ndAgEiCThEdXQ++LPRde3grt2fHw6G9JrUucSi8HhsP9iPgOaTyuWd4N6VkuTN0GdVN+UzeCd8uXOlsLkO/7yuQdgnWvVyhWfgjESHzQkgLPpodX29XBjbfBgeBBcwwVj91+Eu07pm3XNIDvp4dpSxf+ps0TkZvbJzyGp3DwSPw0Pltl2m0YhWj7/lrofpk74j83lQNgebYhtg5QSi874FTh+tX9grofAczOm6Hpo93b/4K6BkTf+qAiYYPm2JI8xH7xW31NzVdB6vH3voAKqqtZrJyE+M67SUACzVaEP59uBt0Upa5Y+gH7RCQN6dCDShE+8C2fN5yfcW+DS5cGLE3qIbpiv0Log2DZ7JPI6nM+8/N24EwwX9BVKEELd4bZYB3T6e8qvbYXgyzNfRrbDgZKGNd/ng9KiuMXHMF8Tq9X6YfrKzRMRJwxYhgq9jaBoSp2YgtChyCNqKihduoO6XQC8upQhxF8nKOWikwo6BMhLDDIB8ieZIMtBbGCdcAAdtPA0yC+kX+4E+hnCCxwV+3gMyCNDJIP4XXSwC3DJV2gDeZVR/CBcFJAKwi3a2QkyKrOpBfkbY0yDOMwenCDOiKMUA2EixP7LAf4nLHyAP3Cni9wZYp1/AkYRW5V0uSBfAAAAAElFTkSuQmCC">
     <link href="/css/styles.css" rel="stylesheet">
 </head>
@@ -22,7 +23,7 @@
                         </div>
                         
                         
-                        <form id="registerForm" method="POST" action="/api/registrar">
+                        <form id="form-registro" method="POST" action="/api/registrar">
                             <div class="mb-3">
                                 <label for="nome" class="form-label">Nome Completo</label>
                                 <div class="input-group">
@@ -72,6 +73,7 @@
                                     <span class="btn-text"><i class="bi bi-person-plus me-2"></i>Registrar</span>
                                 </button>
                             </div>
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         </form>
                         
                         <div class="text-center mt-4">
@@ -104,7 +106,7 @@
             const confirmarInput = document.getElementById('confirmarSenha');
             const senhaRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
 
-            document.querySelectorAll('#registerForm input[required]').forEach(input => {
+            document.querySelectorAll('#form-registro input[required]').forEach(input => {
                 input.addEventListener('input', () => input.classList.remove('is-invalid'));
             });
 
@@ -119,31 +121,66 @@
             });
 
             // Valida o envio do formulário de registro
-            const registerForm = document.getElementById('registerForm');
-            registerForm.addEventListener('submit', function(e) {
+            const form = document.getElementById('form-registro');
+            form.addEventListener('submit', async function(e) {
+                e.preventDefault();
                 let formValido = true;
-                document.querySelectorAll('#registerForm input[required]').forEach(input => {
+                document.querySelectorAll('#form-registro input[required]').forEach(input => {
                     if (!input.value.trim()) {
                         input.classList.add('is-invalid');
                         formValido = false;
                     }
                 });
                 if (!formValido) {
-                    e.preventDefault();
                     return;
                 }
 
                 if (!senhaRegex.test(senhaInput.value)) {
-                    e.preventDefault();
                     senhaInput.classList.add('is-invalid');
                     showToast('A senha não atende aos requisitos de complexidade. Por favor, tente novamente.', 'danger');
                     return;
                 }
 
                 if (senhaInput.value !== confirmarInput.value) {
-                    e.preventDefault();
                     confirmarInput.classList.add('is-invalid');
                     showToast('As senhas não coincidem. Por favor, verifique e tente novamente.', 'danger');
+                    return;
+                }
+
+                const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+                const payload = {
+                    nome: document.querySelector('#nome').value,
+                    email: document.querySelector('#email').value,
+                    senha: senhaInput.value,
+                    confirmarSenha: confirmarInput.value,
+                };
+
+                const btn = document.getElementById('btnRegistrar');
+                btn.querySelector('.spinner-border').classList.remove('d-none');
+                btn.disabled = true;
+
+                try {
+                    const resp = await fetch('/api/registrar', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': token,
+                        },
+                        body: JSON.stringify(payload),
+                        credentials: 'include',
+                    });
+                    const data = await resp.json().catch(() => ({}));
+                    if (resp.ok) {
+                        showToast('Usuário registrado com sucesso!', 'success');
+                        setTimeout(() => { window.location.href = '/admin/login.html'; }, 1500);
+                    } else {
+                        showToast(data.erro || 'Falha ao registrar usuário.', 'danger');
+                    }
+                } catch (err) {
+                    showToast('Falha na comunicação com o servidor.', 'danger');
+                } finally {
+                    btn.disabled = false;
+                    btn.querySelector('.spinner-border').classList.add('d-none');
                 }
             });
         });


### PR DESCRIPTION
## Summary
- Render registration page through Flask blueprint
- Inject CSRF token into register template and use it in JS
- Link login to /register and update public pages list
- Allow /api/registrar to accept JSON payloads and configure CSRF settings

## Testing
- `pre-commit run --files src/static/js/app.js src/static/admin/login.html src/blueprints/auth.py src/main.py src/templates/admin/register.html src/routes/user.py` *(fails: flake8, bandit)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fafb2147c8323ad554a80c930b2a1