### PR TITLE
Allow CSRF cookie in development

### DIFF
--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -8,7 +8,8 @@ auth_bp = Blueprint("auth", __name__)
 def register_page():
     """Renderiza a página de registro e define o cookie CSRF."""
     token = generate_csrf()
-    secure_cookie = current_app.config.get("COOKIE_SECURE", True)
+    secure_cookie = current_app.config.get("COOKIE_SECURE", False)
+    samesite = current_app.config.get("COOKIE_SAMESITE", "Lax")
     resp = make_response(render_template("admin/register.html", csrf_token=token))
-    resp.set_cookie("csrf_token", token, secure=secure_cookie, samesite="Strict")
+    resp.set_cookie("csrf_token", token, secure=secure_cookie, samesite=samesite)
     return resp

--- a/src/main.py
+++ b/src/main.py
@@ -172,6 +172,15 @@ def create_app():
         WTF_CSRF_TIME_LIMIT=3600,
     )
 
+    cookie_secure_env = os.getenv('COOKIE_SECURE')
+    if cookie_secure_env is None:
+        cookie_secure = not app.config.get('DEBUG', False)
+    else:
+        cookie_secure = cookie_secure_env.lower() in ('true', '1', 't')
+    cookie_samesite = os.getenv('COOKIE_SAMESITE', 'Strict' if cookie_secure else 'Lax')
+    app.config['COOKIE_SECURE'] = cookie_secure
+    app.config['COOKIE_SAMESITE'] = cookie_samesite
+
     db.init_app(app)
     Migrate(app, db, directory=migrations_dir)
     init_redis(app)

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -58,9 +58,10 @@ def verificar_csrf():
 @user_bp.route("/csrf-token", methods=["GET"])
 def get_csrf_token():
     token = generate_csrf()
-    secure_cookie = current_app.config.get("COOKIE_SECURE", True)
+    secure_cookie = current_app.config.get("COOKIE_SECURE", False)
+    samesite = current_app.config.get("COOKIE_SAMESITE", "Lax")
     resp = jsonify({"csrf_token": token})
-    resp.set_cookie("csrf_token", token, secure=secure_cookie, samesite="Strict")
+    resp.set_cookie("csrf_token", token, secure=secure_cookie, samesite=samesite)
     return resp
 
 


### PR DESCRIPTION
## Summary
- respect COOKIE_SECURE and COOKIE_SAMESITE settings for CSRF cookies
- expose environment-based defaults for these settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fbd0e13348323bd37c426a6415e2e