### PR TITLE
Improve CSRF handling and registration response

### DIFF
--- a/src/static/admin/usuarios.html
+++ b/src/static/admin/usuarios.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Gerenciamento de Usuários</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/brand.css">

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -347,22 +347,29 @@ async function verificarPermissaoAdmin() {
  * @returns {Promise} - Promise com o resultado da chamada
  */
 async function chamarAPI(endpoint, method = 'GET', body = null, requerAuth = true) {
+    // Busca o token da meta tag que adicionamos no HTML
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+
     const headers = {
         'Content-Type': 'application/json'
     };
     
+    // Adiciona o cabeçalho CSRF se o método não for GET e o token existir
+    if (method !== 'GET' && csrfToken) {
+        headers['X-CSRFToken'] = csrfToken;
+    }
+    
     // Garante que o endpoint comece com /
     const endpointFormatado = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
     const url = `${API_URL}${endpointFormatado}`;
-    
-    
+
     const options = {
         method,
         headers,
         credentials: 'include'
     };
-    
-    if (body && (method === 'POST' || method === 'PUT')) {
+
+    if (body && (method === 'POST' || method === 'PUT' || method === 'DELETE')) { // Adicionado DELETE aqui
         options.body = JSON.stringify(body);
     }
     

--- a/src/templates/admin/register.html
+++ b/src/templates/admin/register.html
@@ -102,68 +102,53 @@
       document.addEventListener('DOMContentLoaded', function () {
         const form = document.getElementById('form-registro');
         const btnRegistrar = document.getElementById('btn-registrar');
-        const btnText = document.getElementById('btn-text');
-        const btnSpinner = document.getElementById('btn-spinner');
 
         form.addEventListener('submit', function (event) {
-          event.preventDefault(); // Impede o envio padrão do formulário
+          event.preventDefault();
 
-          // Desabilita o botão para evitar cliques duplos
-          btnRegistrar.disabled = true;
-          btnText.textContent = 'Registrando...';
-          btnSpinner.classList.remove('d-none');
+          const dadosForm = {
+            nome: document.getElementById('nome').value,
+            email: document.getElementById('email').value,
+            senha: document.getElementById('senha').value,
+            confirmarSenha: document.getElementById('confirmarSenha').value
+          };
 
-          const formData = new FormData(form);
-          const data = Object.fromEntries(formData.entries());
-          
-          // Pega o token CSRF do campo oculto no formulário
-          const csrfToken = data.csrf_token;
+          // Usa a função global para feedback visual no botão
+          executarAcaoComFeedback(btnRegistrar, async () => {
+            try {
+              const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
+              const response = await fetch('/api/registrar', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'X-CSRFToken': csrfToken
+                },
+                body: JSON.stringify(dadosForm)
+              });
 
-          fetch('/api/registrar', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-CSRFToken': csrfToken // Adiciona o token CSRF ao cabeçalho
-            },
-            body: JSON.stringify({
-                nome: data.nome,
-                email: data.email,
-                senha: data.senha,
-                confirmarSenha: data.confirmarSenha
-            })
-          })
-          .then(response => {
-            if (response.headers.get("content-type") && response.headers.get("content-type").includes("application/json")) {
-                return response.json();
+              // ANÁLISE ROBUSTA DA RESPOSTA
+              if (response.headers.get("content-type")?.includes("application/json")) {
+                  const result = await response.json();
+                  if (!response.ok) {
+                      throw new Error(result.erro || 'Ocorreu um erro desconhecido.');
+                  }
+                  showToast(result.sucesso || 'Usuário registrado com sucesso!', 'success');
+                  setTimeout(() => { window.location.href = '/admin/login.html'; }, 2000);
+              } else {
+                  // Se a resposta não for JSON, trata como um erro de texto
+                  const text = await response.text();
+                  throw new Error("Resposta inesperada do servidor: " + text);
+              }
+
+            } catch (error) {
+              console.error('Erro na requisição de registro:', error);
+              showToast(error.message, 'danger');
+              // Lança o erro para que `executarAcaoComFeedback` saiba que falhou
+              throw error;
             }
-            // Se a resposta não for JSON, trata como um erro de texto
-            return response.text().then(text => { throw new Error("Resposta inesperada do servidor: " + text) });
-          })
-          .then(result => {
-            if (result.sucesso) {
-              showToast(result.sucesso, 'success');
-              setTimeout(() => {
-                window.location.href = '/admin/login.html';
-              }, 2000);
-            } else if (result.erro) {
-              showToast(result.erro, 'danger');
-            } else {
-              showToast('Ocorreu um erro desconhecido.', 'danger');
-            }
-          })
-          .catch(error => {
-            console.error('Erro na requisição:', error);
-            showToast('Falha na comunicação com o servidor. Verifique o console para mais detalhes.', 'danger');
-          })
-          .finally(() => {
-            // Reabilita o botão após a conclusão
-            btnRegistrar.disabled = false;
-            btnText.textContent = 'Registrar';
-            btnSpinner.classList.add('d-none');
           });
         });
       });
     </script>
-
-</body>
+    </body>
 </html>


### PR DESCRIPTION
## Summary
- add CSRF meta tag to user admin page
- inject CSRF token automatically in API helper
- make registration request robust to non-JSON responses

## Testing
- `pre-commit run --files src/templates/admin/register.html src/static/admin/usuarios.html src/static/js/app.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc457d1808323a469ea76d758d9ea