### PR TITLE
fix: handle csrf and accept headers

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -347,14 +347,23 @@ async function verificarPermissaoAdmin() {
  * @returns {Promise} - Promise com o resultado da chamada
  */
 async function chamarAPI(endpoint, method = 'GET', body = null, requerAuth = true) {
-    // Busca o token da meta tag que adicionamos no HTML
-    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+    let csrfToken;
+    if (method !== 'GET') {
+        const metaTag = document.querySelector('meta[name="csrf-token"]');
+        csrfToken = metaTag?.content;
+        if (!csrfToken || csrfToken.includes('{{')) {
+            csrfToken = await obterCsrfToken();
+            if (metaTag) {
+                metaTag.setAttribute('content', csrfToken);
+            }
+        }
+    }
 
     const headers = {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
     };
-    
-    // Adiciona o cabeçalho CSRF se o método não for GET e o token existir
+
     if (method !== 'GET' && csrfToken) {
         headers['X-CSRFToken'] = csrfToken;
     }

--- a/src/templates/admin/register.html
+++ b/src/templates/admin/register.html
@@ -119,8 +119,10 @@
               const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
               const response = await fetch('/api/registrar', {
                 method: 'POST',
+                credentials: 'include',
                 headers: {
                   'Content-Type': 'application/json',
+                  'Accept': 'application/json',
                   'X-CSRFToken': csrfToken
                 },
                 body: JSON.stringify(dadosForm)


### PR DESCRIPTION
## Summary
- ensure register requests include cookies and accept JSON responses
- fetch CSRF token dynamically in API helper and always request JSON

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a002ee1b208323a78485356ad6a144