### PR TITLE
feat: align auth templates with login layout

### DIFF
--- a/src/templates/admin/forgot_password.html
+++ b/src/templates/admin/forgot_password.html
@@ -1,25 +1,71 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="pt-BR">
 <head>
-    <meta charset="utf-8">
-    <title>Recuperar Senha</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Recuperar Senha - Conecta SENAI</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/static/css/brand.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/css/login.css" rel="stylesheet">
 </head>
 <body>
-    {% with messages = get_flashed_messages() %}
-        {% if messages %}
-            <ul>
-            {% for message in messages %}
-                <li>{{ message }}</li>
-            {% endfor %}
-            </ul>
-        {% endif %}
-    {% endwith %}
-    <form method="post">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-        <label for="email">E-mail</label>
-        <input type="email" id="email" name="email" required>
-        <button type="submit">Enviar instruções</button>
-    </form>
-    <p><a href="{{ url_for('static', filename='admin/login.html') }}">Voltar ao login</a></p>
+    <div class="container-fluid vh-100">
+        <div class="row h-100">
+            <div class="col-md-6 login-branding-col d-none d-md-flex align-items-center justify-content-center">
+                <div class="text-center text-white">
+                    <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 150px; margin-bottom: 2rem;">
+                    <h2 class="display-4 fw-bold">Conecta SENAI</h2>
+                    <p class="lead">A sua plataforma integrada de gestão e agendamentos.</p>
+                </div>
+            </div>
+
+            <div class="col-md-6 d-flex align-items-center justify-content-center bg-light">
+                <div class="login-form-container">
+                    <div class="text-center mb-5 d-md-none">
+                        <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 120px;">
+                    </div>
+
+                    {% with messages = get_flashed_messages() %}
+                        {% if messages %}
+                            <div class="alert alert-info">
+                                {% for message in messages %}
+                                    <div>{{ message }}</div>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    {% endwith %}
+
+                    <h1 class="h3 mb-3 fw-normal">Recuperar Senha</h1>
+                    <p class="text-muted mb-4">Insira seu e-mail para receber as instruções de redefinição.</p>
+
+                    <form method="post">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                        <div class="form-floating mb-3">
+                            <input type="email" class="form-control" id="email" name="email" placeholder="seu@email.com" required>
+                            <label for="email"><i class="bi bi-envelope me-2"></i>Email</label>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-primary btn-lg">Enviar Instruções</button>
+                        </div>
+                    </form>
+
+                    <div class="text-center mt-4">
+                        <a href="{{ url_for('static', filename='admin/login.html') }}">Voltar ao login</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="mt-5 py-3 bg-dark text-white text-center">
+        <div class="container">
+            <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/templates/admin/register.html
+++ b/src/templates/admin/register.html
@@ -3,97 +3,85 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Registro - Sistema de Agenda de Laboratório</title>
+    <title>Registro - Conecta SENAI</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <meta name="csrf-token" content="{{ csrf_token }}">
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAIEAYAAADIFSHsAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAAAAAAAAPlDu38AAAAHdElNRQfpBgoBOhQj05UdAAADXUlEQVRIx92UbUzUdQDHP7/73zXgyjs6uPA8Kg82BgyYFDLNbt1YuWkOcqvZow8V4pouXYLQA3OSTHCGBBtl6RuaY7nVKtwCshU2EQRbK7BJhweUHOw87gTugfv/f72IttYbhRe59Xn/3b6f74uvsFpdrqam4ccBIK2DWyGRSNAe1Y7LfFjblWdZcQg2VjjrHKcheGGmLFoJ39T19nuq4KX3ntyYHYLwZ9FCNRcGbEMlXiukD6c6zQegs7TH5KkG+6b7ku+RMFY08W1wC/gGAlnhT2B3y7PHVo3AYdtHLT0GKGzLed9mg5ncuReijXCuqzc02giKouwXO27Z/l/4A7oF8c23nYkSQwMiRInB6oac6uXLQHVp3fIcBI7MPhx5HlIqLenGHkh6LfF0wna4kj9S7/saPMnX+wIDkOlytFqC8MzVJ5SMPZC119FniQNzeNlQXB8U3MjOSimGla22kyYV8iYziqz1kLIjadSYD9Yf7+1NMIAMy0xZu1jxv0k0LQxA2W1ndAgEiCThEdXQ++LPRde3grt2fHw6G9JrUucSi8HhsP9iPgOaTyuWd4N6VkuTN0GdVN+UzeCd8uXOlsLkO/7yuQdgnWvVyhWfgjESHzQkgLPpodX29XBjbfBgeBBcwwVj91+Eu07pm3XNIDvp4dpSxf+ps0TkZvbJzyGp3DwSPw0Pltl2m0YhWj7/lrofpk74j83lQNgebYhtg5QSi874FTh+tX9grofAczOm6Hpo93b/4K6BkTf+qAiYYPm2JI8xH7xW31NzVdB6vH3voAKqqtZrJyE+M67SUACzVaEP59uBt0Upa5Y+gH7RCQN6dCDShE+8C2fN5yfcW+DS5cGLE3qIbpiv0Log2DZ7JPI6nM+8/N24EwwX9BVKEELd4bZYB3T6e8qvbYXgyzNfRrbDgZKGNd/ng9KiuMXHMF8Tq9X6YfrKzRMRJwxYhgq9jaBoSp2YgtChyCNqKihduoO6XQC8upQhxF8nKOWikwo6BMhLDDIB8ieZIMtBbGCdcAAdtPA0yC+kX+4E+hnCCxwV+3gMyCNDJIP4XXSwC3DJV2gDeZVR/CBcFJAKwi3a2QkyKrOpBfkbY0yDOMwenCDOiKMUA2EixP7LAf4nLHyAP3Cni9wZYp1/AkYRW5V0uSBfAAAAAElFTkSuQmCC">
     <link href="/css/styles.css" rel="stylesheet">
+    <link href="/css/login.css" rel="stylesheet">
 </head>
-<body class="bg-light">
-    <div class="container">
-        <div class="row justify-content-center mt-5">
-            <div class="col-md-8 col-lg-6">
-                <div class="card shadow-sm">
-                    <div class="card-body p-4">
-                        <div class="text-center mb-4">
-                            <h1 class="h3 mb-3 fw-normal">Criar Nova Conta</h1>
-                            <p class="text-muted">Preencha os dados para se registrar no sistema</p>
-                        </div>
-                        
-                        
-                        <form id="form-registro" method="POST" action="/api/registrar">
-                            <div class="mb-3">
-                                <label for="nome" class="form-label">Nome Completo</label>
-                                <div class="input-group">
-                                    <span class="input-group-text"><i class="bi bi-person"></i></span>
-                                    <input type="text" class="form-control" id="nome" name="nome" required aria-required="true" aria-describedby="nome-help nome-error">
-                                </div>
-                                <div id="nome-help" class="form-text">Informe seu nome completo.</div>
-                                <div id="nome-error" class="invalid-feedback">Por favor, informe seu nome completo.</div>
-                            </div>
-
-                        <div class="mb-3">
-                                <label for="email" class="form-label">Email</label>
-                                <div class="input-group">
-                                    <span class="input-group-text"><i class="bi bi-envelope"></i></span>
-                                    <input type="email" class="form-control" id="email" name="email" required aria-required="true" aria-describedby="email-help email-error">
-                                </div>
-                                <div id="email-help" class="form-text">Informe um endereço de email válido.</div>
-                                <div id="email-error" class="invalid-feedback">Por favor, informe um email válido.</div>
-                            </div>
-
-
-                            <div class="row">
-                                <div class="col-md-6 mb-3">
-                                    <label for="senha" class="form-label">Senha</label>
-                                    <div class="input-group">
-                                        <span class="input-group-text"><i class="bi bi-lock"></i></span>
-                                        <input type="password" class="form-control" id="senha" name="senha" required aria-required="true" aria-describedby="senha-help senha-error">
-                                    </div>
-                                    <div id="senha-help" class="form-text text-danger">A senha deve ter pelo menos 8 caracteres, incluindo letra maiúscula, letra minúscula, número e caractere especial.</div>
-                                    <div id="senha-error" class="invalid-feedback">A senha não atende aos requisitos.</div>
-                                </div>
-
-                                <div class="col-md-6 mb-3">
-                                    <label for="confirmarSenha" class="form-label">Confirmar Senha</label>
-                                    <div class="input-group">
-                                        <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
-                                        <input type="password" class="form-control" id="confirmarSenha" name="confirmarSenha" required aria-required="true" aria-describedby="confirmarSenha-help confirmarSenha-error">
-                                    </div>
-                                    <div id="confirmarSenha-help" class="form-text">Repita a senha para confirmação.</div>
-                                    <div id="confirmarSenha-error" class="invalid-feedback">As senhas não coincidem.</div>
-                                </div>
-                            </div>
-                            
-                            <div class="d-grid gap-2">
-                                <button class="btn btn-primary" type="submit" id="btn-registrar">
-                                    <span id="btn-spinner" class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
-                                    <span id="btn-text"><i class="bi bi-person-plus me-2"></i>Registrar</span>
-                                </button>
-                            </div>
-                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-                        </form>
-                        
-                        <div class="text-center mt-4">
-                            <p>Já tem uma conta? <a href="/admin/login.html">Faça login</a></p>
-                        </div>
-                    </div>
+<body>
+    <div class="container-fluid vh-100">
+        <div class="row h-100">
+            <div class="col-md-6 login-branding-col d-none d-md-flex align-items-center justify-content-center">
+                <div class="text-center text-white">
+                    <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 150px; margin-bottom: 2rem;">
+                    <h2 class="display-4 fw-bold">Conecta SENAI</h2>
+                    <p class="lead">A sua plataforma integrada de gestão e agendamentos.</p>
                 </div>
-                
-                <div class="text-center mt-4 text-muted">
-                    <small>&copy; 2025 Sistema de Agenda de Laboratório</small>
+            </div>
+
+            <div class="col-md-6 d-flex align-items-center justify-content-center bg-light">
+                <div class="login-form-container">
+                    <div class="text-center mb-5 d-md-none">
+                        <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 120px;">
+                    </div>
+                    <h1 class="h3 mb-3 fw-normal">Crie sua Conta</h1>
+                    <p class="text-muted mb-4">Preencha os dados para se registrar no sistema.</p>
+
+                    <form id="form-registro" method="POST" action="/api/registrar">
+                        <div class="form-floating mb-3">
+                            <input type="text" class="form-control" id="nome" name="nome" placeholder="Nome Completo" required aria-required="true" aria-describedby="nome-help nome-error">
+                            <label for="nome"><i class="bi bi-person me-2"></i>Nome Completo</label>
+                            <div id="nome-error" class="invalid-feedback">Por favor, informe seu nome completo.</div>
+                        </div>
+                        <div id="nome-help" class="form-text">Informe seu nome completo.</div>
+
+                        <div class="form-floating mb-3">
+                            <input type="email" class="form-control" id="email" name="email" placeholder="seu@email.com" required aria-required="true" aria-describedby="email-help email-error">
+                            <label for="email"><i class="bi bi-envelope me-2"></i>Email</label>
+                            <div id="email-error" class="invalid-feedback">Por favor, informe um email válido.</div>
+                        </div>
+                        <div id="email-help" class="form-text">Informe um endereço de email válido.</div>
+
+                        <div class="form-floating mb-3">
+                            <input type="password" class="form-control" id="senha" name="senha" placeholder="Senha" required aria-required="true" aria-describedby="senha-help senha-error">
+                            <label for="senha"><i class="bi bi-lock me-2"></i>Senha</label>
+                            <div id="senha-error" class="invalid-feedback">A senha não atende aos requisitos.</div>
+                        </div>
+                        <div id="senha-help" class="form-text text-danger">A senha deve ter pelo menos 8 caracteres, incluindo letra maiúscula, letra minúscula, número e caractere especial.</div>
+
+                        <div class="form-floating mb-3">
+                            <input type="password" class="form-control" id="confirmarSenha" name="confirmarSenha" placeholder="Confirmar Senha" required aria-required="true" aria-describedby="confirmarSenha-help confirmarSenha-error">
+                            <label for="confirmarSenha"><i class="bi bi-lock-fill me-2"></i>Confirmar Senha</label>
+                            <div id="confirmarSenha-error" class="invalid-feedback">As senhas não coincidem.</div>
+                        </div>
+                        <div id="confirmarSenha-help" class="form-text">Repita a senha para confirmação.</div>
+
+                        <div class="d-grid">
+                            <button class="btn btn-primary btn-lg" type="submit" id="btn-registrar">
+                                <span id="btn-spinner" class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                                <span id="btn-text"><i class="bi bi-person-plus me-2"></i>Registrar</span>
+                            </button>
+                        </div>
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    </form>
+
+                    <div class="text-center mt-4">
+                        <p class="text-muted">Já tem uma conta? <a href="/admin/login.html">Faça login</a></p>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
 
-<footer class="mt-5 py-3 bg-dark text-white text-center">
-    <div class="container">
-        <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
-    </div>
-</footer>
+    <footer class="mt-5 py-3 bg-dark text-white text-center">
+        <div class="container">
+            <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
+        </div>
+    </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
@@ -113,7 +101,6 @@
             confirmarSenha: document.getElementById('confirmarSenha').value
           };
 
-          // Usa a função global para feedback visual no botão
           executarAcaoComFeedback(btnRegistrar, async () => {
             try {
               const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
@@ -126,29 +113,26 @@
                 body: JSON.stringify(dadosForm)
               });
 
-              // ANÁLISE ROBUSTA DA RESPOSTA
               if (response.headers.get("content-type")?.includes("application/json")) {
-                  const result = await response.json();
-                  if (!response.ok) {
-                      throw new Error(result.erro || 'Ocorreu um erro desconhecido.');
-                  }
-                  showToast(result.sucesso || 'Usuário registrado com sucesso!', 'success');
-                  setTimeout(() => { window.location.href = '/admin/login.html'; }, 2000);
+                const result = await response.json();
+                if (!response.ok) {
+                    throw new Error(result.erro || 'Ocorreu um erro desconhecido.');
+                }
+                showToast(result.sucesso || 'Usuário registrado com sucesso!', 'success');
+                setTimeout(() => { window.location.href = '/admin/login.html'; }, 2000);
               } else {
-                  // Se a resposta não for JSON, trata como um erro de texto
-                  const text = await response.text();
-                  throw new Error("Resposta inesperada do servidor: " + text);
+                const text = await response.text();
+                throw new Error("Resposta inesperada do servidor: " + text);
               }
 
             } catch (error) {
               console.error('Erro na requisição de registro:', error);
               showToast(error.message, 'danger');
-              // Lança o erro para que `executarAcaoComFeedback` saiba que falhou
               throw error;
             }
           });
         });
       });
     </script>
-    </body>
+</body>
 </html>

--- a/src/templates/admin/reset_password.html
+++ b/src/templates/admin/reset_password.html
@@ -1,27 +1,71 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="pt-BR">
 <head>
-    <meta charset="utf-8">
-    <title>Redefinir Senha</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Redefinir Senha - Conecta SENAI</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/static/css/brand.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+    <link href="/css/styles.css" rel="stylesheet">
+    <link href="/css/login.css" rel="stylesheet">
 </head>
 <body>
-    {% with messages = get_flashed_messages() %}
-        {% if messages %}
-            <ul>
-            {% for message in messages %}
-                <li>{{ message }}</li>
-            {% endfor %}
-            </ul>
-        {% endif %}
-    {% endwith %}
-    <form method="post">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-        <input type="hidden" name="token" value="{{ token }}">
-        <label for="password">Nova senha</label>
-        <input type="password" id="password" name="password" required>
-        <label for="confirm_password">Confirmar senha</label>
-        <input type="password" id="confirm_password" name="confirm_password" required>
-        <button type="submit">Definir nova senha</button>
-    </form>
+    <div class="container-fluid vh-100">
+        <div class="row h-100">
+            <div class="col-md-6 login-branding-col d-none d-md-flex align-items-center justify-content-center">
+                <div class="text-center text-white">
+                    <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 150px; margin-bottom: 2rem;">
+                    <h2 class="display-4 fw-bold">Conecta SENAI</h2>
+                    <p class="lead">A sua plataforma integrada de gestão e agendamentos.</p>
+                </div>
+            </div>
+
+            <div class="col-md-6 d-flex align-items-center justify-content-center bg-light">
+                <div class="login-form-container">
+                    <div class="text-center mb-5 d-md-none">
+                        <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 120px;">
+                    </div>
+
+                    {% with messages = get_flashed_messages() %}
+                        {% if messages %}
+                            <div class="alert alert-info">
+                                {% for message in messages %}
+                                    <div>{{ message }}</div>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    {% endwith %}
+
+                    <h1 class="h3 mb-3 fw-normal">Redefinir Senha</h1>
+
+                    <form method="post">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                        <input type="hidden" name="token" value="{{ token }}">
+                        <div class="form-floating mb-3">
+                            <input type="password" class="form-control" id="password" name="password" placeholder="Nova Senha" required>
+                            <label for="password"><i class="bi bi-lock me-2"></i>Nova Senha</label>
+                        </div>
+                        <div class="form-floating mb-3">
+                            <input type="password" class="form-control" id="confirm_password" name="confirm_password" placeholder="Confirmar Senha" required>
+                            <label for="confirm_password"><i class="bi bi-lock-fill me-2"></i>Confirmar Senha</label>
+                        </div>
+                        <div class="d-grid">
+                            <button type="submit" class="btn btn-primary btn-lg">Definir Nova Senha</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="mt-5 py-3 bg-dark text-white text-center">
+        <div class="container">
+            <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
+        </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor registration template to reuse login branding and form floating fields
- restyle password reset and recovery templates with two-column layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0c536d8408323831a9b5bd383db69