### PR TITLE
Allow unauthenticated access to password recovery pages

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -332,7 +332,8 @@ async function verificarPermissaoAdmin() {
 // evitando loops na página de login ou registro.
 (async function() {
     const currentPage = window.location.pathname;
-    const paginasPublicas = ['/admin/login.html', '/register'];
+    // Adiciona '/forgot' e '/reset' à lista de páginas públicas
+    const paginasPublicas = ['/admin/login.html', '/register', '/forgot', '/reset'];
 
     // Se a página não for pública, valida a sessão no servidor
     if (!paginasPublicas.includes(currentPage)) {


### PR DESCRIPTION
## Summary
- ensure password reset routes (/forgot and /reset) are treated as public pages

## Testing
- `pytest -q >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68a15269a3fc83238ee8d04c7b206f09