### PR TITLE
Fix password reset pages redirect behavior

### DIFF
--- a/src/blueprints/auth_reset.py
+++ b/src/blueprints/auth_reset.py
@@ -57,7 +57,7 @@ def forgot_post():
             except Exception as e:  # pragma: no cover - envio de email
                 current_app.logger.error('Falha ao enviar e-mail de redefinição: %s', e)
     flash('Se o e-mail existir em nossa base, você receberá as instruções para redefinir sua senha.', 'info')
-    return redirect(url_for('auth_reset.forgot_get'))
+    return redirect('/admin/login.html')
 
 
 @auth_reset_bp.get('/reset')

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -759,14 +759,15 @@ function configurarNavbarOffcanvas() {
 // Inicialização da página
 document.addEventListener('DOMContentLoaded', async function() {
 
-    // Verifica autenticação em todas as páginas exceto login e registro
+    // Verifica autenticação em todas as páginas exceto as públicas
     const paginaAtual = window.location.pathname;
+    const paginasPublicas = ['/admin/login.html', '/register', '/forgot', '/reset'];
 
     // Limpa escolha salva ao retornar para a seleção de sistema
     document.querySelectorAll('a[href="/selecao-sistema.html"]').forEach(link => {
         link.addEventListener('click', () => localStorage.removeItem('moduloSelecionado'));
     });
-    
+
     // Configura o botão de logout em todas as páginas
     const btnLogout = document.getElementById('btnLogout');
     if (btnLogout) {
@@ -775,11 +776,11 @@ document.addEventListener('DOMContentLoaded', async function() {
             realizarLogout();
         });
     }
-    
-    if (paginaAtual === '/admin/login.html' || paginaAtual === '/register') {
+
+    if (paginasPublicas.includes(paginaAtual)) {
         return;
     }
-    
+
     // Verifica se o usuário está autenticado
     if (!(await verificarAutenticacao())) {
         return;


### PR DESCRIPTION
## Summary
- Ensure `/forgot` and `/reset` pages are treated as public and don't force authentication
- Redirect users to login after submitting forgot password form

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a155be97b8832398ded4a405a06ee7