### PR TITLE
Add schedule and workload panels to planning data page

### DIFF
--- a/src/static/js/planejamento-basedados.js
+++ b/src/static/js/planejamento-basedados.js
@@ -21,6 +21,16 @@ document.addEventListener('DOMContentLoaded', () => {
             { id: 1, nome: 'Semipresencial' },
             { id: 2, nome: 'Presencial' },
             { id: 3, nome: 'Online' }
+        ],
+        horario: [
+            { id: 1, nome: '08:00 - 12:00' },
+            { id: 2, nome: '13:00 - 17:00' },
+            { id: 3, nome: '18:00 - 22:00' }
+        ],
+        cargahoraria: [
+            { id: 1, nome: '4 horas' },
+            { id: 2, nome: '8 horas' },
+            { id: 3, nome: '16 horas' }
         ]
     };
 
@@ -76,7 +86,9 @@ document.addEventListener('DOMContentLoaded', () => {
             treinamento: 'Treinamento',
             instrutor: 'Instrutor',
             local: 'Local',
-            modalidade: 'Modalidade'
+            modalidade: 'Modalidade',
+            horario: 'Horário',
+            cargahoraria: 'Carga Horária'
         };
         const titulo = titulos[type] || 'Item';
 
@@ -167,5 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
     renderizarTabela('instrutor');
     renderizarTabela('local');
     renderizarTabela('modalidade');
+    renderizarTabela('horario');
+    renderizarTabela('cargahoraria');
 });
 

--- a/src/static/planejamento-basedados.html
+++ b/src/static/planejamento-basedados.html
@@ -138,6 +138,38 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-md-6 mb-4">
+                        <div class="card h-100">
+                            <div class="card-header d-flex justify-content-between align-items-center">
+                                <h2 class="card-title mb-0"><i class="bi bi-clock-fill me-2"></i>Horário</h2>
+                                <button class="btn btn-primary btn-sm" onclick="abrirModal('horario')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                            </div>
+                            <div class="card-body p-0">
+                                <div class="table-responsive">
+                                    <table class="table table-striped table-hover mb-0">
+                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                        <tbody id="tabela-horario"></tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6 mb-4">
+                        <div class="card h-100">
+                            <div class="card-header d-flex justify-content-between align-items-center">
+                                <h2 class="card-title mb-0"><i class="bi bi-hourglass-split me-2"></i>Carga Horária</h2>
+                                <button class="btn btn-primary btn-sm" onclick="abrirModal('cargahoraria')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                            </div>
+                            <div class="card-body p-0">
+                                <div class="table-responsive">
+                                    <table class="table table-striped table-hover mb-0">
+                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                        <tbody id="tabela-cargahoraria"></tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </main>
         </div>


### PR DESCRIPTION
## Summary
- add panels for "Horário" and "Carga Horária" to the planning database page
- extend JavaScript logic to manage new lists and actions

## Testing
- `pre-commit run --files src/static/js/planejamento-basedados.js src/static/planejamento-basedados.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1ca27a0808323bfd4a9b0e3101bf2