### PR TITLE
Add público alvo management card and mock data

### DIFF
--- a/src/static/js/planejamento-basedados.js
+++ b/src/static/js/planejamento-basedados.js
@@ -26,6 +26,10 @@ document.addEventListener('DOMContentLoaded', () => {
             { id: 1, nome: '4 horas' },
             { id: 2, nome: '8 horas' },
             { id: 3, nome: '16 horas' }
+        ],
+        'publico-alvo': [
+            { id: 1, nome: 'Empregados Anglo American' },
+            { id: 2, nome: 'Comunidade' }
         ]
     };
 
@@ -195,7 +199,7 @@ document.addEventListener('DOMContentLoaded', () => {
         
         const titulos = {
             treinamento: 'Treinamento', local: 'Local', modalidade: 'Modalidade',
-            horario: 'Horário', cargahoraria: 'Carga Horária'
+            horario: 'Horário', cargahoraria: 'Carga Horária', 'publico-alvo': 'Público Alvo'
         };
         const titulo = titulos[type] || 'Item';
 
@@ -275,5 +279,6 @@ document.addEventListener('DOMContentLoaded', () => {
     renderizarTabelaGenerica('modalidade');
     renderizarTabelaGenerica('horario');
     renderizarTabelaGenerica('cargahoraria');
+    renderizarTabelaGenerica('publico-alvo');
 });
 

--- a/src/static/planejamento-basedados.html
+++ b/src/static/planejamento-basedados.html
@@ -108,6 +108,23 @@
                     <div class="col-md-6 mb-4">
                         <div class="card h-100">
                             <div class="card-header d-flex justify-content-between align-items-center">
+                                <h2 class="card-title mb-0"><i class="bi bi-people-fill me-2"></i>Publico alvo</h2>
+                                <button class="btn btn-primary btn-sm" onclick="abrirModal('publico-alvo')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                            </div>
+                            <div class="card-body p-0">
+                                <div class="table-responsive">
+                                    <table class="table table-striped table-hover mb-0">
+                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                        <tbody id="tabela-publico-alvo"></tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-md-6 mb-4">
+                        <div class="card h-100">
+                            <div class="card-header d-flex justify-content-between align-items-center">
                                 <h2 class="card-title mb-0"><i class="bi bi-geo-alt-fill me-2"></i>Locais</h2>
                                 <button class="btn btn-primary btn-sm" onclick="abrirModal('local')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
                             </div>


### PR DESCRIPTION
## Summary
- Add "Público Alvo" card to database planning page
- Support managing público alvo entries in planning JS logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1f0396d348323b396a04b2a671132