### PR TITLE
feat: add quarterly planning view

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -1,0 +1,167 @@
+// src/static/js/planejamento-trimestral.js
+
+document.addEventListener('DOMContentLoaded', () => {
+    // --- Verificações Iniciais ---
+    if (!verificarAutenticacao()) {
+        console.warn("Usuário não autenticado.");
+        return;
+    }
+    const usuario = getUsuarioLogado();
+    if (usuario) {
+        document.getElementById('userName').textContent = usuario.nome;
+    }
+
+    // --- Dados (Mock e API) ---
+    // Usamos os mesmos dados da página de base de dados para consistência.
+    const mockData = {
+        treinamento: [
+            { id: 1, nome: 'NR 22 SEGURANCA E SAUDE OCUPACIONAL NA MINERACAO - AMBIENTACAO (2º Dia - AA e Contratada)&CONTRATADA' },
+            { id: 2, nome: 'NR 22 SEGURANCA E SAUDE OCUPACIONAL NA MINERACAO - AMBIENTACAO (3º Dia - Filtragem)' },
+        ],
+        local: [
+            { id: 1, nome: 'ONLINE/HOME OFFICE' },
+            { id: 2, nome: 'CMD' },
+            { id: 3, nome: 'TRANSMISSÃO ONLINE' },
+            { id: 4, nome: 'SAG' }
+        ],
+        modalidade: [
+            { id: 1, nome: 'Semipresencial' },
+            { id: 2, nome: 'Presencial' },
+            { id: 3, nome: 'Online' }
+        ],
+        horario: [
+            { id: 1, nome: '08:00 às 16:00' },
+            { id: 2, nome: '08:00 às 12:00' },
+            { id: 3, nome: '18:00 - 22:00' }
+        ],
+        cargahoraria: [
+            { id: 1, nome: '4 horas' },
+            { id: 2, nome: '8 horas' },
+            { id: 3, nome: '16 horas' },
+            { id: 4, nome: '24 horas' }
+        ],
+        publicoalvo: [ // Nome ajustado para ser um identificador válido
+            { id: 1, nome: 'PROJETOS' },
+            { id: 2, nome: 'RECLEANER' },
+            { id: 3, nome: 'Turma D' },
+            { id: 4, nome: 'CMD' }
+        ]
+    };
+
+    let instrutores = [];
+
+    // --- Elementos do DOM ---
+    const adicionarBtn = document.getElementById('adicionarTreinamentoBtn');
+    const treinamentoModalEl = document.getElementById('treinamentoModal');
+    const treinamentoModal = new bootstrap.Modal(treinamentoModalEl);
+    const treinamentoForm = document.getElementById('treinamentoForm');
+    const tabelaCorpo = document.getElementById('planejamentoTabelaCorpo');
+
+    /**
+     * Carrega dados dinâmicos (instrutores) da API.
+     */
+    async function carregarInstrutores() {
+        if (instrutores.length > 0) return;
+        try {
+            instrutores = await chamarAPI('/instrutores');
+        } catch (e) {
+            console.error('Falha ao carregar instrutores:', e);
+            showToast('Não foi possível carregar a lista de instrutores.', 'danger');
+        }
+    }
+
+    /**
+     * Preenche os seletores (dropdowns) do modal com os dados carregados.
+     */
+    function popularSeletoresModal() {
+        const seletores = {
+            'modalTreinamento': mockData.treinamento,
+            'modalHorario': mockData.horario,
+            'modalCargaHoraria': mockData.cargahoraria,
+            'modalModalidade': mockData.modalidade,
+            'modalCmd': mockData.publicoalvo,
+            'modalSjb': mockData.publicoalvo,
+            'modalSag': mockData.publicoalvo,
+            'modalInstrutor': instrutores,
+            'modalLocal': mockData.local,
+        };
+
+        for (const [id, data] of Object.entries(seletores)) {
+            const select = document.getElementById(id);
+            select.innerHTML = '<option value="">Selecione...</option>';
+            data.forEach(item => {
+                select.innerHTML += `<option value="${item.nome}">${escapeHTML(item.nome)}</option>`;
+            });
+        }
+    }
+    
+    /**
+     * Abre o modal de adição de treinamento.
+     */
+    adicionarBtn.addEventListener('click', async () => {
+        treinamentoForm.reset();
+        await carregarInstrutores();
+        popularSeletoresModal();
+        treinamentoModal.show();
+    });
+
+    /**
+     * Lida com o envio do formulário do modal.
+     */
+    treinamentoForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+
+        const formData = new FormData(treinamentoForm);
+        const dados = Object.fromEntries(formData.entries());
+
+        const dataInicio = new Date(dados.inicio + 'T00:00:00-03:00');
+        const dataTermino = new Date(dados.termino + 'T00:00:00-03:00');
+        
+        if (dataInicio > dataTermino) {
+            showToast('A data de término não pode ser anterior à data de início.', 'warning');
+            return;
+        }
+
+        // Gera as linhas da tabela para cada dia no intervalo
+        let diaAtual = new Date(dataInicio);
+        while (diaAtual <= dataTermino) {
+            adicionarLinhaTabela(dados, new Date(diaAtual));
+            diaAtual.setDate(diaAtual.getDate() + 1);
+        }
+
+        treinamentoModal.hide();
+    });
+
+    /**
+     * Adiciona uma nova linha à tabela de planejamento.
+     * @param {object} dados - Os dados do formulário.
+     * @param {Date} dataLinha - A data específica para esta linha.
+     */
+    function adicionarLinhaTabela(dados, dataLinha) {
+        const semana = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado'][dataLinha.getDay()];
+        
+        // Formata a data no padrão dd/mm/aaaa
+        const inicioFormatado = dataLinha.toLocaleDateString('pt-BR');
+        const terminoFormatado = new Date(dados.termino + 'T00:00:00-03:00').toLocaleDateString('pt-BR');
+
+
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${inicioFormatado}</td>
+            <td>${terminoFormatado}</td>
+            <td>${semana}</td>
+            <td>${escapeHTML(dados.horario)}</td>
+            <td>${escapeHTML(dados.ch)}</td>
+            <td>${escapeHTML(dados.modalidade)}</td>
+            <td>${escapeHTML(dados.treinamento)}</td>
+            <td>${escapeHTML(dados.cmd)}</td>
+            <td>${escapeHTML(dados.sjb)}</td>
+            <td>${escapeHTML(dados.sag)}</td>
+            <td>${escapeHTML(dados.instrutor)}</td>
+            <td>${escapeHTML(dados.local)}</td>
+            <td><input type="text" class="form-control form-control-sm" value="${escapeHTML(dados.observacao)}"></td>
+        `;
+        tabelaCorpo.appendChild(tr);
+    }
+});
+

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -67,13 +67,119 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h1 class="mb-0">Planejamento Trimestral</h1>
+                    <button id="adicionarTreinamentoBtn" class="btn btn-primary"><i class="bi bi-plus-circle me-2"></i>Adicionar Treinamento</button>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead class="table-primary">
+                                    <tr>
+                                        <th scope="col">Início</th>
+                                        <th scope="col">Término</th>
+                                        <th scope="col">Semana</th>
+                                        <th scope="col">Horário</th>
+                                        <th scope="col">C.H.</th>
+                                        <th scope="col">Modalidade</th>
+                                        <th scope="col">Treinamentos</th>
+                                        <th scope="col">CMD</th>
+                                        <th scope="col">SJB</th>
+                                        <th scope="col">SAG/TOMBOS</th>
+                                        <th scope="col">Instrutor</th>
+                                        <th scope="col">Local</th>
+                                        <th scope="col">Observação</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="planejamentoTabelaCorpo">
+                                    </tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
             </main>
         </div>
     </div>
 
+    <div class="modal fade" id="treinamentoModal" tabindex="-1" aria-labelledby="treinamentoModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2 class="modal-title" id="treinamentoModalLabel">Adicionar Treinamento ao Planejamento</h2>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="treinamentoForm">
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="modalInicio" class="form-label">Data de Início*</label>
+                                <input type="date" class="form-control" id="modalInicio" name="inicio" required>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="modalTermino" class="form-label">Data de Término*</label>
+                                <input type="date" class="form-control" id="modalTermino" name="termino" required>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="modalTreinamento" class="form-label">Treinamento*</label>
+                            <select class="form-select" id="modalTreinamento" name="treinamento" required></select>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-4 mb-3">
+                                <label for="modalHorario" class="form-label">Horário*</label>
+                                <select class="form-select" id="modalHorario" name="horario" required></select>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="modalCargaHoraria" class="form-label">Carga Horária*</label>
+                                <select class="form-select" id="modalCargaHoraria" name="ch" required></select>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="modalModalidade" class="form-label">Modalidade*</label>
+                                <select class="form-select" id="modalModalidade" name="modalidade" required></select>
+                            </div>
+                        </div>
+                        <div class="row">
+                             <div class="col-md-4 mb-3">
+                                <label for="modalCmd" class="form-label">CMD*</label>
+                                <select class="form-select" id="modalCmd" name="cmd" required></select>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="modalSjb" class="form-label">SJB*</label>
+                                <select class="form-select" id="modalSjb" name="sjb" required></select>
+                            </div>
+                             <div class="col-md-4 mb-3">
+                                <label for="modalSag" class="form-label">SAG/TOMBOS*</label>
+                                <select class="form-select" id="modalSag" name="sag" required></select>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="modalInstrutor" class="form-label">Instrutor*</label>
+                                <select class="form-select" id="modalInstrutor" name="instrutor" required></select>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="modalLocal" class="form-label">Local*</label>
+                                <select class="form-select" id="modalLocal" name="local" required></select>
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="modalObservacao" class="form-label">Observação</label>
+                            <textarea class="form-control" id="modalObservacao" name="observacao" rows="3"></textarea>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" form="treinamentoForm" class="btn btn-primary">Adicionar à Tabela</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="/js/planejamento-trimestral.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add quarterly planning page markup with table, button and modal
- implement frontend logic to populate training planning table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1f310ac2883239f51b47faaa70d7b