### PR TITLE
Add frontend for training planning table with modal

### DIFF
--- a/src/static/js/planejamento-basedados.js
+++ b/src/static/js/planejamento-basedados.js
@@ -1,284 +1,40 @@
-document.addEventListener('DOMContentLoaded', () => {
-    // --- DADOS DE EXEMPLO (MOCK) ---
-    // Mantemos os dados que não vêm da API.
-    const mockData = {
-        treinamento: [
-            { id: 1, nome: 'Gerenciamento de Risco' },
-            { id: 2, nome: 'ALFI Básico' },
-            { id: 3, nome: 'Aperfeiçoamento Prof Seg Trafego Mina FM' }
-        ],
-        local: [
-            { id: 1, nome: 'ONLINE/HOME OFFICE' },
-            { id: 2, nome: 'CMD' },
-            { id: 3, nome: 'TRANSMISSÃO ONLINE' }
-        ],
-        modalidade: [
-            { id: 1, nome: 'Semipresencial' },
-            { id: 2, nome: 'Presencial' },
-            { id: 3, nome: 'Online' }
-        ],
-        horario: [
-            { id: 1, nome: '08:00 - 12:00' },
-            { id: 2, nome: '13:00 - 17:00' },
-            { id: 3, nome: '18:00 - 22:00' }
-        ],
-        cargahoraria: [
-            { id: 1, nome: '4 horas' },
-            { id: 2, nome: '8 horas' },
-            { id: 3, nome: '16 horas' }
-        ],
-        'publico-alvo': [
-            { id: 1, nome: 'Empregados Anglo American' },
-            { id: 2, nome: 'Comunidade' }
-        ]
-    };
+// Simula uma base de dados central para as opções do planejamento.
+// Em uma aplicação real, estes dados viriam de uma API.
 
-    // --- VARIÁVEIS GLOBAIS ---
-    const geralModal = new bootstrap.Modal(document.getElementById('geralModal'));
-    const instrutorModal = new bootstrap.Modal(document.getElementById('instrutorModal'));
-    const confirmacaoModal = new bootstrap.Modal(document.getElementById('confirmacaoModal'));
-    let itemParaExcluir = { type: null, id: null };
-    let areasDeAtuacao = [];
-
-    // ===================================================================
-    // LÓGICA PARA INSTRUTORES (MODAL COMPLETO)
-    // ===================================================================
-
-    /**
-     * Carrega as áreas de atuação da API para popular o select do modal.
-     */
-    async function carregarAreasParaModal() {
-        if (areasDeAtuacao.length > 0) return;
-        try {
-            areasDeAtuacao = await chamarAPI('/instrutores/areas-atuacao');
-            const select = document.getElementById('instrutorArea');
-            select.innerHTML = '<option value="">Selecione...</option>';
-            areasDeAtuacao.forEach(area => {
-                select.innerHTML += `<option value="${escapeHTML(area.valor)}">${escapeHTML(area.nome)}</option>`;
-            });
-        } catch (e) {
-            console.error('Falha ao carregar áreas de atuação:', e);
-            showToast('Não foi possível carregar as áreas de atuação.', 'danger');
-        }
-    }
-
-    /**
-     * Carrega os instrutores da API e renderiza a tabela.
-     */
-    async function carregarInstrutoresDaAPI() {
-        try {
-            const instrutores = await chamarAPI('/instrutores');
-            const tbody = document.getElementById('tabela-instrutor');
-            tbody.innerHTML = '';
-
-            if (instrutores.length === 0) {
-                tbody.innerHTML = `<tr><td colspan="2" class="text-center text-muted">Nenhum instrutor cadastrado.</td></tr>`;
-                return;
-            }
-
-            instrutores.forEach(item => {
-                const tr = document.createElement('tr');
-                tr.innerHTML = `
-                    <td>${escapeHTML(item.nome)}</td>
-                    <td class="text-end">
-                        <button class="btn btn-sm btn-outline-primary me-1" onclick="abrirModalInstrutor(${item.id})"><i class="bi bi-pencil"></i></button>
-                        <button class="btn btn-sm btn-outline-danger" onclick="confirmarExclusao('instrutor', ${item.id})"><i class="bi bi-trash"></i></button>
-                    </td>
-                `;
-                tbody.appendChild(tr);
-            });
-        } catch (error) {
-            console.error('Falha ao carregar instrutores:', error);
-            showToast('Não foi possível carregar a lista de instrutores.', 'danger');
-        }
-    }
-
-    /**
-     * Abre o modal completo para adicionar ou editar um instrutor.
-     * @param {number|null} id - O ID do instrutor para edição.
-     */
-    window.abrirModalInstrutor = async (id = null) => {
-        await carregarAreasParaModal();
-        const form = document.getElementById('formInstrutor');
-        form.reset();
-        document.getElementById('instrutorModalLabel').textContent = id ? 'Editar Instrutor' : 'Novo Instrutor';
-        document.getElementById('instrutorId').value = id || '';
-
-        if (id) {
-            try {
-                const instrutor = await chamarAPI(`/instrutores/${id}`);
-                document.getElementById('instrutorNome').value = instrutor.nome;
-                document.getElementById('instrutorEmail').value = instrutor.email || '';
-                document.getElementById('instrutorArea').value = instrutor.area_atuacao || '';
-                document.getElementById('instrutorStatus').value = instrutor.status || 'ativo';
-                document.getElementById('instrutorObservacoes').value = instrutor.observacoes || '';
-                (instrutor.disponibilidade || []).forEach(d => {
-                    const el = document.getElementById(`disp${d.charAt(0).toUpperCase() + d.slice(1)}`);
-                    if (el) el.checked = true;
-                });
-            } catch(e) {
-                showToast(`Erro ao carregar dados do instrutor: ${e.message}`, 'danger');
-                return;
-            }
-        }
-        instrutorModal.show();
-    };
-
-    /**
-     * Coleta os dados do formulário de instrutor e salva (cria ou atualiza).
-     */
-    async function salvarInstrutor() {
-        const id = document.getElementById('instrutorId').value;
-        const disponibilidade = [];
-        if (document.getElementById('dispManha').checked) disponibilidade.push('manha');
-        if (document.getElementById('dispTarde').checked) disponibilidade.push('tarde');
-        if (document.getElementById('dispNoite').checked) disponibilidade.push('noite');
-
-        const body = {
-            nome: document.getElementById('instrutorNome').value,
-            email: document.getElementById('instrutorEmail').value,
-            area_atuacao: document.getElementById('instrutorArea').value,
-            status: document.getElementById('instrutorStatus').value,
-            observacoes: document.getElementById('instrutorObservacoes').value,
-            disponibilidade
-        };
-
-        if (!body.nome || !body.email) {
-            showToast('Nome e E-mail são obrigatórios.', 'warning');
-            return;
-        }
-
-        try {
-            const endpoint = id ? `/instrutores/${id}` : '/instrutores';
-            const method = id ? 'PUT' : 'POST';
-            await chamarAPI(endpoint, method, body);
-            showToast(`Instrutor ${id ? 'atualizado' : 'adicionado'} com sucesso!`, 'success');
-            instrutorModal.hide();
-            carregarInstrutoresDaAPI();
-        } catch(e) {
-            showToast(`Erro ao salvar instrutor: ${e.message}`, 'danger');
-        }
-    }
-
-
-    // ===================================================================
-    // LÓGICA PARA ITENS GENÉRICOS (MODAL SIMPLES)
-    // ===================================================================
-
-    function renderizarTabelaGenerica(type) {
-        const tbody = document.getElementById(`tabela-${type}`);
-        if (!tbody) return;
-
-        tbody.innerHTML = '';
-        const dados = mockData[type] || [];
-
-        if (dados.length === 0) {
-            tbody.innerHTML = `<tr><td colspan="2" class="text-center text-muted">Nenhum item cadastrado.</td></tr>`;
-            return;
-        }
-
-        dados.forEach(item => {
-            const tr = document.createElement('tr');
-            tr.innerHTML = `
-                <td>${escapeHTML(item.nome)}</td>
-                <td class="text-end">
-                    <button class="btn btn-sm btn-outline-primary me-1" onclick="abrirModal('${type}', ${item.id})"><i class="bi bi-pencil"></i></button>
-                    <button class="btn btn-sm btn-outline-danger" onclick="confirmarExclusao('${type}', ${item.id})"><i class="bi bi-trash"></i></button>
-                </td>
-            `;
-            tbody.appendChild(tr);
-        });
-    }
-
-    window.abrirModal = (type, id = null) => {
-        const form = document.getElementById('geralForm');
-        form.reset();
-        
-        document.getElementById('itemType').value = type;
-        const modalLabel = document.getElementById('geralModalLabel');
-        
-        const titulos = {
-            treinamento: 'Treinamento', local: 'Local', modalidade: 'Modalidade',
-            horario: 'Horário', cargahoraria: 'Carga Horária', 'publico-alvo': 'Público Alvo'
-        };
-        const titulo = titulos[type] || 'Item';
-
-        if (id) {
-            modalLabel.textContent = `Editar ${titulo}`;
-            const item = mockData[type].find(i => i.id === id);
-            if (item) {
-                document.getElementById('itemId').value = id;
-                document.getElementById('itemName').value = item.nome;
-            }
-        } else {
-            modalLabel.textContent = `Adicionar Novo ${titulo}`;
-            document.getElementById('itemId').value = '';
-        }
-        
-        geralModal.show();
-    };
-
-    function salvarItem() {
-        const id = document.getElementById('itemId').value;
-        const type = document.getElementById('itemType').value;
-        const name = document.getElementById('itemName').value;
-
-        if (!name.trim()) {
-            alert('O nome não pode estar vazio.');
-            return;
-        }
-        
-        if (id) {
-            const index = mockData[type].findIndex(i => i.id == id);
-            if (index > -1) mockData[type][index].nome = name;
-        } else {
-            const newId = (mockData[type].length > 0) ? Math.max(...mockData[type].map(i => i.id)) + 1 : 1;
-            mockData[type].push({ id: newId, nome: name });
-        }
-        
-        renderizarTabelaGenerica(type);
-        geralModal.hide();
-    }
-
-    window.confirmarExclusao = (type, id) => {
-        itemParaExcluir = { type, id };
-        confirmacaoModal.show();
-    };
-
-    async function excluirItem() {
-        const { type, id } = itemParaExcluir;
-        if (!type || !id) return;
-        
-        if (type === 'instrutor') {
-            try {
-                await chamarAPI(`/instrutores/${id}`, 'DELETE');
-                showToast('Instrutor excluído com sucesso!', 'success');
-                carregarInstrutoresDaAPI();
-            } catch(error) {
-                showToast(`Erro ao excluir: ${error.message}`, 'danger');
-            }
-        } else {
-            // Lógica antiga para os dados mockados
-            const index = mockData[type].findIndex(i => i.id === id);
-            if (index > -1) mockData[type].splice(index, 1);
-            renderizarTabelaGenerica(type);
-        }
-        
-        confirmacaoModal.hide();
-        itemParaExcluir = { type: null, id: null };
-    }
-
-    // --- REGISTRO DE EVENTOS E CARGA INICIAL ---
-    document.getElementById('btnSalvarGeral').addEventListener('click', salvarItem);
-    document.getElementById('btnSalvarInstrutor').addEventListener('click', salvarInstrutor);
-    document.getElementById('btnConfirmarExclusao').addEventListener('click', excluirItem);
-
-    carregarInstrutoresDaAPI();
-    renderizarTabelaGenerica('treinamento');
-    renderizarTabelaGenerica('local');
-    renderizarTabelaGenerica('modalidade');
-    renderizarTabelaGenerica('horario');
-    renderizarTabelaGenerica('cargahoraria');
-    renderizarTabelaGenerica('publico-alvo');
-});
-
+const baseDeDados = {
+    treinamentos: [
+        "Gerenciamento de Risco",
+        "ALFI Básico",
+        "Aperfeiçoamento Prof Seg Trafego Mina FM"
+    ],
+    horarios: [
+        "08:00 - 12:00",
+        "13:00 - 17:00",
+        "18:00 - 22:00"
+    ],
+    cargaHoraria: [
+        "4 horas",
+        "8 horas",
+        "16 horas"
+    ],
+    modalidades: [
+        "Semipresencial",
+        "Presencial",
+        "Online"
+    ],
+    publicoAlvo: [
+        "CMD",
+        "SJB",
+        "SAG/TOMBOS"
+    ],
+    instrutores: [
+        "João Silva",
+        "Maria Oliveira",
+        "Carlos Pereira"
+    ],
+    locais: [
+        "ONLINE/HOME OFFICE",
+        "CMD",
+        "TRANSMISSÃO ONLINE"
+    ]
+};

--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -1,0 +1,125 @@
+/* global bootstrap */
+
+document.addEventListener('DOMContentLoaded', () => {
+    // --- SELETORES DE ELEMENTOS ---
+    const modalEl = document.getElementById('modalAdicionarTreinamento');
+    const form = document.getElementById('form-treinamento');
+    const btnSalvar = document.getElementById('btn-salvar-treinamento');
+    const tabelaBody = document.getElementById('tabela-planejamento-body');
+
+    // --- FUNÇÕES DE INICIALIZAÇÃO ---
+
+    /**
+     * Carrega as opções dos selects e checkboxes do modal.
+     */
+    function popularFormulario() {
+        // Popula os selects
+        popularSelect('select-treinamento', baseDeDados.treinamentos);
+        popularSelect('select-horario', baseDeDados.horarios);
+        popularSelect('select-carga-horaria', baseDeDados.cargaHoraria);
+        popularSelect('select-modalidade', baseDeDados.modalidades);
+        popularSelect('select-instrutor', baseDeDados.instrutores);
+        popularSelect('select-local', baseDeDados.locais);
+
+        // Popula os checkboxes
+        const containerPublicoAlvo = document.getElementById('checkbox-publico-alvo');
+        containerPublicoAlvo.innerHTML = ''; // Limpa antes de adicionar
+        baseDeDados.publicoAlvo.forEach((alvo) => {
+            containerPublicoAlvo.innerHTML += `
+                <div class="form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" id="check-${alvo.toLowerCase()}" value="${alvo}">
+                    <label class="form-check-label" for="check-${alvo.toLowerCase()}">${alvo}</label>
+                </div>
+            `;
+        });
+    }
+
+    /**
+     * Função auxiliar para preencher um <select> com opções.
+     * @param {string} selectId - O ID do elemento <select>.
+     * @param {string[]} opcoes - Um array de strings com as opções.
+     */
+    function popularSelect(selectId, opcoes) {
+        const select = document.getElementById(selectId);
+        select.innerHTML = '<option value="">Selecione...</option>';
+        opcoes.forEach((opcao) => {
+            select.innerHTML += `<option value="${opcao}">${opcao}</option>`;
+        });
+    }
+
+
+    // --- LÓGICA DE MANIPULAÇÃO DE DADOS ---
+
+    /**
+     * Processa o formulário e adiciona as linhas na tabela.
+     */
+    function adicionarTreinamento() {
+        // 1. Coleta dos dados do formulário
+        const dataInicioStr = document.getElementById('data-inicio').value;
+        const dataTerminoStr = document.getElementById('data-termino').value;
+        const treinamento = document.getElementById('select-treinamento').value;
+        const horario = document.getElementById('select-horario').value;
+        const cargaHoraria = document.getElementById('select-carga-horaria').value;
+        const modalidade = document.getElementById('select-modalidade').value;
+        const instrutor = document.getElementById('select-instrutor').value;
+        const local = document.getElementById('select-local').value;
+        const observacao = document.getElementById('observacao').value;
+
+        // Coleta os públicos-alvo selecionados
+        const publicosAlvoSelecionados = [];
+        document.querySelectorAll('#checkbox-publico-alvo input:checked').forEach((input) => {
+            publicosAlvoSelecionados.push(input.value);
+        });
+
+        // Validação simples
+        if (!dataInicioStr || !dataTerminoStr || !treinamento) {
+            alert('Por favor, preencha os campos obrigatórios: Datas e Treinamento.');
+            return;
+        }
+
+        // 2. Lógica para criar uma linha por dia
+        const diasDaSemana = ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"];
+        let dataAtual = new Date(`${dataInicioStr}T00:00:00-03:00`); // Adiciona fuso para evitar problemas
+        const dataFim = new Date(`${dataTerminoStr}T00:00:00-03:00`);
+
+        while (dataAtual <= dataFim) {
+            const novaLinha = document.createElement('tr');
+
+            // Formata as datas para o padrão brasileiro
+            const inicioFormatado = new Date(`${dataInicioStr}T00:00:00-03:00`).toLocaleDateString('pt-BR');
+            const terminoFormatado = dataFim.toLocaleDateString('pt-BR');
+            const diaAtualFormatado = dataAtual.toLocaleDateString('pt-BR');
+
+            novaLinha.innerHTML = `
+                <td>${diaAtualFormatado}</td>
+                <td>${terminoFormatado}</td>
+                <td>${diasDaSemana[dataAtual.getDay()]}</td>
+                <td>${horario}</td>
+                <td>${cargaHoraria}</td>
+                <td>${modalidade}</td>
+                <td>${treinamento}</td>
+                <td>${publicosAlvoSelecionados.includes("CMD") ? "X" : ""}</td>
+                <td>${publicosAlvoSelecionados.includes("SJB") ? "X" : ""}</td>
+                <td>${publicosAlvoSelecionados.includes("SAG/TOMBOS") ? "X" : ""}</td>
+                <td>${instrutor}</td>
+                <td>${local}</td>
+                <td>${observacao}</td>
+            `;
+            tabelaBody.appendChild(novaLinha);
+
+            // Incrementa para o próximo dia
+            dataAtual.setDate(dataAtual.getDate() + 1);
+        }
+
+        // 3. Limpa o formulário e fecha o modal
+        form.reset();
+        bootstrap.Modal.getInstance(modalEl).hide();
+    }
+
+
+    // --- EVENT LISTENERS ---
+    btnSalvar.addEventListener('click', adicionarTreinamento);
+
+    // --- EXECUÇÃO INICIAL ---
+    popularFormulario();
+});

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -67,13 +67,111 @@
             <main class="col-lg-9 col-md-12">
                 <div class="page-header">
                     <h1 class="mb-0">Planejamento Trimestral</h1>
+                    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalAdicionarTreinamento">
+                        <i class="bi bi-plus-circle me-2"></i>Adicionar Treinamento
+                    </button>
+                </div>
+
+                <div class="card mt-4">
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover">
+                                <thead class="table-primary">
+                                    <tr>
+                                        <th>Início</th>
+                                        <th>Término</th>
+                                        <th>Semana</th>
+                                        <th>Horário</th>
+                                        <th>C.H.</th>
+                                        <th>Modalidade</th>
+                                        <th>Treinamentos</th>
+                                        <th>CMD</th>
+                                        <th>SJB</th>
+                                        <th>SAG/TOMBOS</th>
+                                        <th>Instrutor</th>
+                                        <th>Local</th>
+                                        <th>Observação</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="tabela-planejamento-body">
+                                    </tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
             </main>
         </div>
     </div>
 
+    <div class="modal fade" id="modalAdicionarTreinamento" tabindex="-1" aria-labelledby="modalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2 class="modal-title" id="modalLabel">Adicionar Novo Treinamento</h2>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="form-treinamento">
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="data-inicio" class="form-label">Data de Início</label>
+                                <input type="date" class="form-control" id="data-inicio" required>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="data-termino" class="form-label">Data de Término</label>
+                                <input type="date" class="form-control" id="data-termino" required>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="select-treinamento" class="form-label">Treinamento</label>
+                                <select id="select-treinamento" class="form-select" required></select>
+                            </div>
+                             <div class="col-md-6 mb-3">
+                                <label for="select-instrutor" class="form-label">Instrutor</label>
+                                <select id="select-instrutor" class="form-select" required></select>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-4 mb-3">
+                                <label for="select-horario" class="form-label">Horário</label>
+                                <select id="select-horario" class="form-select" required></select>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="select-carga-horaria" class="form-label">Carga Horária</label>
+                                <select id="select-carga-horaria" class="form-select" required></select>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="select-modalidade" class="form-label">Modalidade</label>
+                                <select id="select-modalidade" class="form-select" required></select>
+                            </div>
+                        </div>
+                         <div class="mb-3">
+                            <label for="select-local" class="form-label">Local</label>
+                            <select id="select-local" class="form-select" required></select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Público Alvo</label>
+                            <div id="checkbox-publico-alvo">
+                                </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="observacao" class="form-label">Observação</label>
+                            <textarea id="observacao" class="form-control" rows="3"></textarea>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" class="btn btn-primary" id="btn-salvar-treinamento">Salvar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="/js/planejamento-basedados.js"></script>
+    <script src="/js/planejamento-trimestral.js"></script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- add planning table page with button and modal to add trainings
- include mock database of training options
- implement JS logic to populate form and append new rows

## Testing
- `pre-commit run --files src/static/js/planejamento-basedados.js src/static/js/planejamento-trimestral.js src/static/planejamento-trimestral.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1fbbd0688832391626a5bc071d149