### PR TITLE
feat: add interactive quarterly planning table

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -200,6 +200,13 @@ small, .small {
   min-height: 36px;
 }
 
+#tabela-planejamento-trimestral thead th {
+  position: sticky;
+  top: 0;
+  background: var(--light-color);
+  z-index: 1;
+}
+
 .btn-primary {
   background-image: none;
   background-color: var(--primary-color);

--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -1,0 +1,190 @@
+// JavaScript for Planejamento Trimestral page
+
+/* global bootstrap, showToast, escapeHTML */
+document.addEventListener('DOMContentLoaded', () => {
+  const modalEl = document.getElementById('modal-planejamento');
+  const modal = new bootstrap.Modal(modalEl);
+  const btnAdd = document.getElementById('btn-adicionar-planejamento');
+  const form = document.getElementById('form-planejamento');
+  const preview = document.getElementById('linhaPreview');
+  const tbody = document.querySelector('#tabela-planejamento-trimestral tbody');
+
+  const registros = [];
+  let baseCarregada = false;
+  let base = {};
+
+  const diasSemana = ['domingo', 'segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado'];
+
+  btnAdd.addEventListener('click', async () => {
+    if (!baseCarregada) {
+      try {
+        await carregarBase();
+        popularSelects();
+        baseCarregada = true;
+      } catch (e) {
+        console.error(e);
+        showToast('Não foi possível carregar a base de dados.', 'danger');
+        return;
+      }
+    }
+    form.reset();
+    preview.textContent = '';
+    modal.show();
+  });
+
+  form.inicio.addEventListener('change', atualizarPreview);
+  form.fim.addEventListener('change', atualizarPreview);
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const inicio = form.inicio.value;
+    const fim = form.fim.value;
+    if (!inicio || !fim) {
+      showToast('Data de início e término são obrigatórias.', 'warning');
+      return;
+    }
+    if (fim < inicio) {
+      showToast('A data de término deve ser igual ou posterior à de início.', 'warning');
+      return;
+    }
+
+    const horario = form.horario.value;
+    const carga = form.carga_horaria.value;
+    const modalidade = form.modalidade.value;
+    const treinamento = form.treinamento.value;
+    const instrutor = form.instrutor.value;
+    const local = form.local.value;
+    if (!horario || !carga || !modalidade || !treinamento || !instrutor || !local) {
+      showToast('Preencha todos os campos obrigatórios.', 'warning');
+      return;
+    }
+
+    const cmd = getMulti(form.cmd);
+    const sjb = getMulti(form.sjb);
+    const sag = getMulti(form.sag_tombos);
+    const observacao = form.observacao.value;
+
+    const inicioDate = new Date(inicio);
+    const fimDate = new Date(fim);
+    for (let d = new Date(inicioDate); d <= fimDate; d.setDate(d.getDate() + 1)) {
+      const dataStr = d.toISOString().split('T')[0];
+      registros.push({
+        inicio: dataStr,
+        fim: dataStr,
+        semana: diasSemana[d.getDay()],
+        horario,
+        carga,
+        modalidade,
+        treinamento,
+        cmd,
+        sjb,
+        sag,
+        instrutor,
+        local,
+        observacao,
+      });
+    }
+    registros.sort((a, b) => new Date(a.inicio) - new Date(b.inicio));
+    renderTabela();
+    modal.hide();
+    form.reset();
+  });
+
+  tbody.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-index]');
+    if (btn) {
+      const { index } = btn.dataset;
+      registros.splice(Number(index), 1);
+      renderTabela();
+    }
+  });
+
+  function atualizarPreview() {
+    const { inicio, fim } = form;
+    preview.textContent = '';
+    if (inicio.value && fim.value && fim.value >= inicio.value) {
+      const count = Math.floor((new Date(fim.value) - new Date(inicio.value)) / 86400000) + 1;
+      preview.textContent = `Serão criadas ${count} linha${count > 1 ? 's' : ''}.`;
+    }
+  }
+
+  function getMulti(select) {
+    return Array.from(select.selectedOptions).map((o) => o.value).join(', ');
+  }
+
+  function formatarData(iso) {
+    return new Date(iso).toLocaleDateString('pt-BR');
+  }
+
+  function renderTabela() {
+    tbody.innerHTML = '';
+    registros.forEach((r, index) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${escapeHTML(formatarData(r.inicio))}</td>
+        <td>${escapeHTML(formatarData(r.fim))}</td>
+        <td>${escapeHTML(r.semana)}</td>
+        <td>${escapeHTML(r.horario)}</td>
+        <td>${escapeHTML(r.carga)}</td>
+        <td>${escapeHTML(r.modalidade)}</td>
+        <td>${escapeHTML(r.treinamento)}</td>
+        <td>${escapeHTML(r.cmd)}</td>
+        <td>${escapeHTML(r.sjb)}</td>
+        <td>${escapeHTML(r.sag)}</td>
+        <td>${escapeHTML(r.instrutor)}</td>
+        <td>${escapeHTML(r.local)}</td>
+        <td>${escapeHTML(r.observacao)}</td>
+        <td class="text-end"><button type="button" class="btn btn-sm btn-outline-danger" data-index="${index}"><i class="bi bi-trash"></i></button></td>
+      `;
+      tbody.appendChild(tr);
+    });
+  }
+
+  async function carregarBase() {
+    const resp = await fetch('/planejamento-basedados.html');
+    const html = await resp.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const extrair = (id) => {
+      const set = new Set();
+      doc.querySelectorAll(`#${id} tbody tr td:first-child`).forEach((td) => {
+        const txt = td.textContent.trim();
+        if (txt) set.add(txt);
+      });
+      return Array.from(set).sort((a, b) => a.localeCompare(b, 'pt-BR'));
+    };
+    base = {
+      horario: extrair('tabela-horario'),
+      carga_horaria: extrair('tabela-cargahoraria'),
+      modalidade: extrair('tabela-modalidade'),
+      treinamento: extrair('tabela-treinamento'),
+      publico: extrair('tabela-publico-alvo'),
+      instrutor: extrair('tabela-instrutor'),
+      local: extrair('tabela-local'),
+    };
+  }
+
+  function popularSelects() {
+    preencher('horario', base.horario);
+    preencher('carga_horaria', base.carga_horaria);
+    preencher('modalidade', base.modalidade);
+    preencher('treinamento', base.treinamento);
+    preencher('cmd', base.publico, true);
+    preencher('sjb', base.publico, true);
+    preencher('sag_tombos', base.publico, true);
+    preencher('instrutor', base.instrutor);
+    preencher('local', base.local);
+  }
+
+  function preencher(id, valores, multiple = false) {
+    const select = document.getElementById(id);
+    if (!select) return;
+    select.innerHTML = multiple ? '' : '<option value="">Selecione...</option>';
+    valores.forEach((v) => {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = v;
+      select.appendChild(opt);
+    });
+  }
+});

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -68,12 +68,113 @@
                 <div class="page-header">
                     <h1 class="mb-0">Planejamento Trimestral</h1>
                 </div>
+                <div id="aba-planejamento-trimestral">
+                    <div class="d-flex justify-content-end mb-3">
+                        <button class="btn btn-primary" id="btn-adicionar-planejamento"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                    </div>
+                    <div class="table-responsive" style="max-height: 60vh;">
+                        <table class="table table-striped table-hover" id="tabela-planejamento-trimestral">
+                            <thead>
+                                <tr>
+                                    <th>Início</th>
+                                    <th>Fim</th>
+                                    <th>Semana</th>
+                                    <th>Horário</th>
+                                    <th>C.H.</th>
+                                    <th>Modalidade</th>
+                                    <th>Treinamentos</th>
+                                    <th>CMD</th>
+                                    <th>SJB</th>
+                                    <th>SAG/TOMBOS</th>
+                                    <th>Instrutor</th>
+                                    <th>Local</th>
+                                    <th>Observação</th>
+                                    <th class="text-end">Ações</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
             </main>
+        </div>
+    </div>
+
+    <div class="modal fade" id="modal-planejamento" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <form id="form-planejamento">
+                    <div class="modal-header">
+                        <h2 class="modal-title">Adicionar Planejamento</h2>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label for="inicio" class="form-label">Data de início</label>
+                                <input type="date" class="form-control" id="inicio" name="inicio" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="fim" class="form-label">Data de término</label>
+                                <input type="date" class="form-control" id="fim" name="fim" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="horario" class="form-label">Horário</label>
+                                <select class="form-select" id="horario" name="horario" required></select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="carga_horaria" class="form-label">Carga Horária</label>
+                                <select class="form-select" id="carga_horaria" name="carga_horaria" required></select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="modalidade" class="form-label">Modalidade</label>
+                                <select class="form-select" id="modalidade" name="modalidade" required></select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="treinamento" class="form-label">Treinamentos</label>
+                                <select class="form-select" id="treinamento" name="treinamento" required></select>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="cmd" class="form-label">CMD</label>
+                                <select class="form-select" id="cmd" name="cmd" multiple></select>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="sjb" class="form-label">SJB</label>
+                                <select class="form-select" id="sjb" name="sjb" multiple></select>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="sag_tombos" class="form-label">SAG/TOMBOS</label>
+                                <select class="form-select" id="sag_tombos" name="sag_tombos" multiple></select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="instrutor" class="form-label">Instrutor</label>
+                                <select class="form-select" id="instrutor" name="instrutor" required></select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="local" class="form-label">Local</label>
+                                <select class="form-select" id="local" name="local" required></select>
+                            </div>
+                            <div class="col-12">
+                                <label for="observacao" class="form-label">Observação</label>
+                                <textarea class="form-control" id="observacao" name="observacao" rows="2"></textarea>
+                            </div>
+                        </div>
+                        <div class="mt-2">
+                            <small id="linhaPreview" class="text-muted"></small>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                        <button type="submit" class="btn btn-primary">Salvar</button>
+                    </div>
+                </form>
+            </div>
         </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="/js/planejamento-trimestral.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add dynamic quarterly planning table with modal entry form
- fetch base data to populate form options and render rows per date
- style table header as sticky

## Testing
- `pre-commit run --files src/static/planejamento-trimestral.html src/static/css/styles.css src/static/js/planejamento-trimestral.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2065c77788323a5f5d8f4859e4ca2