### PR TITLE
Refactor quarterly planning interface

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -1,238 +1,322 @@
 /* global bootstrap, showToast, chamarAPI, escapeHTML */
 
 document.addEventListener('DOMContentLoaded', () => {
-    // ---
-    // Elementos do DOM (mantenha os existentes)
-    // ---
-    const btnAdicionar = document.getElementById('btn-adicionar-planejamento');
-    const tabelaPlanejamento = document.getElementById('tabela-planejamento-trimestral').getElementsByTagName('tbody')[0];
-    const modalEl = document.getElementById('modal-planejamento');
-    const modal = new bootstrap.Modal(modalEl);
-    const form = document.getElementById('form-planejamento');
-    const contadorLinhasEl = document.getElementById('contador-linhas');
-
-    // Cache para armazenar os dados da base de dados
-    let cacheOpcoes = null;
-
-    // -------------------
-    // Funções
-    // -------------------
-
-    /**
-     * Busca os dados para os selects da API.
-     * Utiliza um cache para evitar buscas repetidas.
-     * @returns {Promise<Object>} Um objeto com as listas de opções.
-     */
-    async function carregarOpcoesDaAPI() {
-        if (cacheOpcoes) {
-            return cacheOpcoes;
-        }
-
-        try {
-            // Faz chamadas concorrentes para a API para buscar todas as opções
-            const [dadosBase, treinamentos, instrutores] = await Promise.all([
-                chamarAPI('/planejamento/basedados'),
-                chamarAPI('/treinamentos/catalogo'),
-                chamarAPI('/instrutores')
-            ]);
-
-            cacheOpcoes = {
-                horario: dadosBase.horario || [],
-                carga_horaria: dadosBase.carga_horaria || [],
-                modalidade: dadosBase.modalidade || [],
-                local: dadosBase.local || [],
-                publico_alvo: dadosBase.publico_alvo || [],
-                treinamento: treinamentos.map(t => t.nome) || [],
-                instrutor: instrutores.map(i => i.nome) || []
-            };
-            
-            return cacheOpcoes;
-        } catch (error) {
-            console.error('Erro ao carregar opções da API:', error);
-            showToast('Erro ao carregar opções do formulário.', 'danger');
-            return null;
-        }
-    }
-
-    /**
-     * Preenche um elemento <select> com uma lista de opções.
-     * @param {HTMLSelectElement} selectEl - O elemento select a ser populado.
-     * @param {string[]} opcoes - A lista de strings para as opções.
-     * @param {string} placeholder - O texto inicial (ex: "Selecione...").
-     */
-    function popularSelect(selectEl, opcoes, placeholder) {
-        if (!selectEl) return;
-        selectEl.innerHTML = `<option value="">${placeholder}</option>`;
-        opcoes.forEach((opcao) => {
-            const optionEl = document.createElement('option');
-            optionEl.value = opcao;
-            optionEl.textContent = escapeHTML(opcao);
-            selectEl.appendChild(optionEl);
-        });
-    }
-
-    /**
-     * Popula todos os selects do modal com os dados carregados da API.
-     */
-    async function popularFormulario() {
-        const dados = await carregarOpcoesDaAPI();
-        if (!dados) return;
-
-        popularSelect(form.horario, dados.horario, 'Selecione um horário...');
-        popularSelect(form.carga_horaria, dados.carga_horaria, 'Selecione uma C.H...');
-        popularSelect(form.modalidade, dados.modalidade, 'Selecione uma modalidade...');
-        popularSelect(form.treinamento, dados.treinamento, 'Selecione um treinamento...');
-        popularSelect(form.instrutor, dados.instrutor, 'Selecione um instrutor...');
-        popularSelect(form.local, dados.local, 'Selecione um local...');
+    // Objeto principal para encapsular a lógica da página
+    const gerenciadorPlanejamento = {
+        // --- SELETORES E ESTADO ---
+        tabelaBody: document.getElementById('tabela-planejamento-trimestral').querySelector('tbody'),
+        modalEl: document.getElementById('modal-planejamento'),
+        form: document.getElementById('form-planejamento'),
+        contadorLinhasEl: document.getElementById('contador-linhas'),
+        confirmacaoModalEl: document.getElementById('confirmacaoExclusaoModal'),
         
-        // Popula os campos de público alvo
-        popularSelect(form.cmd, dados.publico_alvo, 'Nenhum');
-        popularSelect(form.sjb, dados.publico_alvo, 'Nenhum');
-        popularSelect(form.sag_tombos, dados.publico_alvo, 'Nenhum');
-    }
+        modal: null,
+        confirmacaoModal: null,
 
-    // --- Mantenha o restante das funções como estão ---
-    // (atualizarContadorLinhas, validarFormulario, ordenarTabela, salvarPlanejamento, removerLinha)
-    // ...
+        planejamentos: [], // Array em memória para armazenar os dados
+        cacheOpcoes: null,
+        loteParaExcluir: null,
 
-    /**
-     * Calcula a diferença de dias entre duas datas e atualiza o contador de linhas.
-     */
-    function atualizarContadorLinhas() {
-        const inicio = form.inicio.valueAsDate;
-        const fim = form.fim.valueAsDate;
+        /**
+         * Inicializa os componentes e os event listeners.
+         */
+        init() {
+            this.modal = new bootstrap.Modal(this.modalEl);
+            this.confirmacaoModal = new bootstrap.Modal(this.confirmacaoModalEl);
 
-        if (inicio && fim && fim >= inicio) {
-            const diffTime = Math.abs(fim - inicio);
-            const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
-            contadorLinhasEl.textContent = `Serão criadas ${diffDays} linha(s) na tabela.`;
-            contadorLinhasEl.classList.remove('d-none');
-        } else {
-            contadorLinhasEl.classList.add('d-none');
-        }
-    }
+            document.getElementById('btn-adicionar-planejamento').addEventListener('click', () => this.abrirModal());
+            this.form.addEventListener('submit', (e) => this.salvar(e));
+            this.tabelaBody.addEventListener('click', (e) => this.handleTabelaClick(e));
+            document.getElementById('btn-confirmar-exclusao').addEventListener('click', () => this.executarExclusao());
 
-    /**
-     * Valida o formulário antes de salvar.
-     * @returns {boolean} True se o formulário for válido.
-     */
-    function validarFormulario() {
-        let valido = true;
-        form.querySelectorAll('[required]').forEach((input) => {
-            if (!input.value) {
-                input.classList.add('is-invalid');
-                valido = false;
-            } else {
-                input.classList.remove('is-invalid');
+            this.form.inicio.addEventListener('change', () => this.atualizarContadorLinhas());
+            this.form.fim.addEventListener('change', () => this.atualizarContadorLinhas());
+
+            this.popularFormulario(); // Pré-carrega os selects
+        },
+
+        // --- FUNÇÕES DE CARREGAMENTO E RENDERIZAÇÃO ---
+
+        async carregarOpcoesDaAPI() {
+            if (this.cacheOpcoes) return this.cacheOpcoes;
+            try {
+                const [dadosBase, treinamentos, instrutores] = await Promise.all([
+                    chamarAPI('/planejamento/basedados'),
+                    chamarAPI('/treinamentos/catalogo'),
+                    chamarAPI('/instrutores')
+                ]);
+                this.cacheOpcoes = {
+                    horario: dadosBase.horario || [],
+                    carga_horaria: dadosBase.carga_horaria || [],
+                    modalidade: dadosBase.modalidade || [],
+                    local: dadosBase.local || [],
+                    publico_alvo: dadosBase.publico_alvo || [],
+                    treinamento: treinamentos.map(t => t.nome) || [],
+                    instrutor: instrutores.map(i => i.nome) || []
+                };
+                return this.cacheOpcoes;
+            } catch (error) {
+                showToast('Erro ao carregar opções do formulário.', 'danger');
+                return null;
             }
-        });
+        },
+        
+        popularSelect(selectEl, opcoes, placeholder) {
+            if (!selectEl) return;
+            selectEl.innerHTML = `<option value="">${placeholder}</option>`;
+            opcoes.forEach(opcao => {
+                const optionEl = document.createElement('option');
+                optionEl.value = opcao;
+                optionEl.textContent = escapeHTML(opcao);
+                selectEl.appendChild(optionEl);
+            });
+        },
 
-        const inicio = form.inicio.valueAsDate;
-        const fim = form.fim.valueAsDate;
-        if (!inicio || !fim || fim < inicio) {
-            form.fim.classList.add('is-invalid');
-            valido = false;
-        } else {
-            form.fim.classList.remove('is-invalid');
+        async popularFormulario() {
+            const dados = await this.carregarOpcoesDaAPI();
+            if (!dados) return;
+
+            this.popularSelect(this.form.horario, dados.horario, 'Selecione...');
+            this.popularSelect(this.form.carga_horaria, dados.carga_horaria, 'Selecione...');
+            this.popularSelect(this.form.modalidade, dados.modalidade, 'Selecione...');
+            this.popularSelect(this.form.treinamento, dados.treinamento, 'Selecione...');
+            this.popularSelect(this.form.instrutor, dados.instrutor, 'Selecione...');
+            this.popularSelect(this.form.local, dados.local, 'Selecione...');
+            this.popularSelect(this.form.cmd, dados.publico_alvo, 'Nenhum');
+            this.popularSelect(this.form.sjb, dados.publico_alvo, 'Nenhum');
+            this.popularSelect(this.form.sag_tombos, dados.publico_alvo, 'Nenhum');
+        },
+
+        renderizarTabela() {
+            this.tabelaBody.innerHTML = '';
+            this.planejamentos.sort((a, b) => new Date(a.data) - new Date(b.data));
+
+            this.planejamentos.forEach(item => {
+                const tr = document.createElement('tr');
+                tr.dataset.rowId = item.rowId;
+                tr.dataset.loteId = item.loteId;
+                
+                tr.innerHTML = `
+                    <td>${this.formatarData(item.data)}</td>
+                    <td>${this.formatarData(item.data)}</td>
+                    <td>${item.semana}</td>
+                    <td>${escapeHTML(item.horario)}</td>
+                    <td>${escapeHTML(item.cargaHoraria)}</td>
+                    <td>${escapeHTML(item.modalidade)}</td>
+                    <td>${escapeHTML(item.treinamento)}</td>
+                    <td>${escapeHTML(item.cmd || '-')}</td>
+                    <td>${escapeHTML(item.sjb || '-')}</td>
+                    <td>${escapeHTML(item.sagTombos || '-')}</td>
+                    <td>${escapeHTML(item.instrutor)}</td>
+                    <td>${escapeHTML(item.local)}</td>
+                    <td>${escapeHTML(item.observacao || '-')}</td>
+                    <td class="text-end">
+                        <button class="btn btn-sm btn-outline-primary btn-editar-planejamento" title="Editar">
+                            <i class="bi bi-pencil"></i>
+                        </button>
+                        <button class="btn btn-sm btn-outline-danger btn-excluir-planejamento" title="Excluir Lote">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </td>
+                `;
+                this.tabelaBody.appendChild(tr);
+            });
+        },
+        
+        // --- LÓGICA DO MODAL E FORMULÁRIO ---
+
+        abrirModal(modo = 'add', rowId = null) {
+            this.form.reset();
+            this.form.classList.remove('was-validated');
+            this.contadorLinhasEl.classList.add('d-none');
+            this.modalEl.dataset.mode = modo;
+            this.modalEl.dataset.rowId = rowId || '';
+
+            const label = this.modalEl.querySelector('#modalPlanejamentoLabel');
+            const dataInicioInput = this.form.inicio;
+            const dataFimInput = this.form.fim;
+
+            if (modo === 'edit') {
+                label.textContent = 'Editar Item do Planejamento';
+                const item = this.planejamentos.find(p => p.rowId === rowId);
+                if (item) {
+                    // Preenche o formulário
+                    Object.keys(item).forEach(key => {
+                        if (this.form[key]) {
+                            this.form[key].value = item[key];
+                        }
+                    });
+                    // Ajusta nomes de campo
+                    this.form.carga_horaria.value = item.cargaHoraria;
+                    this.form.sag_tombos.value = item.sagTombos;
+                    // Lida com as datas
+                    dataInicioInput.value = item.data;
+                    dataFimInput.value = item.data;
+                    dataInicioInput.disabled = false; 
+                    dataFimInput.disabled = true; // Em modo de edição, só pode alterar a data da linha
+                }
+            } else { // modo 'add'
+                label.textContent = 'Adicionar Item ao Planejamento';
+                dataInicioInput.disabled = false;
+                dataFimInput.disabled = false;
+            }
+
+            this.modal.show();
+        },
+
+        salvar(event) {
+            event.preventDefault();
+            if (!this.validarFormulario()) return;
+
+            const modo = this.modalEl.dataset.mode;
+            if (modo === 'edit') {
+                this.executarEdicao();
+            } else {
+                this.executarAdicao();
+            }
+        },
+
+        executarAdicao() {
+            const dadosForm = Object.fromEntries(new FormData(this.form).entries());
+            const dataInicio = new Date(`${dadosForm.inicio}T12:00:00Z`);
+            const dataFim = new Date(`${dadosForm.fim}T12:00:00Z`);
+            const loteId = this.gerarUUID();
+
+            for (let d = new Date(dataInicio); d <= dataFim; d.setDate(d.getDate() + 1)) {
+                const dataAtual = new Date(d);
+                const novoItem = {
+                    rowId: this.gerarUUID(),
+                    loteId: loteId,
+                    data: dataAtual.toISOString().split('T')[0],
+                    semana: this.getDiaSemana(dataAtual),
+                    horario: dadosForm.horario,
+                    cargaHoraria: dadosForm.carga_horaria,
+                    modalidade: dadosForm.modalidade,
+                    treinamento: dadosForm.treinamento,
+                    cmd: dadosForm.cmd,
+                    sjb: dadosForm.sjb,
+                    sagTombos: dadosForm.sag_tombos,
+                    instrutor: dadosForm.instrutor,
+                    local: dadosForm.local,
+                    observacao: dadosForm.observacao
+                };
+                this.planejamentos.push(novoItem);
+            }
+            showToast('Lote de planejamento adicionado com sucesso!', 'success');
+            this.finalizarAcao();
+        },
+
+        executarEdicao() {
+            const rowId = this.modalEl.dataset.rowId;
+            const itemIndex = this.planejamentos.findIndex(p => p.rowId === rowId);
+
+            if (itemIndex > -1) {
+                const dadosForm = Object.fromEntries(new FormData(this.form).entries());
+                const dataAtualizada = new Date(`${dadosForm.inicio}T12:00:00Z`);
+                
+                // Atualiza os dados do objeto no array
+                this.planejamentos[itemIndex] = {
+                    ...this.planejamentos[itemIndex], // Mantém rowId e loteId
+                    data: dataAtualizada.toISOString().split('T')[0],
+                    semana: this.getDiaSemana(dataAtualizada),
+                    horario: dadosForm.horario,
+                    cargaHoraria: dadosForm.carga_horaria,
+                    modalidade: dadosForm.modalidade,
+                    treinamento: dadosForm.treinamento,
+                    cmd: dadosForm.cmd,
+                    sjb: dadosForm.sjb,
+                    sagTombos: dadosForm.sag_tombos,
+                    instrutor: dadosForm.instrutor,
+                    local: dadosForm.local,
+                    observacao: dadosForm.observacao
+                };
+                showToast('Item atualizado com sucesso!', 'success');
+                this.finalizarAcao();
+            } else {
+                showToast('Erro: Item não encontrado para edição.', 'danger');
+            }
+        },
+        
+        finalizarAcao() {
+            this.renderizarTabela();
+            this.modal.hide();
+        },
+
+        // --- LÓGICA DE EXCLUSÃO ---
+        
+        confirmarExclusao(loteId) {
+            this.loteParaExcluir = loteId;
+            const linhasDoLote = this.planejamentos.filter(p => p.loteId === loteId).length;
+            
+            const modalBody = this.confirmacaoModalEl.querySelector('#confirmacaoExclusaoModalBody');
+            modalBody.textContent = `Serão excluídas ${linhasDoLote} linha(s) deste lote. Deseja continuar?`;
+            
+            this.confirmacaoModal.show();
+        },
+        
+        executarExclusao() {
+            if (this.loteParaExcluir) {
+                this.planejamentos = this.planejamentos.filter(p => p.loteId !== this.loteParaExcluir);
+                this.renderizarTabela();
+                showToast('Lote de planejamento excluído com sucesso!', 'info');
+            }
+            this.loteParaExcluir = null;
+            this.confirmacaoModal.hide();
+        },
+
+        // --- MANIPULADORES DE EVENTOS E UTILITÁRIOS ---
+
+        handleTabelaClick(event) {
+            const btnEditar = event.target.closest('.btn-editar-planejamento');
+            const btnExcluir = event.target.closest('.btn-excluir-planejamento');
+
+            if (btnEditar) {
+                const rowId = btnEditar.closest('tr').dataset.rowId;
+                this.abrirModal('edit', rowId);
+            }
+
+            if (btnExcluir) {
+                const loteId = btnExcluir.closest('tr').dataset.loteId;
+                this.confirmarExclusao(loteId);
+            }
+        },
+
+        atualizarContadorLinhas() {
+            const inicio = this.form.inicio.valueAsDate;
+            const fim = this.form.fim.valueAsDate;
+            if (inicio && fim && fim >= inicio) {
+                const diffTime = Math.abs(fim - inicio);
+                const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
+                this.contadorLinhasEl.textContent = `Serão criadas ${diffDays} linha(s) na tabela.`;
+                this.contadorLinhasEl.classList.remove('d-none');
+            } else {
+                this.contadorLinhasEl.classList.add('d-none');
+            }
+        },
+        
+        validarFormulario() {
+            this.form.classList.add('was-validated');
+            return this.form.checkValidity();
+        },
+
+        getDiaSemana(data) {
+            const dia = data.toLocaleDateString('pt-BR', { weekday: 'long' });
+            return dia.charAt(0).toUpperCase() + dia.slice(1);
+        },
+
+        formatarData(dataISO) {
+            const [ano, mes, dia] = dataISO.split('-');
+            return `${dia}/${mes}/${ano}`;
+        },
+        
+        gerarUUID() {
+            return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+                (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+            );
         }
+    };
 
-        if (!valido) {
-            showToast('Por favor, corrija os campos marcados em vermelho.', 'warning');
-        }
-
-        return valido;
-    }
-
-    /**
-     * Ordena as linhas da tabela pela coluna "Início" (data).
-     */
-    function ordenarTabela() {
-        const rows = Array.from(tabelaPlanejamento.querySelectorAll('tr'));
-        rows.sort((a, b) => {
-            const dateA = a.dataset.date;
-            const dateB = b.dataset.date;
-            if (dateA < dateB) return -1;
-            if (dateA > dateB) return 1;
-            return 0;
-        });
-        rows.forEach((row) => tabelaPlanejamento.appendChild(row));
-    }
-
-    /**
-     * Processa o envio do formulário: valida, cria e insere as linhas na tabela.
-     * @param {Event} event - O evento de submit do formulário.
-     */
-    async function salvarPlanejamento(event) {
-        event.preventDefault();
-        if (!validarFormulario()) return;
-
-        const dadosForm = Object.fromEntries(new FormData(form).entries());
-        const dataInicio = new Date(`${dadosForm.inicio}T00:00:00-03:00`);
-        const dataFim = new Date(`${dadosForm.fim}T00:00:00-03:00`);
-
-        for (let d = new Date(dataInicio); d <= dataFim; d.setDate(d.getDate() + 1)) {
-            const dataAtual = new Date(d);
-            const dataFormatada = dataAtual.toISOString().split('T')[0];
-            const diaSemana = dataAtual.toLocaleDateString('pt-BR', { weekday: 'long' });
-
-            const newRow = tabelaPlanejamento.insertRow();
-            newRow.dataset.date = dataFormatada;
-
-            newRow.innerHTML = `
-                <td>${dataFormatada.split('-').reverse().join('/')}</td>
-                <td>${dataFormatada.split('-').reverse().join('/')}</td>
-                <td>${diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1)}</td>
-                <td>${dadosForm.horario}</td>
-                <td>${dadosForm.carga_horaria}</td>
-                <td>${dadosForm.modalidade}</td>
-                <td>${dadosForm.treinamento}</td>
-                <td>${dadosForm.cmd || '-'}</td>
-                <td>${dadosForm.sjb || '-'}</td>
-                <td>${dadosForm.sag_tombos || '-'}</td>
-                <td>${dadosForm.instrutor}</td>
-                <td>${dadosForm.local}</td>
-                <td>${dadosForm.observacao || '-'}</td>
-                <td>
-                    <button class="btn btn-sm btn-outline-danger btn-remover-linha">
-                        <i class="bi bi-trash"></i>
-                    </button>
-                </td>
-            `;
-        }
-
-        ordenarTabela();
-        form.reset();
-        contadorLinhasEl.classList.add('d-none');
-        modal.hide();
-        showToast('Planejamento adicionado com sucesso!', 'success');
-    }
-
-    /**
-     * Remove uma linha da tabela.
-     * @param {Event} event - O evento de clique no botão de remover.
-     */
-    function removerLinha(event) {
-        if (event.target.closest('.btn-remover-linha')) {
-            const row = event.target.closest('tr');
-            row.remove();
-            showToast('Linha removida.', 'info');
-        }
-    }
-
-
-    // -------------------
-    // Event Listeners
-    // -------------------
-    btnAdicionar.addEventListener('click', () => {
-        if (!cacheOpcoes) {
-            popularFormulario();
-        }
-        modal.show();
-    });
-
-    form.addEventListener('submit', salvarPlanejamento);
-    tabelaPlanejamento.addEventListener('click', removerLinha);
-
-    form.inicio.addEventListener('change', atualizarContadorLinhas);
-    form.fim.addEventListener('change', atualizarContadorLinhas);
+    // Inicia a aplicação
+    gerenciadorPlanejamento.init();
 });
+

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -9,16 +9,13 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
     <style>
-        /* Estilo para manter o cabeçalho da tabela fixo */
         .table-responsive {
-            max-height: 70vh;
-            overflow-y: auto;
+            max-height: 75vh;
         }
         .table thead th {
             position: sticky;
             top: 0;
             z-index: 1;
-            background-color: #f8f9fa; /* Cor de fundo para o cabeçalho fixo */
         }
     </style>
 </head>
@@ -89,22 +86,22 @@
                     <div class="card-body p-0">
                         <div class="table-responsive">
                             <table class="table table-striped table-hover mb-0" id="tabela-planejamento-trimestral">
-                                <thead class="table-primary">
+                                <thead>
                                     <tr>
-                                        <th scope="col">Início</th>
-                                        <th scope="col">Fim</th>
-                                        <th scope="col">Semana</th>
-                                        <th scope="col">Horário</th>
-                                        <th scope="col">C.H.</th>
-                                        <th scope="col">Modalidade</th>
-                                        <th scope="col">Treinamentos</th>
-                                        <th scope="col">CMD</th>
-                                        <th scope="col">SJB</th>
-                                        <th scope="col">SAG/TOMBOS</th>
-                                        <th scope="col">Instrutor</th>
-                                        <th scope="col">Local</th>
-                                        <th scope="col">Observação</th>
-                                        <th scope="col">Ações</th>
+                                        <th>Início</th>
+                                        <th>Fim</th>
+                                        <th>Semana</th>
+                                        <th>Horário</th>
+                                        <th>C.H.</th>
+                                        <th>Modalidade</th>
+                                        <th>Treinamentos</th>
+                                        <th>CMD</th>
+                                        <th>SJB</th>
+                                        <th>SAG/TOMBOS</th>
+                                        <th>Instrutor</th>
+                                        <th>Local</th>
+                                        <th>Observação</th>
+                                        <th class="text-end">Ações</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -138,75 +135,51 @@
                                 <div class="invalid-feedback">A data de término deve ser igual ou posterior à data de início.</div>
                             </div>
                         </div>
-
                         <div id="contador-linhas" class="alert alert-info d-none" role="alert"></div>
-
                         <div class="row">
                              <div class="col-md-6 mb-3">
                                 <label for="horario" class="form-label">Horário</label>
-                                <select class="form-select" id="horario" name="horario" required>
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="horario" name="horario" required></select>
                             </div>
                             <div class="col-md-6 mb-3">
                                 <label for="carga_horaria" class="form-label">C.H. (Carga Horária)</label>
-                                <select class="form-select" id="carga_horaria" name="carga_horaria" required>
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="carga_horaria" name="carga_horaria" required></select>
                             </div>
                         </div>
-
                         <div class="row">
                             <div class="col-md-6 mb-3">
                                 <label for="modalidade" class="form-label">Modalidade</label>
-                                <select class="form-select" id="modalidade" name="modalidade" required>
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="modalidade" name="modalidade" required></select>
                             </div>
                             <div class="col-md-6 mb-3">
                                 <label for="treinamento" class="form-label">Treinamentos</label>
-                                <select class="form-select" id="treinamento" name="treinamento" required>
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="treinamento" name="treinamento" required></select>
                             </div>
                         </div>
-
                         <div class="row">
                             <div class="col-md-4 mb-3">
                                 <label for="cmd" class="form-label">CMD</label>
-                                <select class="form-select" id="cmd" name="cmd">
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="cmd" name="cmd"></select>
                             </div>
                             <div class="col-md-4 mb-3">
                                 <label for="sjb" class="form-label">SJB</label>
-                                <select class="form-select" id="sjb" name="sjb">
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="sjb" name="sjb"></select>
                             </div>
                             <div class="col-md-4 mb-3">
                                 <label for="sag_tombos" class="form-label">SAG/TOMBOS</label>
-                                <select class="form-select" id="sag_tombos" name="sag_tombos">
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="sag_tombos" name="sag_tombos"></select>
                             </div>
                         </div>
-
                         <div class="row">
                             <div class="col-md-6 mb-3">
                                 <label for="instrutor" class="form-label">Instrutor</label>
-                                <select class="form-select" id="instrutor" name="instrutor" required>
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="instrutor" name="instrutor" required></select>
                             </div>
                             <div class="col-md-6 mb-3">
                                 <label for="local" class="form-label">Local</label>
-                                <select class="form-select" id="local" name="local" required>
-                                    <option value="">Carregando...</option>
-                                </select>
+                                <select class="form-select" id="local" name="local" required></select>
                             </div>
                         </div>
-
                         <div class="mb-3">
                             <label for="observacao" class="form-label">Observação</label>
                             <textarea class="form-control" id="observacao" name="observacao" rows="3"></textarea>
@@ -215,7 +188,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" form="form-planejamento" class="btn btn-primary">
+                    <button type="submit" form="form-planejamento" class="btn btn-primary" id="btn-salvar-planejamento">
                         <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
                         <span class="btn-text">Salvar</span>
                     </button>
@@ -223,9 +196,28 @@
             </div>
         </div>
     </div>
+    
+    <div class="modal fade" id="confirmacaoExclusaoModal" tabindex="-1" aria-labelledby="confirmacaoExclusaoModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2 class="modal-title" id="confirmacaoExclusaoModalLabel">Excluir lote de planejamento?</h2>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+                </div>
+                <div class="modal-body" id="confirmacaoExclusaoModalBody">
+                    </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="button" class="btn btn-danger" id="btn-confirmar-exclusao">Sim, Excluir</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add sticky `<thead>` and reusable delete confirmation modal
- overhaul planning JS with in-memory data, batch operations, and edit/delete flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21553a7748323a187e15714a5262e