### PR TITLE
Persistir planejamento com API

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,7 @@ from src.routes.ocupacao import ocupacao_bp, sala_bp, instrutor_bp
 from src.routes.user import user_bp
 from src.routes.rateio import rateio_bp
 from src.routes.treinamentos import treinamento_bp, turma_bp
-from src.routes.planejamento import basedados_bp
+from src.routes.planejamento import basedados_bp, planejamento_bp
 from src.blueprints.auth_reset import auth_reset_bp
 from src.blueprints.auth import auth_bp
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -227,6 +227,7 @@ def create_app():
     app.register_blueprint(rateio_bp, url_prefix='/api')
     app.register_blueprint(treinamento_bp, url_prefix='/api')
     app.register_blueprint(basedados_bp, url_prefix='/api')
+    app.register_blueprint(planejamento_bp, url_prefix='/api')
     app.register_blueprint(auth_reset_bp)
     app.register_blueprint(auth_bp)
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -8,11 +8,12 @@ from .recurso import Recurso  # noqa: E402
 from .audit_log import AuditLog  # noqa: E402
 from .rateio import RateioConfig, LancamentoRateio  # noqa: E402
 from .log_rateio import LogLancamentoRateio  # noqa: E402
-from .treinamento import (
+from .treinamento import (  # noqa: E402
     Treinamento,
     TurmaTreinamento,
     InscricaoTreinamento,
-)  # noqa: E402
+)
+from .planejamento import PlanejamentoItem  # noqa: E402
 
 __all__ = [
     "db",
@@ -25,4 +26,5 @@ __all__ = [
     "Treinamento",
     "TurmaTreinamento",
     "InscricaoTreinamento",
+    "PlanejamentoItem",
 ]

--- a/src/models/planejamento.py
+++ b/src/models/planejamento.py
@@ -1,0 +1,54 @@
+"""Model for storing planning items."""
+from datetime import datetime
+from src.models import db
+
+
+class PlanejamentoItem(db.Model):
+    """Representa uma linha de planejamento trimestral."""
+    __tablename__ = "planejamento_itens"
+
+    id = db.Column(db.Integer, primary_key=True)
+    row_id = db.Column(db.String(36), unique=True, nullable=False)
+    lote_id = db.Column(db.String(36), nullable=False)
+    data = db.Column(db.Date, nullable=False)
+    semana = db.Column(db.String(20))
+    horario = db.Column(db.String(50))
+    carga_horaria = db.Column(db.String(50))
+    modalidade = db.Column(db.String(50))
+    treinamento = db.Column(db.String(100))
+    cmd = db.Column(db.String(100))
+    sjb = db.Column(db.String(100))
+    sag_tombos = db.Column(db.String(100))
+    instrutor = db.Column(db.String(100))
+    local = db.Column(db.String(100))
+    observacao = db.Column(db.String(255))
+    criado_em = db.Column(db.DateTime, default=datetime.utcnow)
+    atualizado_em = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    def to_dict(self):
+        """Converte o item para dicionário."""
+        return {
+            "id": self.id,
+            "rowId": self.row_id,
+            "loteId": self.lote_id,
+            "data": self.data.isoformat() if self.data else None,
+            "semana": self.semana,
+            "horario": self.horario,
+            "cargaHoraria": self.carga_horaria,
+            "modalidade": self.modalidade,
+            "treinamento": self.treinamento,
+            "cmd": self.cmd,
+            "sjb": self.sjb,
+            "sagTombos": self.sag_tombos,
+            "instrutor": self.instrutor,
+            "local": self.local,
+            "observacao": self.observacao,
+            "criadoEm": (
+                self.criado_em.isoformat() if self.criado_em else None
+            ),
+            "atualizadoEm": (
+                self.atualizado_em.isoformat() if self.atualizado_em else None
+            ),
+        }

--- a/src/routes/planejamento/__init__.py
+++ b/src/routes/planejamento/__init__.py
@@ -1,3 +1,4 @@
 from .basedados import basedados_bp  # noqa: F401
+from .planejamento import planejamento_bp  # noqa: F401
 
-__all__ = ["basedados_bp"]
+__all__ = ["basedados_bp", "planejamento_bp"]

--- a/src/routes/planejamento/planejamento.py
+++ b/src/routes/planejamento/planejamento.py
@@ -1,0 +1,117 @@
+"""Rotas para gerenciamento de itens do planejamento trimestral."""
+from datetime import datetime
+from flask import Blueprint, request, jsonify
+from sqlalchemy.exc import SQLAlchemyError
+from src.models import db
+from src.models.planejamento import PlanejamentoItem
+from src.routes.user import verificar_autenticacao
+from src.utils.error_handler import handle_internal_error
+
+planejamento_bp = Blueprint('planejamento', __name__)
+
+
+@planejamento_bp.route('/planejamento', methods=['GET'])
+def listar_planejamentos():
+    """Lista todos os itens de planejamento."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    itens = PlanejamentoItem.query.all()
+    return jsonify([item.to_dict() for item in itens])
+
+
+@planejamento_bp.route('/planejamento', methods=['POST'])
+def criar_planejamento():
+    """Cria um novo item de planejamento."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    data = request.json or {}
+    data_str = data.get('data')
+    try:
+        data_obj = datetime.fromisoformat(data_str).date()
+    except Exception:
+        return jsonify({'erro': 'Data inválida'}), 400
+
+    item = PlanejamentoItem(
+        row_id=data.get('rowId'),
+        lote_id=data.get('loteId'),
+        data=data_obj,
+        semana=data.get('semana'),
+        horario=data.get('horario'),
+        carga_horaria=data.get('cargaHoraria'),
+        modalidade=data.get('modalidade'),
+        treinamento=data.get('treinamento'),
+        cmd=data.get('cmd'),
+        sjb=data.get('sjb'),
+        sag_tombos=data.get('sagTombos'),
+        instrutor=data.get('instrutor'),
+        local=data.get('local'),
+        observacao=data.get('observacao'),
+    )
+    try:
+        db.session.add(item)
+        db.session.commit()
+        return jsonify(item.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@planejamento_bp.route('/planejamento/<string:row_id>', methods=['PUT'])
+def atualizar_planejamento(row_id):
+    """Atualiza um item existente."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    item = PlanejamentoItem.query.filter_by(row_id=row_id).first()
+    if not item:
+        return jsonify({'erro': 'Item não encontrado'}), 404
+
+    data = request.json or {}
+    data_str = data.get('data')
+    try:
+        data_obj = datetime.fromisoformat(data_str).date()
+    except Exception:
+        return jsonify({'erro': 'Data inválida'}), 400
+
+    item.data = data_obj
+    item.semana = data.get('semana')
+    item.horario = data.get('horario')
+    item.carga_horaria = data.get('cargaHoraria')
+    item.modalidade = data.get('modalidade')
+    item.treinamento = data.get('treinamento')
+    item.cmd = data.get('cmd')
+    item.sjb = data.get('sjb')
+    item.sag_tombos = data.get('sagTombos')
+    item.instrutor = data.get('instrutor')
+    item.local = data.get('local')
+    item.observacao = data.get('observacao')
+
+    try:
+        db.session.commit()
+        return jsonify(item.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@planejamento_bp.route(
+    '/planejamento/lote/<string:lote_id>', methods=['DELETE']
+)
+def excluir_lote(lote_id):
+    """Remove todos os itens pertencentes a um lote."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    try:
+        PlanejamentoItem.query.filter_by(lote_id=lote_id).delete()
+        db.session.commit()
+        return jsonify({'mensagem': 'Lote excluído com sucesso'})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)


### PR DESCRIPTION
## Summary
- add model and API to persist planning items
- fetch and store planning data from frontend via API

## Testing
- `pre-commit run --files src/models/planejamento.py src/models/__init__.py src/routes/planejamento/planejamento.py src/routes/planejamento/__init__.py src/main.py src/static/js/planejamento-trimestral.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2343d7c008323ab1ecfcc8aa3df8d