### PR TITLE
fix: disable recaptcha when not configured

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -213,7 +213,9 @@ def create_app():
 
     # Configura chaves do reCAPTCHA (opcional)
     app.config['RECAPTCHA_SITE_KEY'] = os.getenv('RECAPTCHA_SITE_KEY') or os.getenv('SITE_KEY')
-    app.config['RECAPTCHA_SECRET_KEY'] = os.getenv('RECAPTCHA_SECRET_KEY') or os.getenv('CAPTCHA_SECRET_KEY') or os.getenv('SECRET_KEY')
+    app.config['RECAPTCHA_SECRET_KEY'] = (
+        os.getenv('RECAPTCHA_SECRET_KEY') or os.getenv('CAPTCHA_SECRET_KEY')
+    )
     app.config['RECAPTCHA_THRESHOLD'] = float(os.getenv('RECAPTCHA_THRESHOLD', '0.5'))
 
     app.register_blueprint(user_bp, url_prefix='/api')

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -39,7 +39,6 @@ RECAPTCHA_SITE_KEY = os.getenv("RECAPTCHA_SITE_KEY") or os.getenv("SITE_KEY")
 RECAPTCHA_SECRET_KEY = (
     os.getenv("RECAPTCHA_SECRET_KEY")
     or os.getenv("CAPTCHA_SECRET_KEY")
-    or os.getenv("SECRET_KEY")
 )
 RECAPTCHA_THRESHOLD = float(os.getenv("RECAPTCHA_THRESHOLD", "0.5"))
 


### PR DESCRIPTION
## Summary
- prevent RECAPTCHA from defaulting to SECRET_KEY so login works without explicit key

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a23f70e8488323a213d54506c7cd8f