### PR TITLE
Check auth before loading planning data

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -1,6 +1,7 @@
-/* global bootstrap, showToast, chamarAPI, escapeHTML */
+/* global bootstrap, showToast, chamarAPI, escapeHTML, verificarAutenticacao */
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+    if (!(await verificarAutenticacao())) return;
     // Objeto principal para encapsular a lógica da página
     const gerenciadorPlanejamento = {
         // --- SELETORES E ESTADO ---


### PR DESCRIPTION
## Summary
- Ensure quarterly planning page waits for user authentication before loading data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2459ac9048323928bf9d3da8dfc9e