### PR TITLE
fix: ensure gunicorn available in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,43 +2,21 @@ FROM python:3.12-slim AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    POETRY_NO_INTERACTION=1 \
-    POETRY_VIRTUALENVS_IN_PROJECT=false \
-    POETRY_VIRTUALENVS_CREATE=false
+    POETRY_NO_INTERACTION=1
 
 WORKDIR /app
 
-# syntax=docker/dockerfile:1
-FROM python:3.12-slim
+# Install build tools and poetry, then project dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir poetry
 
-# Instala o postgresql-client para usar o comando pg_isready
-RUN apt-get update && apt-get install -y postgresql-client
-
-WORKDIR /app
-
-# Instalação das dependências (mantenha como estava)
 COPY pyproject.toml poetry.lock ./
-RUN pip install --no-cache-dir poetry && poetry config virtualenvs.create false && poetry install --no-dev --no-interaction --no-ansi
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-dev --no-interaction --no-ansi
 
 COPY . .
-
-# Expõe a porta (mantenha como estava)
-EXPOSE 8080
-
-# Seta o entrypoint para o script (mantenha como estava)
-ENTRYPOINT ["/app/scripts/auto_migrate.sh"]
-
-WORKDIR /app
-
-RUN apt-get update && \
-    apt-get install -y build-essential && \
-    rm -rf /var/lib/apt/lists/* && \
-    pip install poetry
-
-COPY poetry.lock pyproject.toml ./
-
-RUN poetry lock --no-interaction
-RUN poetry install --no-root --without dev
 
 FROM python:3.12-slim AS runtime
 
@@ -47,15 +25,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+# Install runtime packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local /usr/local
-COPY ./src ./src
-COPY ./migrations ./migrations
-COPY alembic.ini ./migrations/
+COPY --from=builder /app /app
 
 EXPOSE 8080
-
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhost:8080/ || exit 1
 
 CMD sh -c "flask --app src.main db upgrade && gunicorn --factory -b 0.0.0.0:${PORT:-8080} src.main:create_app"


### PR DESCRIPTION
## Summary
- install dependencies in builder stage and copy to runtime
- include curl and postgresql-client in runtime

## Testing
- `pre-commit run --files Dockerfile`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2536835d88323ba17730d718f252a