### PR TITLE
fix: include readme in poetry install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir poetry
 
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml poetry.lock README.md ./
 RUN poetry config virtualenvs.create false \
     && poetry install --without dev --no-interaction --no-ansi
 


### PR DESCRIPTION
## Summary
- ensure README.md is copied before running Poetry install in Docker build

## Testing
- `pytest -q`
- `docker build --target builder -t testimage .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a2592319708323b28d3f7e4f0f5732