### PR TITLE
fix: corrigir endpoint do planejamento trimestral

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -170,7 +170,7 @@ async function salvarItem() {
         return;
     }
 
-    const endpoint = id ? `/planejamento/itens/${id}` : '/planejamento/itens';
+    const endpoint = id ? `/planejamento/${id}` : '/planejamento';
     const method = id ? 'PUT' : 'POST';
 
     try {
@@ -190,7 +190,7 @@ async function carregarItens() {
     // Esta função deve conter a sua lógica já existente para buscar e renderizar a tabela de planejamento.
     // Exemplo:
     try {
-        const data = await chamarAPI('/planejamento/itens');
+        const data = await chamarAPI('/planejamento');
         // Renderizar os lotes e itens...
     } catch (error) {
         showToast('Não foi possível carregar o planejamento.', 'danger');


### PR DESCRIPTION
## Summary
- corrigir endpoint usado para carregar itens do planejamento trimestral
- ajustar salvamento para usar a mesma rota existente no backend

## Testing
- `pre-commit run --files src/static/js/planejamento-trimestral.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3bbb1de108323ad746f5205049529