### PR TITLE
fix: correct planejamento API endpoint

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -177,7 +177,7 @@ async function salvarItem() {
  */
 async function carregarItens() {
     try {
-        const itens = await chamarAPI('/planejamento/itens');
+        const itens = await chamarAPI('/api/planejamento');
         renderizarLotes(itens);
     } catch (error) {
         showToast('Não foi possível carregar o planejamento.', 'danger');


### PR DESCRIPTION
## Summary
- fix API endpoint for carregarItens in planejamento trimestral

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3c0e3d4448323b56c87eb7f8a29f8