### PR TITLE
Add item-level planning endpoints for trimestral page

### DIFF
--- a/src/routes/planejamento/planejamento.py
+++ b/src/routes/planejamento/planejamento.py
@@ -48,6 +48,12 @@ def listar_planejamentos():
         return handle_internal_error(e)
 
 
+@planejamento_bp.route('/planejamento/itens', methods=['GET'])
+def listar_itens():
+    """Lista todos os itens do planejamento (alias usado pelo frontend)."""
+    return listar_planejamentos()
+
+
 @planejamento_bp.route('/planejamento', methods=['POST'])
 def criar_planejamento():
     """Cria um ou mais itens de planejamento."""
@@ -111,6 +117,62 @@ def criar_planejamento():
         return handle_internal_error(e)
 
 
+@planejamento_bp.route('/planejamento/itens', methods=['POST'])
+def criar_item():
+    """Cria um único item de planejamento (utilizado pela interface web)."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    if not _tabela_planejamento_existe():
+        return (
+            jsonify({'erro': 'Tabela planejamento_itens não existe; execute as migrações.'}),
+            500,
+        )
+
+    payload = request.get_json() or {}
+    detalhes = {}
+
+    treinamento_nome = payload.get('treinamento')
+    instrutor_nome = payload.get('instrutor')
+    if treinamento_nome and not Treinamento.query.filter_by(nome=treinamento_nome).first():
+        detalhes['treinamento'] = 'Treinamento não encontrado'
+    if instrutor_nome and not Instrutor.query.filter_by(nome=instrutor_nome).first():
+        detalhes['instrutor'] = 'Instrutor não encontrado'
+    if detalhes:
+        return jsonify({'erro': 'Dados inválidos', 'detalhes': detalhes}), 422
+
+    try:
+        data_obj = datetime.fromisoformat(payload.get('data', '')).date()
+    except Exception:
+        return jsonify({'erro': 'Data inválida'}), 400
+
+    item = PlanejamentoItem(
+        row_id=str(uuid4()),
+        lote_id=payload.get('loteId') or str(uuid4()),
+        data=data_obj,
+        semana=payload.get('semana'),
+        horario=payload.get('horario'),
+        carga_horaria=payload.get('carga_horaria'),
+        modalidade=payload.get('modalidade'),
+        treinamento=treinamento_nome,
+        cmd=payload.get('cmd'),
+        sjb=payload.get('sjb'),
+        sag_tombos=payload.get('sag_tombos'),
+        instrutor=instrutor_nome,
+        local=payload.get('local'),
+        observacao=payload.get('observacao'),
+    )
+
+    try:
+        db.session.add(item)
+        db.session.commit()
+        return jsonify(item.to_dict()), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
 @planejamento_bp.route('/planejamento/<string:row_id>', methods=['PUT'])
 def atualizar_planejamento(row_id):
     """Atualiza um item existente."""
@@ -151,6 +213,76 @@ def atualizar_planejamento(row_id):
     try:
         db.session.commit()
         return jsonify(item.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@planejamento_bp.route('/planejamento/itens/<int:item_id>', methods=['PUT'])
+def atualizar_item(item_id):
+    """Atualiza um item existente de planejamento."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    if not _tabela_planejamento_existe():
+        return (
+            jsonify({'erro': 'Tabela planejamento_itens não existe; execute as migrações.'}),
+            500,
+        )
+
+    item = PlanejamentoItem.query.get(item_id)
+    if not item:
+        return jsonify({'erro': 'Item não encontrado'}), 404
+
+    data = request.json or {}
+    try:
+        item.data = datetime.fromisoformat(data.get('data', '')).date()
+    except Exception:
+        return jsonify({'erro': 'Data inválida'}), 400
+
+    item.lote_id = data.get('loteId', item.lote_id)
+    item.semana = data.get('semana')
+    item.horario = data.get('horario')
+    item.carga_horaria = data.get('carga_horaria')
+    item.modalidade = data.get('modalidade')
+    item.treinamento = data.get('treinamento')
+    item.cmd = data.get('cmd')
+    item.sjb = data.get('sjb')
+    item.sag_tombos = data.get('sag_tombos')
+    item.instrutor = data.get('instrutor')
+    item.local = data.get('local')
+    item.observacao = data.get('observacao')
+
+    try:
+        db.session.commit()
+        return jsonify(item.to_dict())
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@planejamento_bp.route('/planejamento/itens/<int:item_id>', methods=['DELETE'])
+def excluir_item(item_id):
+    """Remove um item de planejamento."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    if not _tabela_planejamento_existe():
+        return (
+            jsonify({'erro': 'Tabela planejamento_itens não existe; execute as migrações.'}),
+            500,
+        )
+
+    item = PlanejamentoItem.query.get(item_id)
+    if not item:
+        return jsonify({'erro': 'Item não encontrado'}), 404
+
+    try:
+        db.session.delete(item)
+        db.session.commit()
+        return jsonify({'mensagem': 'Item excluído com sucesso'})
     except SQLAlchemyError as e:
         db.session.rollback()
         return handle_internal_error(e)


### PR DESCRIPTION
## Summary
- add GET/POST/PUT/DELETE routes under `/planejamento/itens` for individual planning items
- validate training and instructor existence and parse dates
- expose alias to list items so trimestral planning page loads correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3c3d52214832388d1074f142cf37c