### PR TITLE
feat: open planning modal from add button

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -26,7 +26,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     document.getElementById('itemData').addEventListener('change', calcularSemana);
     document.getElementById('btnConfirmarExclusao').addEventListener('click', executarExclusao);
-    
+
+    document.getElementById('btn-adicionar-planejamento').addEventListener('click', () => abrirModalParaAdicionar());
+
     await inicializarPagina();
 });
 


### PR DESCRIPTION
## Summary
- ensure main planning add button opens modal

## Testing
- `pre-commit run --files src/static/js/planejamento-trimestral.js --hook-stage manual` (skipped)
- `npx eslint@8 src/static/js/planejamento-trimestral.js` (fails: eslint config airbnb-base not found)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c840f3248323a14e38e3b9e0e044