### PR TITLE
Add final date field to planning modal and hide week input

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     itemModal = new bootstrap.Modal(document.getElementById('itemModal'));
     confirmacaoModal = new bootstrap.Modal(document.getElementById('confirmacaoModal'));
 
-    document.getElementById('itemData').addEventListener('change', calcularSemana);
+    document.getElementById('itemDataInicio').addEventListener('change', calcularSemana);
     document.getElementById('btnConfirmarExclusao').addEventListener('click', executarExclusao);
 
     document.getElementById('btn-adicionar-planejamento').addEventListener('click', () => abrirModalParaAdicionar());
@@ -87,7 +87,7 @@ function popularSelect(selectId, dados) {
  * Calcula o número da semana com base na data selecionada.
  */
 function calcularSemana() {
-    const dataInput = document.getElementById('itemData').value;
+    const dataInput = document.getElementById('itemDataInicio').value;
     if (dataInput) {
         const data = new Date(dataInput + "T00:00:00");
         const primeiroDiaDoAno = new Date(data.getFullYear(), 0, 1);
@@ -116,7 +116,8 @@ window.abrirModalParaEditar = (item) => {
     
     document.getElementById('itemId').value = item.id;
     document.getElementById('loteId').value = item.loteId;
-    document.getElementById('itemData').value = item.data;
+    document.getElementById('itemDataInicio').value = item.data;
+    document.getElementById('itemDataFim').value = item.data;
     document.getElementById('itemSemana').value = item.semana;
     document.getElementById('itemHorario').value = item.horario;
     document.getElementById('itemCargaHoraria').value = item.cargaHoraria;
@@ -142,7 +143,8 @@ async function salvarItem() {
     
     const dados = {
         loteId: loteId,
-        data: document.getElementById('itemData').value,
+        data: document.getElementById('itemDataInicio').value,
+        data_fim: document.getElementById('itemDataFim').value,
         semana: document.getElementById('itemSemana').value,
         horario: document.getElementById('itemHorario').value,
         carga_horaria: document.getElementById('itemCargaHoraria').value,

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -101,14 +101,15 @@
                         <input type="hidden" id="loteId">
                         <div class="row">
                             <div class="col-md-6 mb-3">
-                                <label for="itemData" class="form-label">Data</label>
-                                <input type="date" class="form-control" id="itemData" required>
+                                <label for="itemDataInicio" class="form-label">Data Inicial</label>
+                                <input type="date" class="form-control" id="itemDataInicio" required>
                             </div>
                             <div class="col-md-6 mb-3">
-                                <label for="itemSemana" class="form-label">Semana</label>
-                                <input type="text" class="form-control" id="itemSemana" readonly>
+                                <label for="itemDataFim" class="form-label">Data Final</label>
+                                <input type="date" class="form-control" id="itemDataFim" required>
                             </div>
                         </div>
+                        <input type="hidden" id="itemSemana">
                         <div class="row">
                             <div class="col-md-4 mb-3">
                                 <label for="itemHorario" class="form-label">Horário</label>


### PR DESCRIPTION
## Summary
- show both start and end dates when adding a planning item
- hide calculated week field from the modal

## Testing
- `pytest -q`
- `alembic upgrade 1faac30c7383`
- `alembic upgrade cria_tabelas_base_planejamento`

------
https://chatgpt.com/codex/tasks/task_e_68a3d112ebe48323a9501bd05049a14e