### PR TITLE
Delete user occupations by collaborator ID

### DIFF
--- a/src/routes/ocupacao/ocupacao.py
+++ b/src/routes/ocupacao/ocupacao.py
@@ -465,6 +465,29 @@ def remover_ocupacao(id):
         db.session.rollback()
         return handle_internal_error(e)
 
+
+@ocupacao_bp.route('/<int:user_id>', methods=['DELETE'])
+@admin_required
+def delete_ocupacao(user_id):
+    """Exclui todas as ocupações de um usuário específico."""
+    autenticado, user = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    try:
+        ocupacoes = Ocupacao.query.filter_by(user_id=user_id).all()
+        if not ocupacoes:
+            return jsonify({'mensagem': 'Nenhuma ocupação encontrada para este usuário.'}), 404
+
+        for ocupacao in ocupacoes:
+            db.session.delete(ocupacao)
+
+        db.session.commit()
+        return jsonify({'mensagem': 'Todas as ocupações do usuário foram excluídas com sucesso.'}), 200
+    except Exception as e:
+        db.session.rollback()
+        return jsonify({'erro': str(e)}), 500
+
 @ocupacao_bp.route('/ocupacoes/verificar-disponibilidade', methods=['GET'])
 def verificar_disponibilidade():
     """

--- a/src/static/js/ocupacao/corpo-docente.js
+++ b/src/static/js/ocupacao/corpo-docente.js
@@ -226,8 +226,53 @@ class GerenciadorInstrutores {
     }
 }
 
+function loadUsers() {
+    fetch('/api/ocupacao/users')
+        .then(response => response.json())
+        .then(data => {
+            const tbody = document.getElementById('corpo-docente-tbody');
+            tbody.innerHTML = '';
+            const users = data.users;
+
+            users.forEach(user => {
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${user.name}</td>
+                    <td>${user.email || ''}</td>
+                `;
+                const actionsCell = document.createElement('td');
+
+                const deleteBtn = document.createElement('button');
+                deleteBtn.innerHTML = '<i class="fas fa-trash-alt"></i>';
+                deleteBtn.classList.add('btn', 'btn-danger', 'btn-sm');
+                deleteBtn.onclick = function() {
+                    if (confirm(`Tem certeza que deseja excluir todas as ocupações de ${user.name}?`)) {
+                        fetch(`/api/ocupacao/${user.id}`, {
+                            method: 'DELETE',
+                            headers: {
+                                'Authorization': 'Bearer ' + localStorage.getItem('access_token')
+                            }
+                        }).then(response => {
+                            if (response.ok) {
+                                alert('Ocupações excluídas com sucesso!');
+                                loadUsers();
+                            } else {
+                                alert('Falha ao excluir as ocupações.');
+                            }
+                        });
+                    }
+                };
+
+                actionsCell.appendChild(deleteBtn);
+                row.appendChild(actionsCell);
+                tbody.appendChild(row);
+            });
+        });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     verificarAutenticacao();
     verificarPermissaoAdmin();
     window.gerenciadorInstrutores = new GerenciadorInstrutores();
+    loadUsers();
 });


### PR DESCRIPTION
## Summary
- Allow removal of all occupations for a user by collaborator ID
- Update front-end to send user ID when deleting a user's occupations

## Testing
- `pytest`
- `flake8` *(fails: line too long in tests)*
- `bandit -r .`


------
https://chatgpt.com/codex/tasks/task_e_68a4855c91888323900d64854739ff2e