### PR TITLE
Fix group deletion in planning table

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -308,7 +308,7 @@ function criarLinhaItem(item, dataFinal) {
     const diaSemana = dataObj.toLocaleDateString('pt-BR', { weekday: 'long' });
     const itemJsonString = JSON.stringify(item).replace(/'/g, "\\'");
     return `
-        <tr>
+        <tr data-group-id="${item.loteId}">
             <td>${dataInicialFormatada}</td>
             <td>${dataFinalFormatada}</td>
             <td>${diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1)}</td>
@@ -326,7 +326,7 @@ function criarLinhaItem(item, dataFinal) {
                 <button class="btn btn-sm btn-outline-primary" onclick='abrirModalParaEditar(${itemJsonString})'>
                     <i class="bi bi-pencil"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-danger" onclick="confirmarExclusao(${item.id})">
+                <button class="btn btn-sm btn-outline-danger" onclick="removerLinha(this)">
                     <i class="bi bi-trash"></i>
                 </button>
             </td>
@@ -359,6 +359,27 @@ async function executarExclusao() {
         confirmacaoModal.hide();
     }
 }
+
+/**
+ * Remove todas as linhas da tabela que pertencem ao mesmo grupo
+ * do botão de exclusão clicado. Os grupos são identificados pelo
+ * atributo `data-group-id` presente nas linhas da tabela.
+ *
+ * @param {HTMLElement} botao - O botão de exclusão acionado.
+ */
+window.removerLinha = (botao) => {
+    const linha = botao.closest('tr');
+    if (!linha) return;
+
+    const groupId = linha.dataset.groupId;
+    if (groupId) {
+        document
+            .querySelectorAll(`tr[data-group-id="${groupId}"]`)
+            .forEach((tr) => tr.remove());
+    } else {
+        linha.remove();
+    }
+};
 
 /**
  * Renderiza uma linha de planejamento no DOM sem recriar toda a tabela.


### PR DESCRIPTION
## Summary
- ensure planning table rows include a `data-group-id` and use a unified delete handler
- add `removerLinha` helper to remove all rows sharing the same `data-group-id`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a8ca56b08323b1027a8241ed9a87