### PR TITLE
fix: remove all planning rows on delete

### DIFF
--- a/src/routes/planejamento/planejamento.py
+++ b/src/routes/planejamento/planejamento.py
@@ -426,9 +426,9 @@ def excluir_lote(lote_id):
         )
 
     try:
-        PlanejamentoItem.query.filter_by(lote_id=lote_id).delete()
+        PlanejamentoItem.query.filter_by(lote_id=lote_id).delete(synchronize_session=False)
         db.session.commit()
-        return jsonify({'mensagem': 'Lote excluído com sucesso'})
+        return '', 204
     except SQLAlchemyError as e:
         db.session.rollback()
         return handle_internal_error(e)

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -184,24 +184,6 @@
         </div>
     </div>
 
-    <div class="modal fade" id="confirmacaoModal" tabindex="-1" aria-labelledby="confirmacaoModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="confirmacaoModalLabel">Confirmar Exclusão</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <p>Tem certeza de que deseja excluir este item do planejamento?</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="button" class="btn btn-danger" id="btnConfirmarExclusao">Excluir</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>


### PR DESCRIPTION
## Summary
- delete planning items by lote and remove all DOM rows sharing the same identifier
- tag rendered rows and delete buttons with a common data-item-id
- return 204 when removing planning lote

## Testing
- `pre-commit run --files src/routes/planejamento/planejamento.py src/static/js/planejamento-trimestral.js src/static/planejamento-trimestral.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a9f4dd9883239a59513d7ae974a7