### PR TITLE
fix: corrigir edição e exclusão no planejamento

### DIFF
--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -68,7 +68,7 @@ function showDeleteConfirm(message) {
         const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
         const btn = document.getElementById('deleteConfirmBtn');
 
-        const onConfirm = () => { cleanup(); resolve(true); };
+        const onConfirm = () => { modal.hide(); cleanup(); resolve(true); };
         const onHidden = () => { cleanup(); resolve(false); };
 
         function cleanup() {
@@ -417,11 +417,10 @@ async function salvarPlanejamento() {
     try {
         await executarAcaoComFeedback(btnSalvar, async () => {
             if (edicaoId) {
-                await chamarAPI(`/planejamento/lote/${edicaoId}`, 'PUT', registros);
-            } else {
-                const promessas = registros.map(reg => chamarAPI('/planejamento/itens', 'POST', reg));
-                await Promise.all(promessas);
+                await chamarAPI(`/planejamento/lote/${edicaoId}`, 'DELETE');
             }
+            const promessas = registros.map(reg => chamarAPI('/planejamento/itens', 'POST', reg));
+            await Promise.all(promessas);
         });
         showToast('Item salvo com sucesso!', 'success');
         itemModal.hide();


### PR DESCRIPTION
## Summary
- close confirmation modal when deleting items
- handle editing of planning items by re-creating lote records

## Testing
- `pre-commit run --files src/static/js/planejamento-trimestral.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e811fc208323b41a837fa5fe7749