### PR TITLE
Implement PATCH update for planejamento lote and line

### DIFF
--- a/src/routes/planejamento/planejamento.py
+++ b/src/routes/planejamento/planejamento.py
@@ -21,7 +21,11 @@ from src.models.instrutor import Instrutor
 from src.routes.user import verificar_autenticacao
 from src.utils.error_handler import handle_internal_error
 from pydantic import ValidationError
-from src.schemas.planejamento import PlanejamentoCreateSchema
+from src.schemas.planejamento import (
+    PlanejamentoCreateSchema,
+    PlanejamentoUpdateInstrutorSchema,
+    PlanejamentoUpdateLoteSchema,
+)
 
 planejamento_bp = Blueprint('planejamento', __name__)
 
@@ -290,6 +294,96 @@ def criar_planejamento_ids():
         db.session.add(item)
         db.session.commit()
         return jsonify({'id': item.id}), 201
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@planejamento_bp.route('/planejamento/lote/<lote_id>', methods=['PATCH'])
+def atualizar_lote(lote_id):
+    """Atualiza campos comuns para todas as linhas de um lote."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    if not _tabela_planejamento_existe():
+        return (
+            jsonify({'erro': 'Tabela planejamento_itens não existe; execute as migrações.'}),
+            500,
+        )
+
+    payload = request.get_json() or {}
+    try:
+        dados = PlanejamentoUpdateLoteSchema(**payload)
+    except ValidationError as exc:
+        detalhes = {err['loc'][-1]: err['msg'] for err in exc.errors()}
+        return jsonify({'erro': 'Dados inválidos', 'detalhes': detalhes}), 422
+
+    updates: dict[str, object] = {}
+    if dados.horario is not None:
+        updates['horario'] = dados.horario
+    if dados.carga_horaria is not None:
+        updates['carga_horaria'] = str(dados.carga_horaria)
+    if dados.modalidade is not None:
+        updates['modalidade'] = dados.modalidade
+    if dados.treinamento_id is not None:
+        treinamento = Treinamento.query.get(dados.treinamento_id)
+        if not treinamento:
+            return jsonify({'erro': 'Treinamento não encontrado'}), 404
+        updates['treinamento'] = treinamento.nome
+    if dados.polos is not None:
+        updates['cmd'] = str(dados.polos.cmd)
+        updates['sjb'] = str(dados.polos.sjb)
+        updates['sag_tombos'] = str(dados.polos.sag_tombos)
+    if dados.local is not None:
+        updates['local'] = dados.local
+    if dados.observacao is not None:
+        updates['observacao'] = dados.observacao
+
+    try:
+        itens = PlanejamentoItem.query.filter_by(lote_id=lote_id).all()
+        for item in itens:
+            for campo, valor in updates.items():
+                setattr(item, campo, valor)
+        db.session.commit()
+        return jsonify({'mensagem': 'Lote atualizado', 'quantidade': len(itens)})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
+@planejamento_bp.route('/planejamento/<row_id>', methods=['PATCH'])
+def atualizar_linha(row_id):
+    """Atualiza apenas o instrutor de uma linha especifica."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    if not _tabela_planejamento_existe():
+        return (
+            jsonify({'erro': 'Tabela planejamento_itens não existe; execute as migrações.'}),
+            500,
+        )
+
+    item = PlanejamentoItem.query.filter_by(row_id=row_id).first()
+    if not item:
+        return jsonify({'erro': 'Item não encontrado'}), 404
+
+    payload = request.get_json() or {}
+    try:
+        dados = PlanejamentoUpdateInstrutorSchema(**payload)
+    except ValidationError as exc:
+        detalhes = {err['loc'][-1]: err['msg'] for err in exc.errors()}
+        return jsonify({'erro': 'Dados inválidos', 'detalhes': detalhes}), 422
+
+    instrutor = Instrutor.query.get(dados.instrutor_id)
+    if not instrutor:
+        return jsonify({'erro': 'Instrutor não encontrado'}), 404
+
+    try:
+        item.instrutor = str(dados.instrutor_id)
+        db.session.commit()
+        return jsonify({'mensagem': 'Linha atualizada'})
     except SQLAlchemyError as e:
         db.session.rollback()
         return handle_internal_error(e)

--- a/src/schemas/planejamento.py
+++ b/src/schemas/planejamento.py
@@ -52,3 +52,37 @@ class PlanejamentoCreateSchema(BaseModel):
 
     class Config:
         populate_by_name = True
+
+
+class PlanejamentoUpdateInstrutorSchema(BaseModel):
+    instrutor_id: int
+
+
+class PlanejamentoUpdateLoteSchema(BaseModel):
+    horario: str | None = None
+    carga_horaria: int | None = Field(None, alias="carga_horaria")
+    modalidade: str | None = None
+    treinamento_id: int | None = None
+    polos: PolosSchema | None = None
+    local: str | None = ""
+    observacao: str | None = ""
+
+    @field_validator("horario")
+    @classmethod
+    def validar_horario(cls, v):
+        if v is None:
+            return v
+        datetime.strptime(v, "%H:%M")
+        return v
+
+    @field_validator("carga_horaria")
+    @classmethod
+    def validar_ch(cls, v):
+        if v is None:
+            return v
+        if v <= 0:
+            raise ValueError("Carga horária deve ser maior que zero")
+        return v
+
+    class Config:
+        populate_by_name = True

--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -133,7 +133,7 @@ function preencherFormulario(item) {
     const form = document.getElementById('itemForm');
     form.reset();
 
-    document.getElementById('itemId').value = item.id || '';
+    document.getElementById('rowId').value = item.rowId || '';
     document.getElementById('loteId').value = item.loteId || '';
 
     const dtIni = toInputDate(item.data_inicial || item.data);
@@ -384,7 +384,7 @@ function calcularSemana() {
  */
 window.abrirModalParaAdicionar = (loteId = '') => {
     document.getElementById('itemForm').reset();
-    document.getElementById('itemId').value = '';
+    document.getElementById('rowId').value = '';
     document.getElementById('loteId').value = loteId;
     document.getElementById('itemModalLabel').textContent = 'Adicionar Item ao Planejamento';
     edicaoId = null;
@@ -520,7 +520,7 @@ function criarLinhaItem(item, dataFinal) {
     const dataFinalFormatada = new Date(dataFinal + 'T00:00:00').toLocaleDateString('pt-BR');
     const diaSemana = dataObj.toLocaleDateString('pt-BR', { weekday: 'long' });
     return `
-        <tr data-item-id="${item.loteId}">
+        <tr data-row-id="${item.rowId}" data-lote-id="${item.loteId}" data-item-id="${item.loteId}">
             <td>${dataInicialFormatada}</td>
             <td>${dataFinalFormatada}</td>
             <td>${diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1)}</td>

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -97,8 +97,8 @@
                 </div>
                 <div class="modal-body">
                     <form id="itemForm">
-                        <input type="hidden" id="itemId">
-                        <input type="hidden" id="loteId">
+                        <input type="hidden" name="rowId" id="rowId">
+                        <input type="hidden" name="loteId" id="loteId">
                         <div class="row">
                             <div class="col-md-6 mb-3">
                                 <label for="itemDataInicio" class="form-label">Data Inicial</label>

--- a/tests/test_planejamento.py
+++ b/tests/test_planejamento.py
@@ -1,7 +1,11 @@
 import pytest
+from datetime import date
+from uuid import uuid4
+
 from src.models import db
 from src.models.treinamento import Treinamento
 from src.models.instrutor import Instrutor
+from src.models.planejamento import PlanejamentoItem
 
 
 @pytest.fixture
@@ -150,3 +154,96 @@ def test_cria_tabela_quando_ausente(
         '/api/planejamento/itens', json=payload, headers=headers
     )
     assert resp.status_code == 201
+
+
+@pytest.fixture
+def lote_setup(app):
+    with app.app_context():
+        t1 = Treinamento(nome='T1', codigo='T1')
+        t2 = Treinamento(nome='T2', codigo='T2')
+        i1 = Instrutor(nome='Instrutor 1')
+        i2 = Instrutor(nome='Instrutor 2')
+        db.session.add_all([t1, t2, i1, i2])
+        db.session.commit()
+        lote_id = str(uuid4())
+        row_ids = []
+        for dia in range(1, 4):
+            item = PlanejamentoItem(
+                row_id=str(uuid4()),
+                lote_id=lote_id,
+                data=date(2024, 1, dia),
+                semana='1',
+                horario='08:00',
+                carga_horaria='8',
+                modalidade='P',
+                treinamento=t1.nome,
+                cmd='True',
+                sjb='False',
+                sag_tombos='False',
+                instrutor=str(i1.id),
+                local='',
+                observacao='',
+            )
+            db.session.add(item)
+            row_ids.append(item.row_id)
+        db.session.commit()
+        return {
+            'lote_id': lote_id,
+            'row_ids': row_ids,
+            't2_id': t2.id,
+            't2_nome': t2.nome,
+            'i1_id': i1.id,
+            'i2_id': i2.id,
+        }
+
+
+def test_patch_lote_atualiza_campos(client, lote_setup, login_admin, csrf_token):
+    headers = auth_headers(client, login_admin, csrf_token)
+    payload = {
+        'horario': '09:00',
+        'carga_horaria': 10,
+        'modalidade': 'E',
+        'treinamento_id': lote_setup['t2_id'],
+        'polos': {'cmd': False, 'sjb': True, 'sag_tombos': False},
+        'local': 'Novo local',
+        'observacao': 'Obs',
+    }
+    resp = client.patch(
+        f"/api/planejamento/lote/{lote_setup['lote_id']}",
+        json=payload,
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['quantidade'] == len(lote_setup['row_ids'])
+
+    with client.application.app_context():
+        itens = PlanejamentoItem.query.filter_by(lote_id=lote_setup['lote_id']).all()
+        assert all(it.horario == '09:00' for it in itens)
+        assert all(it.carga_horaria == '10' for it in itens)
+        assert all(it.modalidade == 'E' for it in itens)
+        assert all(it.treinamento == lote_setup['t2_nome'] for it in itens)
+        assert all(it.cmd == 'False' for it in itens)
+        assert all(it.sjb == 'True' for it in itens)
+        assert all(it.sag_tombos == 'False' for it in itens)
+        assert all(it.local == 'Novo local' for it in itens)
+        assert all(it.observacao == 'Obs' for it in itens)
+        assert all(it.instrutor == str(lote_setup['i1_id']) for it in itens)
+
+
+def test_patch_linha_instrutor(client, lote_setup, login_admin, csrf_token):
+    headers = auth_headers(client, login_admin, csrf_token)
+    row_id = lote_setup['row_ids'][0]
+    payload = {'instrutor_id': lote_setup['i2_id']}
+    resp = client.patch(
+        f"/api/planejamento/{row_id}", json=payload, headers=headers
+    )
+    assert resp.status_code == 200
+
+    with client.application.app_context():
+        itens = PlanejamentoItem.query.filter_by(lote_id=lote_setup['lote_id']).all()
+        atualizados = {it.row_id: it for it in itens}
+        assert atualizados[row_id].instrutor == str(lote_setup['i2_id'])
+        for rid, item in atualizados.items():
+            if rid != row_id:
+                assert item.instrutor == str(lote_setup['i1_id'])


### PR DESCRIPTION
## Summary
- add Pydantic schemas for lote and line updates
- support PATCH routes to update lote fields or a line's instructor
- attach row/lote identifiers in planejamento-trimestral UI
- cover new PATCH behaviors with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4ef224f488323a68b6c455a7c022c