### PR TITLE
Skip non-business days in trimestral planning

### DIFF
--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -204,6 +204,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/date-holidays@3.25.1/dist/umd.min.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- skip weekends and Conceição do Mato Dentro holidays when generating planning lines
- load date-holidays library to check local holidays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a51a0376c88323bb715e16733ff6dc