### PR TITLE
Add dynamic training planning table

### DIFF
--- a/src/static/js/planejamento-treinamentos.js
+++ b/src/static/js/planejamento-treinamentos.js
@@ -1,0 +1,49 @@
+// Popula a tabela de planejamento de treinamentos
+
+function formatarData(iso) {
+    if (!iso) return '';
+    const [ano, mes, dia] = iso.split('-');
+    return `${dia}/${mes}/${ano}`;
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    try {
+        const response = await fetch('/api/planejamento/');
+        if (!response.ok) {
+            throw new Error('Falha ao carregar planejamento');
+        }
+        const dados = await response.json();
+        const tbody = document.getElementById('corpo-tabela-planejamento');
+        dados.forEach(planejamento => {
+            const tr = document.createElement('tr');
+            const celulas = [
+                formatarData(planejamento.data_inicio),
+                formatarData(planejamento.data_termino),
+                '',
+                planejamento.horario || '',
+                planejamento.treinamento?.carga_horaria || '',
+                planejamento.modalidade || '',
+                planejamento.treinamento?.nome || '',
+                planejamento.local || '',
+                ''
+            ];
+            celulas.forEach(texto => {
+                const td = document.createElement('td');
+                td.textContent = texto;
+                tr.appendChild(td);
+            });
+            const tdLink = document.createElement('td');
+            if (planejamento.link_inscricao) {
+                const a = document.createElement('a');
+                a.href = planejamento.link_inscricao;
+                a.textContent = 'Inscrição';
+                a.target = '_blank';
+                tdLink.appendChild(a);
+            }
+            tr.appendChild(tdLink);
+            tbody.appendChild(tr);
+        });
+    } catch (error) {
+        console.error('Erro ao buscar planejamentos:', error);
+    }
+});

--- a/src/static/planejamento-treinamentos.html
+++ b/src/static/planejamento-treinamentos.html
@@ -70,10 +70,34 @@
                 </div>
             </main>
         </div>
+        <div class="row mt-4">
+            <div class="col-12">
+                <div class="table-responsive">
+                    <table class="table table-striped" id="tabela-planejamento">
+                        <thead>
+                            <tr>
+                                <th>DATA INICIO</th>
+                                <th>DATA TERMINO</th>
+                                <th>SEMANA</th>
+                                <th>HORÁRIO</th>
+                                <th>CARGA HORÁRIA</th>
+                                <th>MODALIDADE</th>
+                                <th>TREINAMENTO</th>
+                                <th>LOCAL</th>
+                                <th>LIMITE DE INSCRIÇÃO</th>
+                                <th>LINK</th>
+                            </tr>
+                        </thead>
+                        <tbody id="corpo-tabela-planejamento"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="/static/js/planejamento-treinamentos.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- display training schedule table on planejamento page
- load planning data from `/api/planejamento/`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5b285dc3c832392a676f55830513a