### PR TITLE
feat: calculate registration deadline

### DIFF
--- a/src/static/planejamento-treinamentos.html
+++ b/src/static/planejamento-treinamentos.html
@@ -76,6 +76,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-treinamentos.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load CMD holidays and pass to training table renderer
- compute and display registration deadline two business days before each training, excluding NR 22
- add datas utility script to planning page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a605d0fb9c8323a22965f7ebd801ca