### PR TITLE
Add email column to training export

### DIFF
--- a/src/routes/treinamentos/treinamento.py
+++ b/src/routes/treinamentos/treinamento.py
@@ -623,6 +623,7 @@ def exportar_inscricoes(turma_id):
         writer = csv.writer(si)
         headers = [
             "Nome",
+            "E-mail",
             "CPF",
             "Empresa",
             "Presença Teoria",
@@ -635,6 +636,7 @@ def exportar_inscricoes(turma_id):
         for i in inscricoes:
             row = [
                 i.nome,
+                i.email,
                 i.cpf,
                 i.empresa,
                 "Sim" if i.presenca_teoria else "Não",
@@ -676,7 +678,7 @@ def exportar_inscricoes(turma_id):
 
         # --- Cabeçalho ---
         ws.merge_cells("A1:B2")
-        ws.merge_cells("C1:J2")
+        ws.merge_cells("C1:K2")
 
         # Logo
         try:
@@ -768,15 +770,15 @@ def exportar_inscricoes(turma_id):
         row_idx += 7
 
         # --- Tabela de Participantes ---
-        ws.merge_cells(f"A{row_idx}:E{row_idx}")
+        ws.merge_cells(f"A{row_idx}:F{row_idx}")
         info_cell = ws[f"A{row_idx}"]
         info_cell.value = "Informações dos participantes"
         info_cell.fill = fill_azul
         info_cell.font = font_white_bold
         info_cell.alignment = Alignment(horizontal="center", vertical="center")
 
-        ws.merge_cells(f"F{row_idx}:J{row_idx}")
-        rubrica_cell = ws[f"F{row_idx}"]
+        ws.merge_cells(f"G{row_idx}:K{row_idx}")
+        rubrica_cell = ws[f"G{row_idx}"]
         rubrica_cell.value = "Rubrica do participante conforme data de participação"
         rubrica_cell.fill = fill_azul
         rubrica_cell.font = font_white_bold
@@ -788,6 +790,7 @@ def exportar_inscricoes(turma_id):
             "CPF",
             "Data de Nascimento",
             "Nome do Participante",
+            "E-mail",
             "Empresa",
             "TEORIA",
             "NOTA DA\nTEORIA",
@@ -817,11 +820,12 @@ def exportar_inscricoes(turma_id):
                 ),
             )
             ws.cell(row=row_idx, column=4, value=inscricao.nome)
-            ws.cell(row=row_idx, column=5, value=inscricao.empresa)
+            ws.cell(row=row_idx, column=5, value=inscricao.email)
+            ws.cell(row=row_idx, column=6, value=inscricao.empresa)
             row_idx += 1
 
         # Borda na tabela de participantes
-        for col in "ABCDEFGHIJ":
+        for col in "ABCDEFGHIJK":
             for row in range(row_idx - len(inscricoes) - 2, row_idx):
                 ws[f"{col}{row}"].border = thin_border
                 ws[f"{col}{row}"].alignment = Alignment(
@@ -830,7 +834,7 @@ def exportar_inscricoes(turma_id):
 
         # --- Observações e Assinatura ---
         row_idx += 1
-        ws.merge_cells(f"A{row_idx}:J{row_idx+2}")
+        ws.merge_cells(f"A{row_idx}:K{row_idx+2}")
         obs_cell = ws[f"A{row_idx}"]
         obs_cell.value = "Observações:"
         obs_cell.font = font_bold
@@ -838,7 +842,7 @@ def exportar_inscricoes(turma_id):
         obs_cell.border = thin_border
 
         row_idx += 4
-        ws.merge_cells(f"A{row_idx}:J{row_idx+1}")
+        ws.merge_cells(f"A{row_idx}:K{row_idx+1}")
         ass_cell = ws[f"A{row_idx}"]
         ass_cell.value = "Assinatura do(s) instrutor(es) / Responsável (eis):"
         ass_cell.font = font_bold
@@ -850,12 +854,13 @@ def exportar_inscricoes(turma_id):
         ws.column_dimensions["B"].width = 18
         ws.column_dimensions["C"].width = 15
         ws.column_dimensions["D"].width = 35
-        ws.column_dimensions["E"].width = 20
-        ws.column_dimensions["F"].width = 10
+        ws.column_dimensions["E"].width = 30
+        ws.column_dimensions["F"].width = 20
         ws.column_dimensions["G"].width = 10
         ws.column_dimensions["H"].width = 10
         ws.column_dimensions["I"].width = 10
-        ws.column_dimensions["J"].width = 15
+        ws.column_dimensions["J"].width = 10
+        ws.column_dimensions["K"].width = 15
         ws.row_dimensions[9].height = 40
 
         # --- Salvar em buffer ---


### PR DESCRIPTION
## Summary
- include email field when exporting training enrollments to CSV and XLSX
- adjust training export spreadsheet layout to accommodate email column

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61546eab08323b173b27c4171d471