### PR TITLE
Add hover drawer menu for planejamento pages

### DIFF
--- a/src/static/css/menu-suspenso.css
+++ b/src/static/css/menu-suspenso.css
@@ -1,0 +1,59 @@
+:root {
+  --senai-azul: #164194;
+  --senai-laranja: #F3B54E;
+}
+
+/* Zona de hover na borda esquerda (quase invisível) */
+#hoverEdge{
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 12px;          /* zona segura para o mouse encostar */
+  height: 100vh;
+  z-index: 1030;        /* acima do conteúdo */
+}
+
+/* Drawer */
+#sidebarDrawer.drawer{
+  position: fixed;
+  top: 0;
+  left: -280px;         /* escondido fora da tela */
+  width: 280px;
+  height: 100vh;
+  background: var(--senai-azul);
+  color: #fff;
+  box-shadow: 2px 0 16px rgba(0,0,0,.25);
+  transition: left .25s ease-in-out;
+  z-index: 1040;
+  display: flex;
+  flex-direction: column;
+}
+
+#sidebarDrawer.drawer.open{ left: 0; }
+#sidebarDrawer .drawer-header{ padding: 16px 20px; border-bottom: 1px solid rgba(255,255,255,.15); }
+#sidebarDrawer .drawer-header h2{ font-size: 16px; margin: 0; color:#fff; }
+
+#sidebarDrawer .drawer-nav{ padding: 8px 0; overflow-y: auto; }
+#sidebarDrawer .drawer-nav ul{ list-style: none; margin:0; padding:0; }
+#sidebarDrawer .drawer-nav a{
+  display:block;
+  padding: 12px 20px;
+  color:#fff;
+  text-decoration:none;
+  border-left: 4px solid transparent;
+  outline: none;
+}
+#sidebarDrawer .drawer-nav a:hover,
+#sidebarDrawer .drawer-nav a:focus,
+#sidebarDrawer .drawer-nav li.active > a{
+  background: rgba(255,255,255,.08);
+  border-left-color: var(--senai-laranja);
+}
+
+/* Acessibilidade: foco visível */
+#sidebarDrawer .drawer-nav a:focus{ box-shadow: inset 0 0 0 2px rgba(255,255,255,.35); }
+
+/* Responsivo: em telas muito estreitas o drawer ocupa toda a largura */
+@media (max-width: 480px){
+  #sidebarDrawer.drawer{ width: 88vw; }
+}

--- a/src/static/js/menu-suspenso.js
+++ b/src/static/js/menu-suspenso.js
@@ -1,0 +1,44 @@
+(() => {
+  const drawer = document.getElementById('sidebarDrawer');
+  const edge   = document.getElementById('hoverEdge');
+  if (!drawer || !edge) return;
+
+  let openTimer, closeTimer;
+
+  const open = () => {
+    clearTimeout(closeTimer);
+    drawer.classList.add('open');
+    drawer.setAttribute('aria-expanded', 'true');
+  };
+
+  const close = () => {
+    clearTimeout(openTimer);
+    // só fecha se o mouse não estiver sobre o drawer
+    if (!drawer.matches(':hover')) {
+      drawer.classList.remove('open');
+      drawer.setAttribute('aria-expanded', 'false');
+    }
+  };
+
+  // Abrir ao encostar na borda
+  edge.addEventListener('mouseenter', () => { openTimer = setTimeout(open, 80); });
+
+  // Fechar ao sair do drawer (pequeno atraso para tolerar trajetos do mouse)
+  drawer.addEventListener('mouseleave', () => { closeTimer = setTimeout(close, 150); });
+
+  // Manter aberto enquanto houver foco de teclado dentro do drawer
+  drawer.addEventListener('focusin', open);
+  drawer.addEventListener('focusout', () => { setTimeout(close, 120); });
+
+  // Suporte a toque / fallback sem hover: tocar/clicar na borda alterna o estado
+  edge.addEventListener('click', () => {
+    drawer.classList.toggle('open');
+    const expanded = drawer.classList.contains('open');
+    drawer.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  });
+
+  // Fecha com ESC
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') close();
+  });
+})();

--- a/src/static/planejamento-basedados.html
+++ b/src/static/planejamento-basedados.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/static/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/menu-suspenso.css">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
@@ -51,146 +52,147 @@
         </div>
     </nav>
 
-    <div class="container-fluid py-4">
+        <!-- Zona fina na borda para disparar o hover -->
+    <div id="hoverEdge" aria-hidden="true"></div>
+
+    <!-- Drawer do menu lateral -->
+    <aside id="sidebarDrawer" class="drawer" aria-label="Menu de Planejamento" aria-expanded="false">
+      <div class="drawer-header">
+        <h2>Menu de Planejamento</h2>
+      </div>
+      <nav class="drawer-nav">
+        <ul>
+          <li><a href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a></li>
+          <li><a href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a></li>
+          <li><a href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a></li>
+          <li class="active"><a href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i>Base de Dados</a></li>
+        </ul>
+      </nav>
+    </aside>
+
+    <main class="container-fluid py-4">
+        <div class="page-header">
+            <h1 class="mb-0">Base de Dados</h1>
+        </div>
         <div class="row">
-            <div class="col-lg-3 d-none d-lg-block">
-                <div class="sidebar rounded shadow-sm">
-                    <h2 class="mb-3">Menu de Planejamento</h2>
-                    <div class="nav flex-column">
-                        <a class="nav-link" href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a>
-                        <a class="nav-link" href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a>
-                        <a class="nav-link" href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a>
-                        <a class="nav-link active" href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a>
+            <div class="col-md-6 mb-4">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0"><i class="bi bi-journal-text me-2"></i>Treinamentos</h2>
+                        <button class="btn btn-primary btn-sm" onclick="abrirModal('treinamento')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead><tr><th>Nome</th><th>Carga Horária</th><th class="text-end">Ações</th></tr></thead>
+                                <tbody id="tabela-treinamento"></tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>
 
-            <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h1 class="mb-0">Base de Dados</h1>
-                </div>
-                <div class="row">
-                    <div class="col-md-6 mb-4">
-                        <div class="card h-100">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h2 class="card-title mb-0"><i class="bi bi-journal-text me-2"></i>Treinamentos</h2>
-                                <button class="btn btn-primary btn-sm" onclick="abrirModal('treinamento')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-hover mb-0">
-                                        <thead><tr><th>Nome</th><th>Carga Horária</th><th class="text-end">Ações</th></tr></thead>
-                                        <tbody id="tabela-treinamento"></tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
+            <div class="col-md-6 mb-4">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0"><i class="bi bi-person-badge me-2"></i>Instrutores</h2>
+                        <button class="btn btn-primary btn-sm" onclick="abrirModalInstrutor()"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
                     </div>
-
-                    <div class="col-md-6 mb-4">
-                        <div class="card h-100">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h2 class="card-title mb-0"><i class="bi bi-person-badge me-2"></i>Instrutores</h2>
-                                <button class="btn btn-primary btn-sm" onclick="abrirModalInstrutor()"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-hover mb-0">
-                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
-                                        <tbody id="tabela-instrutor"></tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="col-md-6 mb-4">
-                        <div class="card h-100">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h2 class="card-title mb-0"><i class="bi bi-people-fill me-2"></i>Publico alvo</h2>
-                                <button class="btn btn-primary btn-sm" onclick="abrirModal('publico-alvo')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-hover mb-0">
-                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
-                                        <tbody id="tabela-publico-alvo"></tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="col-md-6 mb-4">
-                        <div class="card h-100">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h2 class="card-title mb-0"><i class="bi bi-geo-alt-fill me-2"></i>Locais</h2>
-                                <button class="btn btn-primary btn-sm" onclick="abrirModal('local')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-hover mb-0">
-                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
-                                        <tbody id="tabela-local"></tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <div class="col-md-6 mb-4">
-                        <div class="card h-100">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h2 class="card-title mb-0"><i class="bi bi-display me-2"></i>Modalidades</h2>
-                                <button class="btn btn-primary btn-sm" onclick="abrirModal('modalidade')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-hover mb-0">
-                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
-                                        <tbody id="tabela-modalidade"></tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-6 mb-4">
-                        <div class="card h-100">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h2 class="card-title mb-0"><i class="bi bi-clock-fill me-2"></i>Horário</h2>
-                                <button class="btn btn-primary btn-sm" onclick="abrirModal('horario')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-hover mb-0">
-                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
-                                        <tbody id="tabela-horario"></tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                     <div class="col-md-6 mb-4">
-                        <div class="card h-100">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h2 class="card-title mb-0"><i class="bi bi-hourglass-split me-2"></i>Carga Horária</h2>
-                                <button class="btn btn-primary btn-sm" onclick="abrirModal('cargahoraria')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
-                            </div>
-                            <div class="card-body p-0">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-hover mb-0">
-                                        <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
-                                        <tbody id="tabela-cargahoraria"></tbody>
-                                    </table>
-                                </div>
-                            </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                <tbody id="tabela-instrutor"></tbody>
+                            </table>
                         </div>
                     </div>
                 </div>
-            </main>
+            </div>
+
+            <div class="col-md-6 mb-4">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0"><i class="bi bi-people-fill me-2"></i>Publico alvo</h2>
+                        <button class="btn btn-primary btn-sm" onclick="abrirModal('publico-alvo')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                <tbody id="tabela-publico-alvo"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 mb-4">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0"><i class="bi bi-geo-alt-fill me-2"></i>Locais</h2>
+                        <button class="btn btn-primary btn-sm" onclick="abrirModal('local')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                <tbody id="tabela-local"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 mb-4">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0"><i class="bi bi-display me-2"></i>Modalidades</h2>
+                        <button class="btn btn-primary btn-sm" onclick="abrirModal('modalidade')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                <tbody id="tabela-modalidade"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6 mb-4">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0"><i class="bi bi-clock-fill me-2"></i>Horário</h2>
+                        <button class="btn btn-primary btn-sm" onclick="abrirModal('horario')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                <tbody id="tabela-horario"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+             <div class="col-md-6 mb-4">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0"><i class="bi bi-hourglass-split me-2"></i>Carga Horária</h2>
+                        <button class="btn btn-primary btn-sm" onclick="abrirModal('cargahoraria')"><i class="bi bi-plus-circle me-1"></i> Adicionar</button>
+                    </div>
+                    <div class="card-body p-0">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover mb-0">
+                                <thead><tr><th>Nome</th><th class="text-end">Ações</th></tr></thead>
+                                <tbody id="tabela-cargahoraria"></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
-
+    </main>
     <div class="modal fade" id="geralModal" tabindex="-1">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -313,6 +315,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="js/menu-suspenso.js"></script>
     <script src="/js/planejamento-basedados.js"></script>
 </body>
 </html>

--- a/src/static/planejamento-instrutores.html
+++ b/src/static/planejamento-instrutores.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/static/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/menu-suspenso.css">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
@@ -51,29 +52,33 @@
         </div>
     </nav>
 
-    <div class="container-fluid py-4">
-        <div class="row">
-            <div class="col-lg-3 d-none d-lg-block">
-                <div class="sidebar rounded shadow-sm">
-                    <h2 class="mb-3">Menu de Planejamento</h2>
-                    <div class="nav flex-column">
-                        <a class="nav-link" href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a>
-                        <a class="nav-link" href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a>
-                        <a class="nav-link active" href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a>
-                        <a class="nav-link" href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a>
-                    </div>
-                </div>
-            </div>
-            <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h1 class="mb-0">Planejamento por Instrutores</h1>
-                </div>
-            </main>
+    <!-- Zona fina na borda para disparar o hover -->
+    <div id="hoverEdge" aria-hidden="true"></div>
+
+    <!-- Drawer do menu lateral -->
+    <aside id="sidebarDrawer" class="drawer" aria-label="Menu de Planejamento" aria-expanded="false">
+      <div class="drawer-header">
+        <h2>Menu de Planejamento</h2>
+      </div>
+      <nav class="drawer-nav">
+        <ul>
+          <li><a href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a></li>
+          <li><a href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a></li>
+          <li class="active"><a href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a></li>
+          <li><a href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a></li>
+        </ul>
+      </nav>
+    </aside>
+
+    <main class="container-fluid py-4">
+        <div class="page-header">
+            <h1 class="mb-0">Planejamento por Instrutores</h1>
         </div>
-    </div>
+    </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="js/menu-suspenso.js"></script>
 </body>
 </html>
 

--- a/src/static/planejamento-treinamentos.html
+++ b/src/static/planejamento-treinamentos.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/static/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/menu-suspenso.css">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
@@ -51,31 +52,35 @@
         </div>
     </nav>
 
-    <div class="container-fluid py-4">
-        <div class="row">
-            <div class="col-lg-3 d-none d-lg-block">
-                <div class="sidebar rounded shadow-sm">
-                    <h2 class="mb-3">Menu de Planejamento</h2>
-                    <div class="nav flex-column">
-                        <a class="nav-link active" href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a>
-                        <a class="nav-link" href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a>
-                        <a class="nav-link" href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a>
-                        <a class="nav-link" href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a>
-                    </div>
-                </div>
-            </div>
-            <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h1 class="mb-0">Treinamentos Disponíveis</h1>
-                </div>
-                <div id="planejamento-container" class="mt-4">
-                    </div>
-            </main>
+    <!-- Zona fina na borda para disparar o hover -->
+    <div id="hoverEdge" aria-hidden="true"></div>
+
+    <!-- Drawer do menu lateral -->
+    <aside id="sidebarDrawer" class="drawer" aria-label="Menu de Planejamento" aria-expanded="false">
+      <div class="drawer-header">
+        <h2>Menu de Planejamento</h2>
+      </div>
+      <nav class="drawer-nav">
+        <ul>
+          <li class="active"><a href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a></li>
+          <li><a href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a></li>
+          <li><a href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a></li>
+          <li><a href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a></li>
+        </ul>
+      </nav>
+    </aside>
+
+    <main class="container-fluid py-4">
+        <div class="page-header">
+            <h1 class="mb-0">Treinamentos Disponíveis</h1>
         </div>
-    </div>
+        <div id="planejamento-container" class="mt-4">
+            </div>
+    </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="js/menu-suspenso.js"></script>
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-treinamentos.js"></script>
 </body>

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/static/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/menu-suspenso.css">
     <style>
         .table-responsive {
             max-height: 75vh;
@@ -61,32 +62,35 @@
         </div>
     </nav>
 
-    <div class="container-fluid py-4" id="aba-planejamento-trimestral">
-        <div class="row">
-            <div class="col-lg-3 d-none d-lg-block">
-                <div class="sidebar rounded shadow-sm">
-                    <h2 class="mb-3">Menu de Planejamento</h2>
-                    <div class="nav flex-column">
-                        <a class="nav-link" href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a>
-                        <a class="nav-link active" href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a>
-                        <a class="nav-link" href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a>
-                        <a class="nav-link" href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a>
-                    </div>
-                </div>
-            </div>
-            <main class="col-lg-9 col-md-12">
-                <div class="page-header">
-                    <h1 class="mb-0">Planejamento Trimestral</h1>
-                    <button id="btn-adicionar-planejamento" class="btn btn-primary">
-                        <i class="bi bi-plus-circle me-2"></i>Adicionar
-                    </button>
-                </div>
+    <!-- Zona fina na borda para disparar o hover -->
+    <div id="hoverEdge" aria-hidden="true"></div>
 
-                <div id="planejamento-container" class="mt-4">
-                    </div>
-            </main>
+    <!-- Drawer do menu lateral -->
+    <aside id="sidebarDrawer" class="drawer" aria-label="Menu de Planejamento" aria-expanded="false">
+      <div class="drawer-header">
+        <h2>Menu de Planejamento</h2>
+      </div>
+      <nav class="drawer-nav">
+        <ul>
+          <li><a href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a></li>
+          <li class="active"><a href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a></li>
+          <li><a href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a></li>
+          <li><a href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a></li>
+        </ul>
+      </nav>
+    </aside>
+
+    <main class="container-fluid py-4" id="aba-planejamento-trimestral">
+        <div class="page-header">
+            <h1 class="mb-0">Planejamento Trimestral</h1>
+            <button id="btn-adicionar-planejamento" class="btn btn-primary">
+                <i class="bi bi-plus-circle me-2"></i>Adicionar
+            </button>
         </div>
-    </div>
+
+        <div id="planejamento-container" class="mt-4">
+            </div>
+    </main>
 
     <div class="modal fade" id="itemModal" tabindex="-1" aria-labelledby="itemModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-lg">
@@ -204,6 +208,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="js/menu-suspenso.js"></script>
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- implement CSS and JS for hover-triggered sidebar drawer
- convert planejamento pages to use overlaid drawer with SENAI colors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6223b2d208323be5e0059a9fbd115