### PR TITLE
feat: enable async sge link updates

### DIFF
--- a/src/routes/planejamento/planejamento.py
+++ b/src/routes/planejamento/planejamento.py
@@ -340,6 +340,31 @@ def atualizar_planejamento(row_id):
         return handle_internal_error(e)
 
 
+@planejamento_bp.route('/planejamento/treinamentos/<int:item_id>', methods=['PUT'])
+def atualizar_planejamento_treinamento(item_id):
+    """Atualiza os campos SGE e link do planejamento de treinamentos."""
+    autenticado, _ = verificar_autenticacao(request)
+    if not autenticado:
+        return jsonify({'erro': 'Não autenticado'}), 401
+
+    item = PlanejamentoTreinamento.query.get(item_id)
+    if not item:
+        return jsonify({'erro': 'Item não encontrado'}), 404
+
+    data = request.get_json() or {}
+    if 'sge' in data:
+        item.sge = bool(data['sge'])
+    if 'link_sge' in data:
+        item.link_sge = data['link_sge']
+
+    try:
+        db.session.commit()
+        return jsonify({'message': 'Atualizado com sucesso'})
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        return handle_internal_error(e)
+
+
 @planejamento_bp.route('/planejamento/itens/<int:item_id>', methods=['PUT'])
 def atualizar_item(item_id):
     """Atualiza um item existente de planejamento."""

--- a/src/static/js/planejamento-treinamentos.js
+++ b/src/static/js/planejamento-treinamentos.js
@@ -73,6 +73,8 @@ function renderizarItens(itens, feriadosSet) {
     for (const { primeiro, dataFinal } of ordenados) {
         tbody.insertAdjacentHTML('beforeend', criarLinhaItem(primeiro, dataFinal, feriadosSet));
     }
+
+    configurarDelegacaoEventos();
 }
 
 /**
@@ -127,7 +129,7 @@ function criarLinhaItem(item, dataFinal, feriadosSet) {
     }
 
     return `
-        <tr>
+        <tr data-id="${item.id || ''}">
             <td>${dataInicialFormatada}</td>
             <td>${dataFinalFormatada}</td>
             <td>${diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1)}</td>
@@ -139,29 +141,71 @@ function criarLinhaItem(item, dataFinal, feriadosSet) {
             <td>${limiteInscricaoHTML}</td>
             <td>
                 <label class="sge-switch" title="Ativar SGE">
-                    <input type="checkbox" class="sge-toggle" data-id="${item.id || ''}" ${item.sge_link ? 'checked' : ''}>
+                    <input type="checkbox" class="sge-toggle" ${item.sge ? 'checked' : ''}>
                     <span class="sge-slider" aria-hidden="true"></span>
                 </label>
             </td>
-            <td class="link-col">${item.sge_link ? `<input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://..." value="${escapeHTML(item.sge_link)}">` : ''}</td>
+            <td class="link-col">${item.sge ? `<input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://..." value="${escapeHTML(item.link_sge || '')}">` : ''}</td>
         </tr>
     `;
 }
 
-document.addEventListener('change', (ev) => {
+function onSgeChange(ev) {
     const el = ev.target;
     if (!el.classList.contains('sge-toggle')) return;
 
     const row = el.closest('tr');
     const linkCell = row ? row.querySelector('td.link-col') : null;
-    if (!linkCell) return;
+    if (!row || !linkCell) return;
 
     if (el.checked) {
         linkCell.innerHTML = `
-            <input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://...">
+            <input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://..." value="">
         `;
     } else {
         linkCell.innerHTML = '';
     }
-});
+
+    const id = row.dataset.id;
+    atualizarPlanejamento(id, { sge: el.checked });
+}
+
+function onLinkBlur(ev) {
+    const el = ev.target;
+    if (!el.classList.contains('sge-link-input')) return;
+    const row = el.closest('tr');
+    if (!row) return;
+    const id = row.dataset.id;
+    atualizarPlanejamento(id, { link_sge: el.value });
+}
+
+function configurarDelegacaoEventos() {
+    const tbody = document.getElementById('planejamento-tbody');
+    if (!tbody) return;
+    tbody.addEventListener('change', onSgeChange);
+    tbody.addEventListener('blur', onLinkBlur, true);
+}
+
+async function atualizarPlanejamento(id, dados) {
+    try {
+        const token = await obterCSRFToken();
+        const resp = await fetch(`${API_URL}/planejamento/treinamentos/${id}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': token
+            },
+            credentials: 'include',
+            body: JSON.stringify(dados)
+        });
+        if (!resp.ok) {
+            throw new Error('Falha na atualização');
+        }
+        showToast('Guardado!', 'success');
+    } catch (err) {
+        console.error(err);
+        showToast('Erro ao guardar', 'danger');
+    }
+}
+
 


### PR DESCRIPTION
## Summary
- add authenticated PUT endpoint to update SGE status and link for planning trainings
- wire up front-end event delegation to persist SGE and link edits via fetch

## Testing
- `pre-commit run --files src/routes/planejamento/planejamento.py src/static/js/planejamento-treinamentos.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a630915290832380a957e67f2e8545