### PR TITLE
Persist SGE link updates in planning table

### DIFF
--- a/src/models/planejamento.py
+++ b/src/models/planejamento.py
@@ -22,6 +22,8 @@ class PlanejamentoItem(db.Model):
     instrutor = db.Column(db.String(100))
     local = db.Column(db.String(100))
     observacao = db.Column(db.String(255))
+    sge_ativo = db.Column(db.Boolean, default=False)
+    sge_link = db.Column(db.String(255))
     criado_em = db.Column(db.DateTime, default=datetime.utcnow)
     atualizado_em = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
@@ -45,6 +47,8 @@ class PlanejamentoItem(db.Model):
             "instrutor": self.instrutor,
             "local": self.local,
             "observacao": self.observacao,
+            "sge_ativo": self.sge_ativo,
+            "sge_link": self.sge_link,
             "criadoEm": (
                 self.criado_em.isoformat() if self.criado_em else None
             ),

--- a/src/routes/planejamento/planejamento.py
+++ b/src/routes/planejamento/planejamento.py
@@ -195,6 +195,8 @@ def criar_item():
         instrutor=instrutor_nome,
         local=payload.get('local'),
         observacao=payload.get('observacao'),
+        sge_ativo=payload.get('sge_ativo', False),
+        sge_link=payload.get('sge_link'),
     )
 
     try:
@@ -358,23 +360,26 @@ def atualizar_item(item_id):
         return jsonify({'erro': 'Item não encontrado'}), 404
 
     data = request.json or {}
-    try:
-        item.data = datetime.fromisoformat(data.get('data', '')).date()
-    except Exception:
-        return jsonify({'erro': 'Data inválida'}), 400
+    if 'data' in data:
+        try:
+            item.data = datetime.fromisoformat(data['data']).date()
+        except Exception:
+            return jsonify({'erro': 'Data inválida'}), 400
 
     item.lote_id = data.get('loteId', item.lote_id)
-    item.semana = data.get('semana')
-    item.horario = data.get('horario')
-    item.carga_horaria = data.get('carga_horaria')
-    item.modalidade = data.get('modalidade')
-    item.treinamento = data.get('treinamento')
-    item.cmd = data.get('cmd')
-    item.sjb = data.get('sjb')
-    item.sag_tombos = data.get('sag_tombos')
-    item.instrutor = data.get('instrutor')
-    item.local = data.get('local')
-    item.observacao = data.get('observacao')
+    item.semana = data.get('semana', item.semana)
+    item.horario = data.get('horario', item.horario)
+    item.carga_horaria = data.get('carga_horaria', item.carga_horaria)
+    item.modalidade = data.get('modalidade', item.modalidade)
+    item.treinamento = data.get('treinamento', item.treinamento)
+    item.cmd = data.get('cmd', item.cmd)
+    item.sjb = data.get('sjb', item.sjb)
+    item.sag_tombos = data.get('sag_tombos', item.sag_tombos)
+    item.instrutor = data.get('instrutor', item.instrutor)
+    item.local = data.get('local', item.local)
+    item.observacao = data.get('observacao', item.observacao)
+    item.sge_ativo = data.get('sge_ativo', item.sge_ativo)
+    item.sge_link = data.get('sge_link', item.sge_link)
 
     try:
         db.session.commit()

--- a/src/static/js/planejamento-treinamentos.js
+++ b/src/static/js/planejamento-treinamentos.js
@@ -139,29 +139,40 @@ function criarLinhaItem(item, dataFinal, feriadosSet) {
             <td>${limiteInscricaoHTML}</td>
             <td>
                 <label class="sge-switch" title="Ativar SGE">
-                    <input type="checkbox" class="sge-toggle" data-id="${item.id || ''}" ${item.sge_link ? 'checked' : ''}>
+                    <input type="checkbox" class="sge-toggle" data-id="${item.id || ''}" ${item.sge_ativo ? 'checked' : ''}>
                     <span class="sge-slider" aria-hidden="true"></span>
                 </label>
             </td>
-            <td class="link-col">${item.sge_link ? `<input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://..." value="${escapeHTML(item.sge_link)}">` : ''}</td>
+            <td class="link-col">${item.sge_ativo ? `<input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://..." value="${escapeHTML(item.sge_link || '')}">` : ''}</td>
         </tr>
     `;
 }
 
 document.addEventListener('change', (ev) => {
     const el = ev.target;
-    if (!el.classList.contains('sge-toggle')) return;
+    if (el.classList.contains('sge-toggle')) {
+        const row = el.closest('tr');
+        const linkCell = row ? row.querySelector('td.link-col') : null;
+        if (!linkCell) return;
 
-    const row = el.closest('tr');
-    const linkCell = row ? row.querySelector('td.link-col') : null;
-    if (!linkCell) return;
+        if (el.checked) {
+            linkCell.innerHTML = `
+                <input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://...">
+            `;
+        } else {
+            linkCell.innerHTML = '';
+        }
 
-    if (el.checked) {
-        linkCell.innerHTML = `
-            <input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://...">
-        `;
-    } else {
-        linkCell.innerHTML = '';
+        const payload = { sge_ativo: el.checked, sge_link: el.checked ? '' : null };
+        chamarAPI(`/planejamento/itens/${el.dataset.id}`, 'PUT', payload)
+            .catch(() => showToast('Não foi possível salvar o status SGE.', 'danger'));
+    } else if (el.classList.contains('sge-link-input')) {
+        const row = el.closest('tr');
+        const toggle = row ? row.querySelector('.sge-toggle') : null;
+        if (!toggle) return;
+        const payload = { sge_ativo: true, sge_link: el.value.trim() };
+        chamarAPI(`/planejamento/itens/${toggle.dataset.id}`, 'PUT', payload)
+            .catch(() => showToast('Não foi possível salvar o link SGE.', 'danger'));
     }
 });
 

--- a/tests/test_planejamento.py
+++ b/tests/test_planejamento.py
@@ -150,3 +150,32 @@ def test_cria_tabela_quando_ausente(
         '/api/planejamento/itens', json=payload, headers=headers
     )
     assert resp.status_code == 201
+
+
+def test_atualiza_sge_link(client, setup_dados, login_admin, csrf_token):
+    treinamento_nome, instrutor_nome = setup_dados
+    headers = auth_headers(client, login_admin, csrf_token)
+    payload = {
+        'data': '2024-05-01',
+        'semana': '1',
+        'horario': '08:00',
+        'carga_horaria': '8',
+        'modalidade': 'P',
+        'treinamento': treinamento_nome,
+        'cmd': True,
+        'sjb': False,
+        'sag_tombos': False,
+        'instrutor': instrutor_nome,
+        'local': '',
+        'observacao': ''
+    }
+    resp = client.post('/api/planejamento/itens', json=payload, headers=headers)
+    assert resp.status_code == 201
+    item_id = resp.get_json()['id']
+
+    update = {'sge_ativo': True, 'sge_link': 'https://exemplo.com'}
+    resp = client.put(f'/api/planejamento/itens/{item_id}', json=update, headers=headers)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['sge_ativo'] is True
+    assert data['sge_link'] == 'https://exemplo.com'


### PR DESCRIPTION
## Summary
- allow PlanejamentoItem to store SGE enabled state and link
- persist SGE status and link through API with partial PUT support
- save SGE toggle/link changes from planning trainings page
- cover SGE update behavior with unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a64399c9888323ad66df33ad7556c8