### PR TITLE
Add SGE columns to planejamento_itens

### DIFF
--- a/migrations/versions/a3e4f5d6c7b8_add_sge_fields_to_planejamento_itens.py
+++ b/migrations/versions/a3e4f5d6c7b8_add_sge_fields_to_planejamento_itens.py
@@ -1,0 +1,31 @@
+"""Add SGE fields to planejamento_itens
+
+Revision ID: a3e4f5d6c7b8
+Revises: 1faac30c7383
+Create Date: 2025-08-21 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'a3e4f5d6c7b8'
+down_revision = '1faac30c7383'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'planejamento_itens',
+        sa.Column('sge_ativo', sa.Boolean(), server_default=sa.text('false')),
+    )
+    op.add_column(
+        'planejamento_itens',
+        sa.Column('sge_link', sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('planejamento_itens', 'sge_link')
+    op.drop_column('planejamento_itens', 'sge_ativo')


### PR DESCRIPTION
## Summary
- add migration adding sge_ativo and sge_link to planejamento_itens

## Testing
- `pre-commit run --files migrations/versions/a3e4f5d6c7b8_add_sge_fields_to_planejamento_itens.py --config .pre-commit-config.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6495951208323851868b68e808e98