### PR TITLE
Add SGE fields to planejamento items

### DIFF
--- a/migrations/versions/a3e4f5d6c7b8_add_sge_fields_to_planejamento_itens.py
+++ b/migrations/versions/a3e4f5d6c7b8_add_sge_fields_to_planejamento_itens.py
@@ -1,31 +1,33 @@
-"""Add SGE fields to planejamento_itens
-
-Revision ID: a3e4f5d6c7b8
-Revises: 1faac30c7383
-Create Date: 2025-08-21 00:00:00.000000
-"""
+"""add sge fields to planejamento_itens"""
 
 from alembic import op
 import sqlalchemy as sa
 
+
 # revision identifiers, used by Alembic.
-revision = 'a3e4f5d6c7b8'
-down_revision = '1faac30c7383'
+revision = "a3e4f5d6c7b8"
+down_revision = "1faac30c7383"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     op.add_column(
-        'planejamento_itens',
-        sa.Column('sge_ativo', sa.Boolean(), server_default=sa.text('false')),
+        "planejamento_itens",
+        sa.Column(
+            "sge_ativo",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
     )
     op.add_column(
-        'planejamento_itens',
-        sa.Column('sge_link', sa.String(length=255), nullable=True),
+        "planejamento_itens",
+        sa.Column("sge_link", sa.String(length=512), nullable=True),
     )
+    op.alter_column("planejamento_itens", "sge_ativo", server_default=None)
 
 
 def downgrade() -> None:
-    op.drop_column('planejamento_itens', 'sge_link')
-    op.drop_column('planejamento_itens', 'sge_ativo')
+    op.drop_column("planejamento_itens", "sge_link")
+    op.drop_column("planejamento_itens", "sge_ativo")

--- a/src/routes/planejamento/planejamento.py
+++ b/src/routes/planejamento/planejamento.py
@@ -119,6 +119,8 @@ def criar_planejamento():
             instrutor=registro.instrutor,
             local=registro.local,
             observacao=registro.observacao,
+            sge_ativo=registro.sge_ativo,
+            sge_link=registro.sge_link,
         )
         itens.append(item)
 
@@ -286,6 +288,8 @@ def criar_planejamento_ids():
         instrutor=instrutor.nome,
         local=local.nome,
         observacao=payload.get('observacao', ''),
+        sge_ativo=payload.get('sge_ativo', False),
+        sge_link=payload.get('sge_link'),
     )
 
     try:
@@ -333,6 +337,8 @@ def atualizar_planejamento(row_id):
     item.instrutor = data.get('instrutor')
     item.local = data.get('local')
     item.observacao = data.get('observacao')
+    item.sge_ativo = data.get('sge_ativo', item.sge_ativo)
+    item.sge_link = data.get('sge_link', item.sge_link)
 
     try:
         db.session.commit()

--- a/src/schemas/planejamento.py
+++ b/src/schemas/planejamento.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from typing import List, Optional
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class PolosSchema(BaseModel):
@@ -21,6 +21,8 @@ class RegistroPlanejamentoSchema(BaseModel):
     instrutor: str
     local: Optional[str] = ""
     observacao: Optional[str] = ""
+    sge_ativo: bool = False
+    sge_link: Optional[str] = None
 
     @field_validator("fim")
     @classmethod

--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -531,6 +531,7 @@ function criarCabecalhoTabela() {
                 <th>Data Inicial</th><th>Data Final</th><th>Semana</th><th>Horário</th><th>C.H.</th>
                 <th>Modalidade</th><th>Treinamento</th><th>CMD</th><th>SJB</th>
                 <th>SAG/TOMBOS</th><th>Instrutor</th><th>Local</th><th>Obs.</th>
+                <th>SGE</th><th>LINK</th>
                 <th class="text-end">Ações</th>
             </tr>
         </thead>
@@ -560,6 +561,13 @@ function criarLinhaItem(item, dataFinal) {
             <td>${escapeHTML(item.instrutor || '')}</td>
             <td>${escapeHTML(item.local || '')}</td>
             <td>${escapeHTML(item.observacao || '')}</td>
+            <td>
+                <label class="sge-switch" title="Ativar SGE">
+                    <input type="checkbox" class="sge-toggle" data-id="${item.id || ''}" ${item.sge_ativo ? 'checked' : ''}>
+                    <span class="sge-slider" aria-hidden="true"></span>
+                </label>
+            </td>
+            <td class="link-col">${item.sge_ativo ? `<input type='url' class='form-control form-control-sm sge-link-input' placeholder='https://...' value='${escapeHTML(item.sge_link || '')}'>` : ''}</td>
             <td class="text-end">
                 <button class="btn btn-sm btn-outline-primary btn-editar" data-item-id="${item.loteId}" data-row-id="${item.id}" data-data-inicial="${item.data}" data-data-final="${dataFinal}">
                     <i class="bi bi-pencil"></i>
@@ -630,3 +638,29 @@ function renderPlanejamento(planejamento) {
     `;
     tbody.appendChild(row);
 }
+
+document.addEventListener('change', (ev) => {
+    const el = ev.target;
+    if (el.classList.contains('sge-toggle')) {
+        const row = el.closest('tr');
+        const linkCell = row ? row.querySelector('td.link-col') : null;
+        if (!linkCell) return;
+        if (el.checked) {
+            linkCell.innerHTML = `
+                <input type="url" class="form-control form-control-sm sge-link-input" placeholder="https://...">
+            `;
+        } else {
+            linkCell.innerHTML = '';
+        }
+        const payload = { sge_ativo: el.checked, sge_link: el.checked ? '' : null };
+        chamarAPI(`/planejamento/itens/${el.dataset.id}`, 'PUT', payload)
+            .catch(() => showToast('Não foi possível salvar o status SGE.', 'danger'));
+    } else if (el.classList.contains('sge-link-input')) {
+        const row = el.closest('tr');
+        const toggle = row ? row.querySelector('.sge-toggle') : null;
+        if (!toggle) return;
+        const payload = { sge_ativo: true, sge_link: el.value.trim() };
+        chamarAPI(`/planejamento/itens/${toggle.dataset.id}`, 'PUT', payload)
+            .catch(() => showToast('Não foi possível salvar o link SGE.', 'danger'));
+    }
+});


### PR DESCRIPTION
## Summary
- add migration for `sge_ativo` and `sge_link` columns
- expose SGE fields through schemas, routes and trimestral UI
- keep SGE data when editing planejamento items

## Testing
- `pre-commit run --files migrations/versions/a3e4f5d6c7b8_add_sge_fields_to_planejamento_itens.py src/routes/planejamento/planejamento.py src/schemas/planejamento.py src/static/js/planejamento-trimestral.js`
- `pytest`
- `SECRET_KEY=dev flask --app src.main db upgrade`


------
https://chatgpt.com/codex/tasks/task_e_68a64d8f8d50832398a63c058f95ed58