### PR TITLE
Ensure planejamento items table includes SGE fields

### DIFF
--- a/src/models/planejamento.py
+++ b/src/models/planejamento.py
@@ -23,7 +23,7 @@ class PlanejamentoItem(db.Model):
     local = db.Column(db.String(100))
     observacao = db.Column(db.String(255))
     sge_ativo = db.Column(db.Boolean, default=False)
-    sge_link = db.Column(db.String(255))
+    sge_link = db.Column(db.String(512))
     criado_em = db.Column(db.DateTime, default=datetime.utcnow)
     atualizado_em = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow


### PR DESCRIPTION
## Summary
- align `sge_link` column size with migration
- auto-create `sge_ativo` and `sge_link` columns when missing
- test automatic addition of SGE columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a657a2ac608323944ee32345e72c6a