### PR TITLE
Rename duplicate InscricaoTreinamento model to avoid SQLAlchemy conflicts

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -18,7 +18,9 @@ from .treinamento import (  # noqa: E402
     TurmaTreinamento,
     InscricaoTreinamento,
 )
-from .inscricao_treinamento import InscricaoTreinamento as InscricaoTreinamentoFormulario  # noqa: E402
+from .inscricao_treinamento import (
+    InscricaoTreinamentoFormulario,
+)  # noqa: E402
 from .planejamento import (  # noqa: E402
     PlanejamentoItem,
     PlanejamentoBDItem,

--- a/src/models/inscricao_treinamento.py
+++ b/src/models/inscricao_treinamento.py
@@ -3,7 +3,17 @@ from sqlalchemy import Column, Integer, String, Date, DateTime
 from src.models import db
 
 
-class InscricaoTreinamento(db.Model):
+class InscricaoTreinamentoFormulario(db.Model):
+    """Dados enviados pelo formulário público de inscrição em treinamentos.
+
+    Essa classe coexistia com ``InscricaoTreinamento`` definida em
+    ``treinamento.py``. Ambas compartilham o mesmo nome de classe e,
+    consequentemente, o mesmo identificador dentro do registro do
+    SQLAlchemy, o que causava o erro ``Multiple classes found for path`` ao
+    inicializar os mapeamentos. Renomear a classe elimina o conflito e
+    permite que os dois modelos representem tabelas distintas.
+    """
+
     __tablename__ = 'inscricoes_treinamento_portal'
     id = Column(Integer, primary_key=True)
     treinamento_id = Column(Integer, nullable=True)

--- a/src/routes/inscricoes_treinamento.py
+++ b/src/routes/inscricoes_treinamento.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, request, jsonify
 from src.models import db
-from src.models.inscricao_treinamento import InscricaoTreinamento
+from src.models.inscricao_treinamento import (
+    InscricaoTreinamentoFormulario,
+)
 from src.schemas.inscricao_treinamento import InscricaoTreinamentoCreate
 
 bp = Blueprint('inscricoes_treinamento', __name__, url_prefix='/api/inscricoes-treinamento')
@@ -11,7 +13,7 @@ def criar():
     data = request.get_json() or {}
     payload = InscricaoTreinamentoCreate(**data)
 
-    ent = InscricaoTreinamento(
+    ent = InscricaoTreinamentoFormulario(
         treinamento_id=payload.treinamento_id,
         nome_treinamento=payload.nome_treinamento,
         matricula=payload.matricula,


### PR DESCRIPTION
## Summary
- rename InscricaoTreinamento model used for portal form to InscricaoTreinamentoFormulario
- update imports and route to use renamed model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a70f6a0be8832386c285cff1e6074c