### PR TITLE
fix: enable add planning modal

### DIFF
--- a/src/static/js/planejamento-treinamentos.js
+++ b/src/static/js/planejamento-treinamentos.js
@@ -1,4 +1,4 @@
-/* global chamarAPI, showToast, escapeHTML, parseISODateToLocal, loadCMDHolidaysBetween, isBusinessDay, toISODateLocal */
+/* global chamarAPI, showToast, escapeHTML, parseISODateToLocal, loadCMDHolidaysBetween, isBusinessDay, toISODateLocal, bootstrap */
 
 // Função para copiar o link de inscrição e dar feedback visual ao usuário
 function copiarLink(event, link) {
@@ -19,7 +19,16 @@ function copiarLink(event, link) {
     });
 }
 
+let itemModal;
+
 document.addEventListener('DOMContentLoaded', async () => {
+    itemModal = new bootstrap.Modal(document.getElementById('itemModal'));
+    document.getElementById('btn-adicionar-planejamento')
+        .addEventListener('click', () => {
+            document.getElementById('itemForm').reset();
+            itemModal.show();
+        });
+
     await carregarItens();
 });
 


### PR DESCRIPTION
## Summary
- ensure clicking the add button opens the planning item modal

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a7544ba43c83239fd898106aeb35f4