### PR TITLE
feat: add global hover sidebar menu

### DIFF
--- a/src/static/admin/login.html
+++ b/src/static/admin/login.html
@@ -58,7 +58,7 @@
     </div>
     
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', async function() {
             let siteKey = '';

--- a/src/static/admin/perfil.html
+++ b/src/static/admin/perfil.html
@@ -174,7 +174,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Verifica autenticação

--- a/src/static/admin/usuarios.html
+++ b/src/static/admin/usuarios.html
@@ -194,7 +194,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/admin/usuarios.js"></script>
 </body>
 </html>

--- a/src/static/css/menu-suspenso.css
+++ b/src/static/css/menu-suspenso.css
@@ -1,59 +1,39 @@
-:root {
-  --senai-azul: #164194;
-  --senai-laranja: #F3B54E;
-}
-
-/* Zona de hover na borda esquerda (quase invisível) */
-#hoverEdge{
+/* Sidebar fixa que aparece ao passar o mouse na borda esquerda */
+.sidebar {
   position: fixed;
-  left: 0;
-  top: 0;
-  width: 12px;          /* zona segura para o mouse encostar */
-  height: 100vh;
-  z-index: 1030;        /* acima do conteúdo */
-}
-
-/* Drawer */
-#sidebarDrawer.drawer{
-  position: fixed;
-  top: 0;
-  left: -280px;         /* escondido fora da tela */
-  width: 280px;
-  height: 100vh;
-  background: var(--senai-azul);
+  top: 0; left: 0; bottom: 0;
+  width: 260px;
+  transform: translateX(-240px);
+  transition: transform .25s ease;
+  background: var(--brand-primary-900, #0d3b66);
   color: #fff;
-  box-shadow: 2px 0 16px rgba(0,0,0,.25);
-  transition: left .25s ease-in-out;
-  z-index: 1040;
-  display: flex;
-  flex-direction: column;
+  z-index: 1030; /* acima do conteúdo */
+  box-shadow: 2px 0 6px rgba(0,0,0,.2);
 }
 
-#sidebarDrawer.drawer.open{ left: 0; }
-#sidebarDrawer .drawer-header{ padding: 16px 20px; border-bottom: 1px solid rgba(255,255,255,.15); }
-#sidebarDrawer .drawer-header h2{ font-size: 16px; margin: 0; color:#fff; }
-
-#sidebarDrawer .drawer-nav{ padding: 8px 0; overflow-y: auto; }
-#sidebarDrawer .drawer-nav ul{ list-style: none; margin:0; padding:0; }
-#sidebarDrawer .drawer-nav a{
-  display:block;
-  padding: 12px 20px;
-  color:#fff;
-  text-decoration:none;
-  border-left: 4px solid transparent;
-  outline: none;
-}
-#sidebarDrawer .drawer-nav a:hover,
-#sidebarDrawer .drawer-nav a:focus,
-#sidebarDrawer .drawer-nav li.active > a{
-  background: rgba(255,255,255,.08);
-  border-left-color: var(--senai-laranja);
+.sidebar:hover,
+.sidebar:focus-within,
+body.show-sidebar .sidebar {
+  transform: translateX(0);
 }
 
-/* Acessibilidade: foco visível */
-#sidebarDrawer .drawer-nav a:focus{ box-shadow: inset 0 0 0 2px rgba(255,255,255,.35); }
+.sidebar-header { font-weight: 600; padding: 1rem 1rem .5rem; }
+.sidebar-menu { list-style: none; margin: 0; padding: .5rem 0 1rem; }
+.sidebar-menu li a {
+  display: block;
+  padding: .75rem 1rem;
+  text-decoration: none;
+  color: inherit;
+}
+.sidebar-menu li a[aria-current="page"] {
+  background: rgba(255,255,255,.12);
+  font-weight: 600;
+}
 
-/* Responsivo: em telas muito estreitas o drawer ocupa toda a largura */
-@media (max-width: 480px){
-  #sidebarDrawer.drawer{ width: 88vw; }
+/* Área invisível que dispara a abertura ao encostar o mouse na borda */
+.sidebar-edge {
+  position: fixed;
+  left: 0; top: 0; bottom: 0;
+  width: 16px;
+  z-index: 1025;
 }

--- a/src/static/inscricao_treinamento.html
+++ b/src/static/inscricao_treinamento.html
@@ -85,7 +85,7 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="/js/app.js"></script>
+  <script defer src="/js/app.js"></script>
   <script src="/js/inscricao_treinamento.js"></script>
 </body>
 </html>

--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -978,3 +978,50 @@ async function preencherTabela(idTabela, endpoint, funcaoRenderizarLinha) {
         return [];
     }
 }
+
+// ==== Menu lateral suspenso global ====
+async function carregarSidebarGlobal() {
+  try {
+    // Evita duplicar
+    if (document.querySelector('#sidebar')) return;
+
+    // Garante o CSS do menu
+    if (!document.querySelector('link[href$="menu-suspenso.css"]')) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = '/css/menu-suspenso.css';
+      document.head.appendChild(link);
+    }
+
+    // Cria a "borda" que ativa o hover
+    const edge = document.createElement('div');
+    edge.className = 'sidebar-edge';
+    document.body.prepend(edge);
+
+    // Busca o parcial e injeta no topo do <body>
+    const resp = await fetch('/partials/sidebar.html', { cache: 'no-store' });
+    if (!resp.ok) throw new Error('Falha ao carregar sidebar.html');
+    const html = await resp.text();
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html.trim();
+    const sidebar = wrap.firstElementChild;
+    document.body.prepend(sidebar);
+
+    // Marca link ativo
+    const path = location.pathname.replace(/\/$/, '');
+    sidebar.querySelectorAll('a[href]').forEach(a => {
+      const href = a.getAttribute('href').replace(/\/$/, '');
+      if (href === path) a.setAttribute('aria-current', 'page');
+    });
+
+    // Acessibilidade / comportamento
+    edge.addEventListener('mouseenter', () => document.body.classList.add('show-sidebar'));
+    sidebar.addEventListener('mouseleave', () => document.body.classList.remove('show-sidebar'));
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') document.body.classList.remove('show-sidebar');
+    });
+  } catch (err) {
+    console.error('Erro ao inicializar o menu lateral:', err);
+  }
+}
+document.addEventListener('DOMContentLoaded', carregarSidebarGlobal);

--- a/src/static/laboratorios/agendamento.html
+++ b/src/static/laboratorios/agendamento.html
@@ -170,7 +170,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Verifica autenticação

--- a/src/static/laboratorios/calendario.html
+++ b/src/static/laboratorios/calendario.html
@@ -129,7 +129,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/locales/pt-br.global.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/laboratorios/agenda-diaria.js"></script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/laboratorios/dashboard.html
+++ b/src/static/laboratorios/dashboard.html
@@ -207,7 +207,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/laboratorios/dashboard.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/laboratorios/logs.html
+++ b/src/static/laboratorios/logs.html
@@ -146,7 +146,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-<script src="/js/app.js"></script>
+<script defer src="/js/app.js"></script>
 <script src="/js/laboratorios/logs.js"></script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/laboratorios/perfil.html
+++ b/src/static/laboratorios/perfil.html
@@ -201,7 +201,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Verifica autenticação

--- a/src/static/laboratorios/turmas.html
+++ b/src/static/laboratorios/turmas.html
@@ -258,7 +258,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Verifica autenticação e permissão de administrador

--- a/src/static/ocupacao/agendamento.html
+++ b/src/static/ocupacao/agendamento.html
@@ -204,7 +204,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/ocupacao/nova-ocupacao.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', async function() {

--- a/src/static/ocupacao/calendario.html
+++ b/src/static/ocupacao/calendario.html
@@ -271,7 +271,7 @@
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/locales/pt-br.global.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/ocupacao/calendario.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/ocupacao/dashboard.html
+++ b/src/static/ocupacao/dashboard.html
@@ -320,7 +320,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/ocupacao/dashboard.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/ocupacao/instrutores.html
+++ b/src/static/ocupacao/instrutores.html
@@ -269,7 +269,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/ocupacao/corpo-docente.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/ocupacao/perfil.html
+++ b/src/static/ocupacao/perfil.html
@@ -218,7 +218,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Verifica autenticação

--- a/src/static/ocupacao/salas.html
+++ b/src/static/ocupacao/salas.html
@@ -284,7 +284,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/ocupacao/salas.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {

--- a/src/static/ocupacao/turmas.html
+++ b/src/static/ocupacao/turmas.html
@@ -227,7 +227,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/ocupacao/turmas.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/partials/sidebar.html
+++ b/src/static/partials/sidebar.html
@@ -1,0 +1,9 @@
+<nav id="sidebar" class="sidebar hover-expand" role="navigation" aria-label="Menu de Planejamento">
+  <div class="sidebar-header">Menu de Planejamento</div>
+  <ul class="sidebar-menu">
+    <li><a href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a></li>
+    <li><a href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a></li>
+    <li><a href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a></li>
+    <li><a href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a></li>
+  </ul>
+</nav>

--- a/src/static/planejamento-basedados.html
+++ b/src/static/planejamento-basedados.html
@@ -314,7 +314,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="js/menu-suspenso.js"></script>
     <script src="/js/planejamento-basedados.js"></script>
 </body>

--- a/src/static/planejamento-instrutores.html
+++ b/src/static/planejamento-instrutores.html
@@ -77,7 +77,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="js/menu-suspenso.js"></script>
 </body>
 </html>

--- a/src/static/planejamento-treinamentos.html
+++ b/src/static/planejamento-treinamentos.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/static/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
-    <link rel="stylesheet" href="css/menu-suspenso.css">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
@@ -52,23 +51,6 @@
         </div>
     </nav>
 
-    <!-- Zona fina na borda para disparar o hover -->
-    <div id="hoverEdge" aria-hidden="true"></div>
-
-    <!-- Drawer do menu lateral -->
-    <aside id="sidebarDrawer" class="drawer" aria-label="Menu de Planejamento" aria-expanded="false">
-      <div class="drawer-header">
-        <h2>Menu de Planejamento</h2>
-      </div>
-      <nav class="drawer-nav">
-        <ul>
-          <li class="active"><a href="/planejamento-treinamentos.html"><i class="bi bi-card-list me-2"></i> Treinamentos</a></li>
-          <li><a href="/planejamento-trimestral.html"><i class="bi bi-calendar-range me-2"></i> Planejamento Trimestral</a></li>
-          <li><a href="/planejamento-instrutores.html"><i class="bi bi-person-workspace me-2"></i> Planejamento por Instrutor</a></li>
-          <li><a href="/planejamento-basedados.html"><i class="bi bi-database-fill me-2"></i> Base de Dados</a></li>
-        </ul>
-      </nav>
-    </aside>
 
     <main class="container-fluid py-4">
         <div class="page-header">
@@ -184,8 +166,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
-    <script src="js/menu-suspenso.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-treinamentos.js"></script>
 </body>

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -210,7 +210,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="js/menu-suspenso.js"></script>
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>

--- a/src/static/rateio/config.html
+++ b/src/static/rateio/config.html
@@ -155,7 +155,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/rateio/config.js"></script>
     <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">

--- a/src/static/rateio/dashboard.html
+++ b/src/static/rateio/dashboard.html
@@ -139,7 +139,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/rateio/lancamentos.js"></script>
     <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">

--- a/src/static/rateio/instrutores.html
+++ b/src/static/rateio/instrutores.html
@@ -232,7 +232,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/rateio/instrutores.js"></script>
     <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
     <script>

--- a/src/static/rateio/logs.html
+++ b/src/static/rateio/logs.html
@@ -148,7 +148,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://unpkg.com/lucide@latest"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-<script src="/js/app.js"></script>
+<script defer src="/js/app.js"></script>
 <script src="/js/rateio/logs.js"></script>
 <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">

--- a/src/static/rateio/perfil.html
+++ b/src/static/rateio/perfil.html
@@ -187,7 +187,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script>lucide.createIcons({attrs:{strokeWidth:1.75}})</script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {

--- a/src/static/selecao-sistema.html
+++ b/src/static/selecao-sistema.html
@@ -155,7 +155,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.4/dist/purify.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Apenas verifica se o usuário está logado

--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -165,7 +165,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/treinamentos/admin.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/treinamentos/admin-historico-passado.html
+++ b/src/static/treinamentos/admin-historico-passado.html
@@ -212,7 +212,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/treinamentos/historico-passado.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/treinamentos/admin-historico-turmas.html
+++ b/src/static/treinamentos/admin-historico-turmas.html
@@ -212,7 +212,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/treinamentos/historico-turmas.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -236,7 +236,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/treinamentos/admin.js"></script>
     <script>
         const params = new URLSearchParams(window.location.search);

--- a/src/static/treinamentos/admin-logs.html
+++ b/src/static/treinamentos/admin-logs.html
@@ -104,7 +104,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/treinamentos/logs.js"></script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -220,7 +220,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/treinamentos/admin.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -156,7 +156,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/treinamentos/cursos.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -146,7 +146,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/treinamentos/cursos.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/src/static/treinamentos/perfil.html
+++ b/src/static/treinamentos/perfil.html
@@ -102,7 +102,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
     <script src="/js/perfil.js"></script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/templates/admin/forgot_password.html
+++ b/src/templates/admin/forgot_password.html
@@ -66,6 +66,6 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
 </body>
 </html>

--- a/src/templates/admin/register.html
+++ b/src/templates/admin/register.html
@@ -84,7 +84,7 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
 
     <script>
       document.addEventListener('DOMContentLoaded', function () {

--- a/src/templates/admin/reset_password.html
+++ b/src/templates/admin/reset_password.html
@@ -66,6 +66,6 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script defer src="/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable sidebar partial
- centralize sidebar styling and inject globally via app.js
- load app.js with `defer` on all pages

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}')`


------
https://chatgpt.com/codex/tasks/task_e_68a77b6c88b88323ac34e72e8c9b71e9