### PR TITLE
Unifica modal de planejamento via partial e script compartilhado

### DIFF
--- a/src/static/js/modal-planejamento.js
+++ b/src/static/js/modal-planejamento.js
@@ -1,0 +1,220 @@
+/* global chamarAPI, showToast, escapeHTML, parseISODateToLocal, loadCMDHolidaysBetween, eachBusinessDay, toISODateLocal, executarAcaoComFeedback, bootstrap */
+
+const selectEndpoints = {
+    'select-horario': '/planejamento-basedados/horario',
+    'select-ch': '/planejamento-basedados/cargahoraria',
+    'select-modalidade': '/planejamento-basedados/modalidade',
+    'select-treinamento': '/planejamento-basedados/treinamento',
+    'select-cmd': '/planejamento-basedados/publico-alvo',
+    'select-sjb': '/planejamento-basedados/publico-alvo',
+    'select-sag_tombos': '/planejamento-basedados/publico-alvo',
+    'select-instrutor': '/instrutores',
+    'select-local': '/planejamento-basedados/local'
+};
+
+function popularSelect(selectEl, dados) {
+    if (!selectEl) return;
+    const placeholder = selectEl.options[0];
+    selectEl.innerHTML = '';
+    if (placeholder) selectEl.appendChild(placeholder);
+    dados.forEach(item => {
+        const option = document.createElement('option');
+        option.value = String(item.id);
+        option.textContent = escapeHTML(item.nome ?? item.descricao ?? '');
+        selectEl.appendChild(option);
+    });
+}
+
+async function carregarCmd() {
+    const dados = await chamarAPI('/planejamento-basedados/publico-alvo');
+    popularSelect(document.getElementById('select-cmd'), dados);
+}
+
+async function carregarSjb() {
+    const dados = await chamarAPI('/planejamento-basedados/publico-alvo');
+    popularSelect(document.getElementById('select-sjb'), dados);
+}
+
+async function carregarSagTombos() {
+    const dados = await chamarAPI('/planejamento-basedados/publico-alvo');
+    popularSelect(document.getElementById('select-sag_tombos'), dados);
+}
+
+async function carregarOpcoesDosSelects() {
+    const promessas = [carregarCmd(), carregarSjb(), carregarSagTombos()];
+    const restante = { ...selectEndpoints };
+    delete restante['select-cmd'];
+    delete restante['select-sjb'];
+    delete restante['select-sag_tombos'];
+
+    Object.entries(restante).forEach(([id, endpoint]) => {
+        promessas.push(
+            chamarAPI(endpoint)
+                .then(dados => popularSelect(document.getElementById(id), dados))
+                .catch(error => {
+                    console.error(`Falha ao carregar opções para ${id}:`, error);
+                    showToast(`Erro ao carregar dados para ${id.replace('select-', '')}.`, 'warning');
+                })
+        );
+    });
+
+    await Promise.all(promessas);
+}
+
+function calcularSemana() {
+    const dataInput = document.getElementById('data-inicial').value;
+    if (dataInput) {
+        const data = new Date(dataInput + 'T00:00:00');
+        const diaSemana = data.toLocaleDateString('pt-BR', { weekday: 'long' });
+        document.getElementById('semana').value = diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1);
+    }
+}
+
+async function montarRegistrosPlanejamento() {
+    const dataInicio = document.getElementById('data-inicial').value;
+    const dataFim = document.getElementById('data-final').value;
+
+    const selectsObrigatorios = ['select-horario', 'select-ch', 'select-modalidade', 'select-treinamento', 'select-cmd', 'select-sjb', 'select-sag_tombos', 'select-instrutor', 'select-local'];
+    const campos = { dataInicio, dataFim };
+    selectsObrigatorios.forEach(id => { campos[id] = document.getElementById(id).value; });
+
+    const nomesCampos = {
+        dataInicio: 'Data Inicial',
+        dataFim: 'Data Final',
+        'select-horario': 'Horário',
+        'select-ch': 'C.H. (Carga Horária)',
+        'select-modalidade': 'Modalidade',
+        'select-treinamento': 'Treinamento',
+        'select-cmd': 'CMD',
+        'select-sjb': 'SJB',
+        'select-sag_tombos': 'SAG/TOMBOS',
+        'select-instrutor': 'Instrutor',
+        'select-local': 'Local'
+    };
+
+    const faltantes = Object.entries(campos)
+        .filter(([, valor]) => !valor)
+        .map(([chave]) => nomesCampos[chave]);
+
+    if (faltantes.length) {
+        showToast(`Preencha os campos: ${faltantes.join(', ')}`, 'warning');
+        return null;
+    }
+
+    const inicioDate = parseISODateToLocal(dataInicio);
+    const fimDate = parseISODateToLocal(dataFim);
+    if (fimDate < inicioDate) {
+        showToast('Data final deve ser maior que a inicial', 'warning');
+        return null;
+    }
+
+    const horario = document.getElementById('select-horario').selectedOptions[0].textContent;
+    const cargaHoraria = document.getElementById('select-ch').selectedOptions[0].textContent;
+    const modalidade = document.getElementById('select-modalidade').selectedOptions[0].textContent;
+    const treinamento = document.getElementById('select-treinamento').selectedOptions[0].textContent;
+    const cmd = document.getElementById('select-cmd').selectedOptions[0].textContent;
+    const sjb = document.getElementById('select-sjb').selectedOptions[0].textContent;
+    const sagTombos = document.getElementById('select-sag_tombos').selectedOptions[0].textContent;
+    const instrutor = document.getElementById('select-instrutor').selectedOptions[0].textContent;
+    const local = document.getElementById('select-local').selectedOptions[0].textContent;
+    const observacao = document.getElementById('observacao').value;
+
+    const loteIdInput = document.getElementById('loteId');
+    const loteId = loteIdInput.value || crypto.randomUUID();
+    loteIdInput.value = loteId;
+
+    const registros = [];
+    const feriadosSet = await loadCMDHolidaysBetween(inicioDate, fimDate);
+    for (const d of eachBusinessDay(inicioDate, fimDate, feriadosSet)) {
+        const iso = toISODateLocal(d);
+        const diaSemana = d.toLocaleDateString('pt-BR', { weekday: 'long' });
+        registros.push({
+            data: iso,
+            loteId,
+            semana: diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1),
+            horario,
+            carga_horaria: cargaHoraria,
+            modalidade,
+            treinamento,
+            cmd,
+            sjb,
+            sag_tombos: sagTombos,
+            instrutor,
+            local,
+            observacao
+        });
+    }
+    return registros;
+}
+
+async function salvarPlanejamento() {
+    const registros = await montarRegistrosPlanejamento();
+    if (!registros) return;
+    const btnSalvar = document.getElementById('btnSalvarItem');
+    try {
+        await executarAcaoComFeedback(btnSalvar, async () => {
+            if (window.edicaoId) {
+                const itensOriginais = (window.itensPorLote || {})[window.edicaoId] || [];
+                const promessas = itensOriginais.map((orig, idx) => {
+                    const base = registros[idx] || registros[registros.length - 1];
+                    const payload = { ...base };
+                    if (String(orig.id) !== String(window.edicaoLinhaId)) {
+                        payload.instrutor = orig.instrutor;
+                    }
+                    return chamarAPI(`/planejamento/itens/${orig.id}`, 'PUT', payload);
+                });
+                await Promise.all(promessas);
+            } else {
+                const promessas = registros.map(reg => chamarAPI('/planejamento/itens', 'POST', reg));
+                await Promise.all(promessas);
+            }
+        });
+        showToast('Item salvo com sucesso!', 'success');
+        modalPlanejamento.hide();
+        window.edicaoId = null;
+        window.edicaoLinhaId = null;
+        if (typeof window.carregarItens === 'function') {
+            await window.carregarItens();
+        }
+    } catch (error) {
+        showToast(error.message || 'Dados inválidos', 'danger');
+    }
+}
+
+window.abrirModalParaAdicionar = function(loteId = '') {
+    const form = document.getElementById('itemForm');
+    form.reset();
+    document.getElementById('itemId').value = '';
+    document.getElementById('loteId').value = loteId;
+    document.getElementById('modalAdicionarPlanejamentoLabel').textContent = 'Adicionar Item ao Planejamento';
+    window.edicaoId = null;
+    window.edicaoLinhaId = null;
+};
+
+let modalPlanejamento;
+
+window.initModalPlanejamento = async function initModalPlanejamento() {
+    window.edicaoId = null;
+    window.edicaoLinhaId = null;
+    window.itensPorLote = window.itensPorLote || {};
+    modalPlanejamento = new bootstrap.Modal(document.getElementById('modalAdicionarPlanejamento'));
+    window.modalPlanejamento = modalPlanejamento;
+
+    await carregarOpcoesDosSelects();
+
+    document.getElementById('data-inicial').addEventListener('change', calcularSemana);
+    document.getElementById('btnSalvarItem').addEventListener('click', salvarPlanejamento);
+    document.getElementById('btnCancelarItem').addEventListener('click', () => {
+        window.edicaoId = null;
+        window.edicaoLinhaId = null;
+    });
+    document.getElementById('modalAdicionarPlanejamento').addEventListener('hidden.bs.modal', () => {
+        window.edicaoId = null;
+        window.edicaoLinhaId = null;
+    });
+
+    const btnAdd = document.getElementById('btn-adicionar-planejamento');
+    if (btnAdd) {
+        btnAdd.addEventListener('click', () => abrirModalParaAdicionar());
+    }
+};

--- a/src/static/js/planejamento-treinamentos.js
+++ b/src/static/js/planejamento-treinamentos.js
@@ -19,16 +19,7 @@ function copiarLink(event, link) {
     });
 }
 
-let itemModal;
-
 document.addEventListener('DOMContentLoaded', async () => {
-    itemModal = new bootstrap.Modal(document.getElementById('itemModal'));
-    document.getElementById('btn-adicionar-planejamento')
-        .addEventListener('click', () => {
-            document.getElementById('itemForm').reset();
-            itemModal.show();
-        });
-
     await carregarItens();
 });
 

--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -1,23 +1,8 @@
 /* global bootstrap, chamarAPI, showToast, escapeHTML, executarAcaoComFeedback */
 
-// Mapeamento dos endpoints da API para os IDs dos selects no HTML
-const mapeamentoSelects = {
-    'itemHorario': '/planejamento-basedados/horario',
-    'itemCargaHoraria': '/planejamento-basedados/cargahoraria',
-    'itemModalidade': '/planejamento-basedados/modalidade',
-    'itemTreinamento': '/planejamento-basedados/treinamento',
-    'itemCmd': '/planejamento-basedados/publico-alvo',
-    'itemSjb': '/planejamento-basedados/publico-alvo',
-    'itemSagTombos': '/planejamento-basedados/publico-alvo',
-    'itemInstrutor': '/instrutores',
-    'itemLocal': '/planejamento-basedados/local',
-};
-
-let itemModal;
-let edicaoId = null;
-let edicaoLinhaId = null;
 const itensCache = {};
 const itensPorLote = {};
+window.itensPorLote = itensPorLote;
 
 function formatarDataPtBr(iso) {
     if (!iso) return '';
@@ -140,36 +125,21 @@ function preencherFormulario(item) {
 
     const dtIni = toInputDate(item.data_inicial || item.data);
     const dtFim = toInputDate(item.data_final || item.data);
-    document.getElementById('itemDataInicio').value = dtIni;
-    document.getElementById('itemDataFim').value = dtFim;
-    document.getElementById('itemSemana').value = new Date(dtIni + 'T00:00:00').toLocaleDateString('pt-BR', { weekday: 'long' }).replace(/^./, c => c.toUpperCase());
+    document.getElementById('data-inicial').value = dtIni;
+    document.getElementById('data-final').value = dtFim;
+    document.getElementById('semana').value = new Date(dtIni + 'T00:00:00').toLocaleDateString('pt-BR', { weekday: 'long' }).replace(/^./, c => c.toUpperCase());
 
-    selecionarPorTexto(document.getElementById('itemHorario'), item.horario);
-    selecionarPorTexto(document.getElementById('itemCargaHoraria'), item.cargaHoraria);
-    selecionarPorTexto(document.getElementById('itemModalidade'), item.modalidade);
-    selecionarPorTexto(document.getElementById('itemTreinamento'), item.treinamento);
-    selecionarValorOuCriar(document.getElementById('itemCmd'), item.cmd_id, item.cmd);
-    selecionarValorOuCriar(document.getElementById('itemSjb'), item.sjb_id, item.sjb);
-    selecionarValorOuCriar(document.getElementById('itemSagTombos'), item.sag_tombos_id, item.sagTombos || item.sag_tombos);
-    selecionarPorTexto(document.getElementById('itemInstrutor'), item.instrutor);
-    selecionarPorTexto(document.getElementById('itemLocal'), item.local);
+    selecionarPorTexto(document.getElementById('select-horario'), item.horario);
+    selecionarPorTexto(document.getElementById('select-ch'), item.cargaHoraria);
+    selecionarPorTexto(document.getElementById('select-modalidade'), item.modalidade);
+    selecionarPorTexto(document.getElementById('select-treinamento'), item.treinamento);
+    selecionarValorOuCriar(document.getElementById('select-cmd'), item.cmd_id, item.cmd);
+    selecionarValorOuCriar(document.getElementById('select-sjb'), item.sjb_id, item.sjb);
+    selecionarValorOuCriar(document.getElementById('select-sag_tombos'), item.sag_tombos_id, item.sagTombos || item.sag_tombos);
+    selecionarPorTexto(document.getElementById('select-instrutor'), item.instrutor);
+    selecionarPorTexto(document.getElementById('select-local'), item.local);
 
-    document.getElementById('itemObservacao').value = item.observacao || '';
-}
-
-async function carregarCmd() {
-    const dados = await chamarAPI('/planejamento-basedados/publico-alvo');
-    popularSelect('itemCmd', dados);
-}
-
-async function carregarSjb() {
-    const dados = await chamarAPI('/planejamento-basedados/publico-alvo');
-    popularSelect('itemSjb', dados);
-}
-
-async function carregarSagTombos() {
-    const dados = await chamarAPI('/planejamento-basedados/publico-alvo');
-    popularSelect('itemSagTombos', dados);
+    document.getElementById('observacao').value = item.observacao || '';
 }
 
 async function obterItemPorId(idItem) {
@@ -184,18 +154,30 @@ async function obterItemPorId(idItem) {
     }
 }
 
+window.abrirModalParaEditar = async (idItem, rowId) => {
+    const item = await obterItemPorId(idItem);
+    window.edicaoId = idItem;
+    window.edicaoLinhaId = rowId;
+
+    await Promise.all([carregarCmd(), carregarSjb(), carregarSagTombos()]);
+
+    const lista = itensPorLote[idItem] || [];
+    const linha = lista.find(it => String(it.id) === String(rowId));
+    if (linha) {
+        item.instrutor = linha.instrutor;
+    }
+
+    preencherFormulario(item);
+    document.getElementById('itemId').value = rowId || '';
+
+    document.getElementById('modalAdicionarPlanejamentoLabel').textContent = 'Editar Item do Planejamento';
+    modalPlanejamento.show();
+};
+
 /**
  * Função executada quando o DOM está totalmente carregado.
  */
 document.addEventListener('DOMContentLoaded', async () => {
-    itemModal = new bootstrap.Modal(document.getElementById('itemModal'));
-
-    document.getElementById('itemDataInicio').addEventListener('change', calcularSemana);
-    document.getElementById('btn-adicionar-planejamento').addEventListener('click', () => abrirModalParaAdicionar());
-    document.getElementById('btnSalvarItem').addEventListener('click', salvarPlanejamento);
-    document.getElementById('btnCancelarItem').addEventListener('click', () => { edicaoId = null; edicaoLinhaId = null; });
-    document.getElementById('itemModal').addEventListener('hidden.bs.modal', () => { edicaoId = null; edicaoLinhaId = null; });
-
     const tabelaContainer = document.getElementById('planejamento-container');
     tabelaContainer.addEventListener('click', async (e) => {
         const btnEditar = e.target.closest('.btn-editar');
@@ -231,228 +213,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     });
 
-    await inicializarPagina();
+    await carregarItens();
 });
-
-/**
- * Orquestra o carregamento inicial dos dados da página.
- */
-async function inicializarPagina() {
-    try {
-        await Promise.all([
-            carregarOpcoesDosSelects(),
-            carregarItens()
-        ]);
-    } catch (error) {
-        console.error("Erro ao inicializar a página:", error);
-        showToast("Falha ao carregar dados iniciais da página.", 'danger');
-    }
-}
-
-/**
- * Busca os dados da API e popula todos os campos de seleção do modal.
- */
-async function carregarOpcoesDosSelects() {
-    const promessas = [carregarCmd(), carregarSjb(), carregarSagTombos()];
-
-    const restante = { ...mapeamentoSelects };
-    delete restante.itemCmd;
-    delete restante.itemSjb;
-    delete restante.itemSagTombos;
-
-    Object.entries(restante).forEach(([selectId, endpoint]) => {
-        promessas.push(
-            chamarAPI(endpoint)
-                .then(dados => popularSelect(selectId, dados))
-                .catch(error => {
-                    console.error(`Falha ao carregar opções para ${selectId}:`, error);
-                    showToast(`Erro ao carregar dados para ${selectId.replace('item', '')}.`, 'warning');
-                })
-        );
-    });
-
-    await Promise.all(promessas);
-}
-
-/**
- * Popula um elemento <select> com os dados fornecidos.
- */
-function popularSelect(selectId, dados) {
-    const select = document.getElementById(selectId);
-    if (!select) return;
-
-    const placeholder = select.options[0];
-    select.innerHTML = '';
-    select.appendChild(placeholder);
-
-    dados.forEach(item => {
-        const option = document.createElement('option');
-        option.value = String(item.id);
-        option.textContent = escapeHTML(item.nome ?? item.descricao ?? '');
-        select.appendChild(option);
-    });
-}
-
-async function montarRegistrosPlanejamento() {
-    const dataInicio = document.getElementById('itemDataInicio').value;
-    const dataFim = document.getElementById('itemDataFim').value;
-
-    const selectsObrigatorios = ['itemHorario', 'itemCargaHoraria', 'itemModalidade', 'itemTreinamento', 'itemCmd', 'itemSjb', 'itemSagTombos', 'itemInstrutor', 'itemLocal'];
-    const campos = { dataInicio, dataFim };
-    selectsObrigatorios.forEach(id => { campos[id] = document.getElementById(id).value; });
-
-    const nomesCampos = {
-        dataInicio: 'Data Inicial',
-        dataFim: 'Data Final',
-        itemHorario: 'Horário',
-        itemCargaHoraria: 'Carga Horária',
-        itemModalidade: 'Modalidade',
-        itemTreinamento: 'Treinamento',
-        itemCmd: 'CMD',
-        itemSjb: 'SJB',
-        itemSagTombos: 'SAG/TOMBOS',
-        itemInstrutor: 'Instrutor',
-        itemLocal: 'Local'
-    };
-
-    const faltantes = Object.entries(campos)
-        .filter(([_, valor]) => !valor)
-        .map(([chave]) => nomesCampos[chave]);
-
-    if (faltantes.length) {
-        showToast(`Preencha os campos: ${faltantes.join(', ')}`, 'warning');
-        return null;
-    }
-
-    const inicioDate = parseISODateToLocal(dataInicio);
-    const fimDate = parseISODateToLocal(dataFim);
-    if (fimDate < inicioDate) {
-        showToast('Data final deve ser maior que a inicial', 'warning');
-        return null;
-    }
-
-    const horario = document.getElementById('itemHorario').selectedOptions[0].textContent;
-    const cargaHoraria = document.getElementById('itemCargaHoraria').selectedOptions[0].textContent;
-    const modalidade = document.getElementById('itemModalidade').selectedOptions[0].textContent;
-    const treinamento = document.getElementById('itemTreinamento').selectedOptions[0].textContent;
-    const cmd = document.getElementById('itemCmd').selectedOptions[0].textContent;
-    const sjb = document.getElementById('itemSjb').selectedOptions[0].textContent;
-    const sagTombos = document.getElementById('itemSagTombos').selectedOptions[0].textContent;
-    const instrutor = document.getElementById('itemInstrutor').selectedOptions[0].textContent;
-    const local = document.getElementById('itemLocal').selectedOptions[0].textContent;
-    const observacao = document.getElementById('itemObservacao').value;
-
-    const loteIdInput = document.getElementById('loteId');
-    const loteId = loteIdInput.value || crypto.randomUUID();
-    loteIdInput.value = loteId;
-
-    const registros = [];
-    const feriadosSet = await loadCMDHolidaysBetween(inicioDate, fimDate);
-    for (const d of eachBusinessDay(inicioDate, fimDate, feriadosSet)) {
-        const iso = toISODateLocal(d);
-        const diaSemana = d.toLocaleDateString('pt-BR', { weekday: 'long' });
-        registros.push({
-            data: iso,
-            loteId,
-            semana: diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1),
-            horario,
-            carga_horaria: cargaHoraria,
-            modalidade,
-            treinamento,
-            cmd,
-            sjb,
-            sag_tombos: sagTombos,
-            instrutor,
-            local,
-            observacao
-        });
-    }
-
-    return registros;
-}
-
-/**
- * Calcula o número da semana com base na data selecionada.
- */
-function calcularSemana() {
-    const dataInput = document.getElementById('itemDataInicio').value;
-    if (dataInput) {
-        const data = new Date(dataInput + 'T00:00:00');
-        const diaSemana = data.toLocaleDateString('pt-BR', { weekday: 'long' });
-        document.getElementById('itemSemana').value = diaSemana.charAt(0).toUpperCase() + diaSemana.slice(1);
-    }
-}
-
-/**
- * Abre o modal para adicionar um novo item.
- */
-window.abrirModalParaAdicionar = (loteId = '') => {
-    document.getElementById('itemForm').reset();
-    document.getElementById('itemId').value = '';
-    document.getElementById('loteId').value = loteId;
-    document.getElementById('itemModalLabel').textContent = 'Adicionar Item ao Planejamento';
-    edicaoId = null;
-    itemModal.show();
-};
-
-/**
- * Abre o modal para editar um item existente.
- */
-window.abrirModalParaEditar = async (idItem, rowId) => {
-    const item = await obterItemPorId(idItem);
-    edicaoId = idItem;
-    edicaoLinhaId = rowId;
-
-    await Promise.all([carregarCmd(), carregarSjb(), carregarSagTombos()]);
-
-    const lista = itensPorLote[idItem] || [];
-    const linha = lista.find(it => String(it.id) === String(rowId));
-    if (linha) {
-        item.instrutor = linha.instrutor;
-    }
-
-    preencherFormulario(item);
-    document.getElementById('itemId').value = rowId || '';
-
-    document.getElementById('itemModalLabel').textContent = 'Editar Item do Planejamento';
-    bootstrap.Modal.getOrCreateInstance(document.getElementById('itemModal')).show();
-};
-
-
-/**
- * Envia o planejamento para a API.
- */
-async function salvarPlanejamento() {
-    const registros = await montarRegistrosPlanejamento();
-    if (!registros) return;
-    const btnSalvar = document.getElementById('btnSalvarItem');
-    try {
-        await executarAcaoComFeedback(btnSalvar, async () => {
-            if (edicaoId) {
-                const itensOriginais = itensPorLote[edicaoId] || [];
-                const promessas = itensOriginais.map((orig, idx) => {
-                    const base = registros[idx] || registros[registros.length - 1];
-                    const payload = { ...base };
-                    if (String(orig.id) !== String(edicaoLinhaId)) {
-                        payload.instrutor = orig.instrutor;
-                    }
-                    return chamarAPI(`/planejamento/itens/${orig.id}`, 'PUT', payload);
-                });
-                await Promise.all(promessas);
-            } else {
-                const promessas = registros.map(reg => chamarAPI('/planejamento/itens', 'POST', reg));
-                await Promise.all(promessas);
-            }
-        });
-        showToast('Item salvo com sucesso!', 'success');
-        itemModal.hide();
-        edicaoId = null;
-        edicaoLinhaId = null;
-        await carregarItens();
-    } catch (error) {
-        showToast(error.message || 'Dados inválidos', 'danger');
-    }
-}
 
 /**
  * Carrega e renderiza todos os itens do planejamento.

--- a/src/static/planejamento-treinamentos.html
+++ b/src/static/planejamento-treinamentos.html
@@ -73,121 +73,24 @@
     <main class="container-fluid py-4">
         <div class="page-header">
             <h1 class="mb-0">Treinamentos Disponíveis</h1>
-         <button id="btn-adicionar-planejamento" class="btn btn-primary">
+        <button id="btn-adicionar-planejamento" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalAdicionarPlanejamento">
                 <i class="bi bi-plus-circle me-2"></i>Adicionar
             </button>
         </div>
 
-<div id="planejamento-container" class="mt-4">
+        <div id="planejamento-container" class="mt-4">
             </div>
     </main>
 
-    <div class="modal fade" id="itemModal" tabindex="-1" aria-labelledby="itemModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="itemModalLabel">Adicionar Item ao Planejamento</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <form id="itemForm">
-                        <input type="hidden" id="itemId">
-                        <input type="hidden" id="loteId">
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <label for="itemDataInicio" class="form-label">Data Inicial</label>
-                                <input type="date" class="form-control" id="itemDataInicio" required>
-                            </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="itemDataFim" class="form-label">Data Final</label>
-                                <input type="date" class="form-control" id="itemDataFim" required>
-                            </div>
-                        </div>
-                        <input type="hidden" id="itemSemana">
-                        <div class="row">
-                            <div class="col-md-4 mb-3">
-                                <label for="itemHorario" class="form-label">Horário</label>
-                                <select class="form-select" id="itemHorario" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="itemCargaHoraria" class="form-label">C.H. (Carga Horária)</label>
-                                <select class="form-select" id="itemCargaHoraria" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="itemModalidade" class="form-label">Modalidade</label>
-                                <select class="form-select" id="itemModalidade" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="itemTreinamento" class="form-label">Treinamento</label>
-                            <select class="form-select" id="itemTreinamento" required>
-                                <option value="" selected disabled>Selecione...</option>
-                            </select>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-4 mb-3">
-                                <label for="itemCmd" class="form-label">CMD</label>
-                                <select class="form-select" id="itemCmd" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="itemSjb" class="form-label">SJB</label>
-                                <select class="form-select" id="itemSjb" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="itemSagTombos" class="form-label">SAG/TOMBOS</label>
-                                <select class="form-select" id="itemSagTombos" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <label for="itemInstrutor" class="form-label">Instrutor</label>
-                                <select class="form-select" id="itemInstrutor" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="itemLocal" class="form-label">Local</label>
-                                <select class="form-select" id="itemLocal" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="itemObservacao" class="form-label">Observação</label>
-                            <textarea class="form-control" id="itemObservacao" rows="2"></textarea>
-                        </div>
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="btnCancelarItem">Cancelar</button>
-                    <button type="button" class="btn btn-primary" id="btnSalvarItem">Salvar</button>
-                </div>
-            </div>
-        </div>
-    </div>
-
-        <!-- A tabela de treinamentos é renderizada via JavaScript.
-             A coluna SGE (toggle) é adicionada dinamicamente. -->
-        <div id="planejamento-container" class="mt-4"></div>
-    </main>
+    {% include 'partials/_modal_adicionar_planejamento.html' %}
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="js/menu-suspenso.js"></script>
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-treinamentos.js"></script>
+    <script src="{{ url_for('static', filename='js/modal-planejamento.js') }}"></script>
+    <script>document.addEventListener('DOMContentLoaded', () => { initModalPlanejamento(); });</script>
 </body>
 </html>
 

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -86,7 +86,7 @@
     <main class="container-fluid py-4" id="aba-planejamento-trimestral">
         <div class="page-header">
             <h1 class="mb-0">Planejamento Trimestral</h1>
-            <button id="btn-adicionar-planejamento" class="btn btn-primary">
+            <button id="btn-adicionar-planejamento" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalAdicionarPlanejamento">
                 <i class="bi bi-plus-circle me-2"></i>Adicionar
             </button>
         </div>
@@ -94,102 +94,7 @@
         <div id="planejamento-container" class="mt-4">
             </div>
     </main>
-
-    <div class="modal fade" id="itemModal" tabindex="-1" aria-labelledby="itemModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="itemModalLabel">Adicionar Item ao Planejamento</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <form id="itemForm">
-                        <input type="hidden" id="itemId">
-                        <input type="hidden" id="loteId">
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <label for="itemDataInicio" class="form-label">Data Inicial</label>
-                                <input type="date" class="form-control" id="itemDataInicio" required>
-                            </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="itemDataFim" class="form-label">Data Final</label>
-                                <input type="date" class="form-control" id="itemDataFim" required>
-                            </div>
-                        </div>
-                        <input type="hidden" id="itemSemana">
-                        <div class="row">
-                            <div class="col-md-4 mb-3">
-                                <label for="itemHorario" class="form-label">Horário</label>
-                                <select class="form-select" id="itemHorario" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="itemCargaHoraria" class="form-label">C.H. (Carga Horária)</label>
-                                <select class="form-select" id="itemCargaHoraria" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="itemModalidade" class="form-label">Modalidade</label>
-                                <select class="form-select" id="itemModalidade" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="itemTreinamento" class="form-label">Treinamento</label>
-                            <select class="form-select" id="itemTreinamento" required>
-                                <option value="" selected disabled>Selecione...</option>
-                            </select>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-4 mb-3">
-                                <label for="itemCmd" class="form-label">CMD</label>
-                                <select class="form-select" id="itemCmd" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="itemSjb" class="form-label">SJB</label>
-                                <select class="form-select" id="itemSjb" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-4 mb-3">
-                                <label for="itemSagTombos" class="form-label">SAG/TOMBOS</label>
-                                <select class="form-select" id="itemSagTombos" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-6 mb-3">
-                                <label for="itemInstrutor" class="form-label">Instrutor</label>
-                                <select class="form-select" id="itemInstrutor" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="itemLocal" class="form-label">Local</label>
-                                <select class="form-select" id="itemLocal" required>
-                                    <option value="" selected disabled>Selecione...</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="itemObservacao" class="form-label">Observação</label>
-                            <textarea class="form-control" id="itemObservacao" rows="2"></textarea>
-                        </div>
-                    </form>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="btnCancelarItem">Cancelar</button>
-                    <button type="button" class="btn btn-primary" id="btnSalvarItem">Salvar</button>
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include 'partials/_modal_adicionar_planejamento.html' %}
 
     <div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
@@ -214,5 +119,7 @@
     <script src="js/menu-suspenso.js"></script>
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>
+    <script src="{{ url_for('static', filename='js/modal-planejamento.js') }}"></script>
+    <script>document.addEventListener('DOMContentLoaded', () => { initModalPlanejamento(); });</script>
 </body>
 </html>

--- a/src/templates/partials/_modal_adicionar_planejamento.html
+++ b/src/templates/partials/_modal_adicionar_planejamento.html
@@ -1,0 +1,95 @@
+<div class="modal fade" id="modalAdicionarPlanejamento" tabindex="-1" aria-labelledby="modalAdicionarPlanejamentoLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalAdicionarPlanejamentoLabel">Adicionar Item ao Planejamento</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="itemForm">
+                    <input type="hidden" id="itemId">
+                    <input type="hidden" id="loteId">
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="data-inicial" class="form-label">Data Inicial</label>
+                            <input type="date" class="form-control" id="data-inicial" required>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="data-final" class="form-label">Data Final</label>
+                            <input type="date" class="form-control" id="data-final" required>
+                        </div>
+                    </div>
+                    <input type="hidden" id="semana">
+                    <div class="row">
+                        <div class="col-md-4 mb-3">
+                            <label for="select-horario" class="form-label">Horário</label>
+                            <select class="form-select" id="select-horario" required>
+                                <option value="" selected disabled>Selecione...</option>
+                            </select>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label for="select-ch" class="form-label">C.H. (Carga Horária)</label>
+                            <select class="form-select" id="select-ch" required>
+                                <option value="" selected disabled>Selecione...</option>
+                            </select>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label for="select-modalidade" class="form-label">Modalidade</label>
+                            <select class="form-select" id="select-modalidade" required>
+                                <option value="" selected disabled>Selecione...</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="select-treinamento" class="form-label">Treinamento</label>
+                        <select class="form-select" id="select-treinamento" required>
+                            <option value="" selected disabled>Selecione...</option>
+                        </select>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-4 mb-3">
+                            <label for="select-cmd" class="form-label">CMD</label>
+                            <select class="form-select" id="select-cmd" required>
+                                <option value="" selected disabled>Selecione...</option>
+                            </select>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label for="select-sjb" class="form-label">SJB</label>
+                            <select class="form-select" id="select-sjb" required>
+                                <option value="" selected disabled>Selecione...</option>
+                            </select>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label for="select-sag_tombos" class="form-label">SAG/TOMBOS</label>
+                            <select class="form-select" id="select-sag_tombos" required>
+                                <option value="" selected disabled>Selecione...</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label for="select-instrutor" class="form-label">Instrutor</label>
+                            <select class="form-select" id="select-instrutor" required>
+                                <option value="" selected disabled>Selecione...</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label for="select-local" class="form-label">Local</label>
+                            <select class="form-select" id="select-local" required>
+                                <option value="" selected disabled>Selecione...</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="observacao" class="form-label">Observação</label>
+                        <textarea class="form-control" id="observacao" rows="2"></textarea>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" id="btnCancelarItem">Cancelar</button>
+                <button type="button" class="btn btn-primary" id="btnSalvarItem">Salvar</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- move HTML do modal para partial reutilizável
- adiciona script modal-planejamento.js para popular selects e gerenciar o modal
- atualiza páginas de planejamento para usar o partial e o script compartilhado

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a86b2954a883238df115f3780e930e