### PR TITLE
feat: add vanilla table filters to quarterly plan

### DIFF
--- a/src/static/css/filtros-tabela.css
+++ b/src/static/css/filtros-tabela.css
@@ -1,0 +1,17 @@
+th { position: relative; }
+.filter-toggle {
+  margin-left: .5rem; border: 1px solid #ddd; background: #fff; cursor: pointer;
+  font-size: 12px; padding: 2px 6px; border-radius: 4px;
+}
+.filter-menu {
+  position: absolute; top: 100%; right: 0; min-width: 220px; z-index: 1000;
+  background: #fff; border: 1px solid #ddd; border-radius: 8px;
+  padding: 8px; box-shadow: 0 8px 20px rgba(0,0,0,.15);
+}
+.filter-menu.hidden { display: none; }
+.filter-menu .search { width: 100%; margin-bottom: 6px; padding: 6px; }
+.filter-menu .options { max-height: 240px; overflow: auto; }
+.filter-menu .actions { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; }
+.filter-menu .btn {
+  border: 1px solid #ddd; background: #f7f7f7; padding: 4px 8px; border-radius: 4px; cursor: pointer;
+}

--- a/src/static/js/filtros-tabela.js
+++ b/src/static/js/filtros-tabela.js
@@ -1,0 +1,136 @@
+(function(){
+  function inicializarFiltrosTabela(selector){
+    const table = document.querySelector(selector);
+    if(!table) return;
+    const tbody = table.tBodies[0];
+    if(!tbody) return;
+
+    // limpar instâncias anteriores
+    table.querySelectorAll('.filter-toggle').forEach(el=>el.remove());
+    table.querySelectorAll('.filter-menu').forEach(el=>el.remove());
+
+    const rows = Array.from(tbody.rows);
+    const filtros = {};
+
+    const fecharMenus = () => {
+      table.querySelectorAll('.filter-menu').forEach(m=>m.classList.add('hidden'));
+    };
+    document.addEventListener('click', fecharMenus);
+
+    Array.from(table.tHead.rows[0].cells).forEach((th, index) => {
+      if(th.dataset.noFilter === 'true' || th.dataset.filterable !== 'true') return;
+
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'filter-toggle';
+      btn.textContent = '▼';
+      th.appendChild(btn);
+
+      const menu = document.createElement('div');
+      menu.className = 'filter-menu hidden';
+      menu.innerHTML = `
+        <input type="text" class="search" placeholder="Buscar...">
+        <div class="options"></div>
+        <div class="actions">
+          <button type="button" class="btn aplicar">Aplicar</button>
+          <button type="button" class="btn limpar">Limpar</button>
+          <button type="button" class="btn asc">A→Z</button>
+          <button type="button" class="btn desc">Z→A</button>
+        </div>`;
+      th.appendChild(menu);
+
+      const searchInput = menu.querySelector('.search');
+      const optionsDiv = menu.querySelector('.options');
+      const applyBtn = menu.querySelector('.aplicar');
+      const clearBtn = menu.querySelector('.limpar');
+      const ascBtn = menu.querySelector('.asc');
+      const descBtn = menu.querySelector('.desc');
+
+      const valores = [...new Set(rows.map(r => (r.cells[index]?.innerText || '').trim()))]
+        .sort((a,b)=>a.localeCompare(b,'pt-BR'));
+      valores.forEach(v=>{
+        const label = document.createElement('label');
+        const cb = document.createElement('input');
+        cb.type='checkbox';
+        cb.value=v;
+        cb.checked=true;
+        label.appendChild(cb);
+        label.appendChild(document.createTextNode(' '+v));
+        optionsDiv.appendChild(label);
+      });
+
+      searchInput.addEventListener('input', ()=>{
+        const termo = searchInput.value.toLowerCase();
+        Array.from(optionsDiv.children).forEach(label=>{
+          label.style.display = label.textContent.toLowerCase().includes(termo)?'':'none';
+        });
+      });
+
+      btn.addEventListener('click', (e)=>{
+        e.stopPropagation();
+        const oculto = menu.classList.contains('hidden');
+        fecharMenus();
+        if(oculto) menu.classList.remove('hidden');
+      });
+      menu.addEventListener('click', e=>e.stopPropagation());
+
+      const aplicar = ()=>{
+        const selecionados = Array.from(optionsDiv.querySelectorAll('input:checked')).map(cb=>cb.value);
+        const termo = searchInput.value.trim().toLowerCase();
+        if(selecionados.length === valores.length && !termo){
+          delete filtros[index];
+        } else {
+          filtros[index] = {valores: selecionados, termo};
+        }
+        aplicarFiltros();
+        menu.classList.add('hidden');
+      };
+
+      applyBtn.addEventListener('click', aplicar);
+      clearBtn.addEventListener('click', ()=>{
+        searchInput.value='';
+        optionsDiv.querySelectorAll('input').forEach(cb=>cb.checked=true);
+        delete filtros[index];
+        aplicarFiltros();
+        menu.classList.add('hidden');
+      });
+      ascBtn.addEventListener('click', ()=>{ordenar(index,'asc'); menu.classList.add('hidden');});
+      descBtn.addEventListener('click', ()=>{ordenar(index,'desc'); menu.classList.add('hidden');});
+    });
+
+    function aplicarFiltros(){
+      rows.forEach(r=>r.style.display='');
+      rows.forEach(r=>{
+        for(const [idx,f] of Object.entries(filtros)){
+          const texto = (r.cells[idx]?.innerText || '').trim();
+          const textoLower = texto.toLowerCase();
+          if(f.termo && !textoLower.includes(f.termo)) { r.style.display='none'; break; }
+          if(f.valores && f.valores.length && !f.valores.includes(texto)) { r.style.display='none'; break; }
+        }
+      });
+    }
+
+    function ordenar(colIdx, dir){
+      const visiveis = rows.filter(r=>r.style.display!=='none');
+      const ocultos = rows.filter(r=>r.style.display==='none');
+      const collator = new Intl.Collator('pt-BR',{numeric:true,sensitivity:'base'});
+      visiveis.sort((a,b)=>{
+        const aT = (a.cells[colIdx]?.innerText || '').trim();
+        const bT = (b.cells[colIdx]?.innerText || '').trim();
+        return dir==='asc'?collator.compare(aT,bT):collator.compare(bT,aT);
+      });
+      tbody.append(...visiveis, ...ocultos);
+    }
+
+    const resetBtn = document.querySelector('[data-reset-filtros]');
+    if(resetBtn){
+      resetBtn.addEventListener('click', ()=>{
+        Object.keys(filtros).forEach(k=>delete filtros[k]);
+        table.querySelectorAll('.filter-menu .search').forEach(i=>i.value='');
+        table.querySelectorAll('.filter-menu .options input').forEach(cb=>cb.checked=true);
+        aplicarFiltros();
+      });
+    }
+  }
+  window.inicializarFiltrosTabela = inicializarFiltrosTabela;
+})();

--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -477,6 +477,7 @@ async function carregarItens() {
         });
 
         renderizarItens(itens);
+        window.inicializarFiltrosTabela?.('#tabela-trimestral');
     } catch (error) {
         showToast('Não foi possível carregar o planejamento.', 'danger');
     }
@@ -486,21 +487,9 @@ async function carregarItens() {
  * Renderiza todos os itens do planejamento em uma única tabela.
  */
 function renderizarItens(itens) {
-    const container = document.getElementById('planejamento-container');
-
-    container.innerHTML = `
-        <div class="card mb-4">
-            <div class="card-body p-0">
-                <div class="table-responsive">
-                    <table id="tabela-planejamento" class="table table-striped table-hover mb-0">
-                        ${criarCabecalhoTabela()}
-                        <tbody id="planejamento-tbody"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>`;
-
     const tbody = document.getElementById('planejamento-tbody');
+    if (!tbody) return;
+
     tbody.innerHTML = '';
 
     if (itens.length === 0) {
@@ -519,23 +508,6 @@ function renderizarItens(itens) {
         const dataFinal = dataFinalPorLote[item.loteId];
         tbody.insertAdjacentHTML('beforeend', criarLinhaItem(item, dataFinal));
     });
-}
-
-/**
- * Cria o cabeçalho da tabela de itens.
- */
-function criarCabecalhoTabela() {
-    return `
-        <thead>
-            <tr>
-                <th>Data Inicial</th><th>Data Final</th><th>Semana</th><th>Horário</th><th>C.H.</th>
-                <th>Modalidade</th><th>Treinamento</th><th>CMD</th><th>SJB</th>
-                <th>SAG/TOMBOS</th><th>Instrutor</th><th>Local</th><th>Obs.</th>
-                <th class="hidden-col" style="display: none;">SGE</th><th class="hidden-col" style="display: none;">LINK</th>
-                <th class="text-end">Ações</th>
-            </tr>
-        </thead>
-    `;
 }
 
 /**

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -9,7 +9,6 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
     <link rel="stylesheet" href="css/menu-suspenso.css">
-    <link rel="stylesheet" href="/static/css/tabela-filtro.css">
     <style>
         .table-responsive {
             max-height: 75vh;
@@ -92,7 +91,35 @@
             </button>
         </div>
 
-        <div id="planejamento-container" class="mt-4"></div>
+        <div id="planejamento-container" class="mt-4">
+            <div class="card mb-4">
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table id="tabela-trimestral" class="table table-striped table-hover mb-0">
+                            <thead>
+                                <tr>
+                                    <th data-filterable="true">Data Inicial</th>
+                                    <th data-filterable="true">Data Final</th>
+                                    <th data-filterable="true">Semana</th>
+                                    <th data-filterable="true">Horário</th>
+                                    <th data-filterable="true">C.H.</th>
+                                    <th data-filterable="true">Modalidade</th>
+                                    <th data-filterable="true">Treinamento</th>
+                                    <th data-filterable="true">CMD</th>
+                                    <th data-filterable="true">SJB</th>
+                                    <th data-filterable="true">SAG/TOMBOS</th>
+                                    <th data-filterable="true">Instrutor</th>
+                                    <th data-filterable="true">Local</th>
+                                    <th data-filterable="true">Obs.</th>
+                                    <th data-no-filter="true" class="text-end">Ações</th>
+                                </tr>
+                            </thead>
+                            <tbody id="planejamento-tbody"></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
         <div class="mt-2">
             <button type="button" class="btn btn-outline-secondary btn-sm" data-reset-filtros>Limpar todos os filtros</button>
         </div>
@@ -217,6 +244,12 @@
     <script src="js/menu-suspenso.js"></script>
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>
-    <script src="/static/js/tabela-filtro.js" defer></script>
+    <link rel="stylesheet" href="./css/filtros-tabela.css">
+    <script src="./js/filtros-tabela.js" defer></script>
+    <script defer>
+      document.addEventListener('DOMContentLoaded', () => {
+        window.inicializarFiltrosTabela?.('#tabela-trimestral');
+      });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add table id and filterable headers to quarterly plan page
- implement vanilla JS column filters with apply/clear/sort
- add minimal CSS for filter menu styling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac996ff3f083239bb7d9d163a0200b