### PR TITLE
Refina filtros e layout no planejamento trimestral

### DIFF
--- a/src/static/css/planejamento-trimestral.css
+++ b/src/static/css/planejamento-trimestral.css
@@ -1,0 +1,96 @@
+:root{
+  --fiemg-blue: #164194;   /* Azul CNI (primário) */
+  --fiemg-orange: #F3B54E; /* Laranja SENAI (destaque) */
+  --ink-900: #222;         /* Texto principal */
+  --ink-600: #5B5B5F;      /* Cinza texto secundário (Cool Gray 11 aprox.) */
+  --ink-300: #D8D9DD;      /* Cinza claro (7541C aprox.) */
+  --surface: #FFFFFF;
+  --radius-lg: 12px;
+  --radius-md: 10px;
+  --shadow-md: 0 6px 24px rgba(22,65,148,0.08), 0 2px 8px rgba(0,0,0,0.05);
+  --focus: 0 0 0 3px rgba(22,65,148,.22);
+}
+
+html, body {
+  font-family: "Gibson","Neo Sans","Exo 2","Calibri",system-ui,-apple-system,Segoe UI,Arial,sans-serif;
+  color: var(--ink-900);
+}
+
+/* Cabeçalho sem quebra e alinhado */
+.table thead th, .table thead td {
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.th-content{
+  display: flex; align-items: center; justify-content: space-between; gap: .5rem;
+}
+.th-label{ font-weight: 600; }
+
+/* Botão filtro clean */
+.filter-btn{
+  display:inline-flex; align-items:center; justify-content:center;
+  width: 32px; height: 32px; min-width:32px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--ink-300);
+  background: var(--surface);
+  color: var(--ink-600);
+  transition: all .15s ease;
+}
+.filter-btn .icon{ display:block; }
+.filter-btn:hover{ border-color: var(--fiemg-blue); color: var(--fiemg-blue); }
+.filter-btn:focus-visible{ outline: none; box-shadow: var(--focus); }
+.filter-btn[aria-expanded="true"]{
+  background: rgba(22,65,148,.06);
+  color: var(--fiemg-blue);
+  border-color: var(--fiemg-blue);
+}
+
+.filter-dropdown[hidden]{ display:none !important; }
+.filter-dropdown{
+  position:absolute; z-index: 50; min-width: 260px; max-width: 320px;
+  margin-top: .5rem;
+}
+.filter-card{
+  background: var(--surface); border: 1px solid var(--ink-300);
+  border-radius: var(--radius-lg); box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+.filter-head{ padding: .75rem .75rem 0 .75rem; }
+.filter-list{
+  max-height: 220px; overflow:auto; padding: .5rem .75rem;
+}
+.filter-item{
+  display:flex; align-items:center; gap:.5rem; padding:.35rem .25rem;
+  border-radius: 8px; cursor:pointer; user-select:none;
+}
+.filter-item:hover{ background: rgba(22,65,148,.06); }
+.filter-item input{ width:16px; height:16px; }
+
+.filter-actions{
+  display:flex; align-items:center; justify-content:space-between;
+  gap:.75rem; padding:.75rem;
+  border-top:1px solid var(--ink-300);
+}
+.sort-group .btn{ border-color: var(--ink-300); }
+.sort-group .btn:focus-visible{ box-shadow: var(--focus); outline:0; }
+.cta-group .btn-primary{
+  background: var(--fiemg-blue); border-color: var(--fiemg-blue);
+}
+.cta-group .btn-primary:hover{ filter: brightness(1.05); }
+.cta-group .btn-outline-secondary{ border-color: var(--ink-300); color: var(--ink-600); }
+.cta-group .btn-outline-secondary:hover{ background:#f7f7f9; }
+
+.filter-foot{
+  font-size:.75rem; padding: .25rem .75rem .6rem .75rem;
+}
+
+.table td, .table th{ vertical-align: middle; }
+.table th, .table td{ white-space: nowrap; }
+.table .text-wrap{ white-space: normal; }
+.text-muted{ color: var(--ink-600) !important; }
+
+.btn{ border-radius: 10px; }
+.btn-sm{ padding: .35rem .6rem; min-width: 84px; }
+.actions .btn, .table .btn-icon{
+  min-width: 32px; width: 32px; height: 32px; padding: 0; display:inline-flex; align-items:center; justify-content:center;
+}

--- a/src/static/js/filtros-tabela.js
+++ b/src/static/js/filtros-tabela.js
@@ -18,28 +18,47 @@
     headers.forEach((th, idx) => {
       const btn = th.querySelector('.filter-btn');
       if(!btn) return;
-      const col = btn.getAttribute('data-col');
+      const col = btn.getAttribute('data-filter-for');
       colIndex[col] = idx;
 
-      const menu = th.querySelector('.filter-menu [data-role="filter-options"]');
-      if(!menu) return;
-
+      const dd = th.querySelector('.filter-dropdown');
+      if(!dd) return;
+      dd.innerHTML = `
+        <div class="filter-card">
+          <div class="filter-head">
+            <input type="text" class="form-control form-control-sm filter-search" placeholder="Buscar...">
+          </div>
+          <div class="filter-list" role="group" aria-label="Opções de filtro"></div>
+          <div class="filter-actions">
+            <div class="sort-group" role="group" aria-label="Ordenação">
+              <button type="button" class="btn btn-light btn-sm sort-asc" title="Ordenar A–Z">A–Z</button>
+              <button type="button" class="btn btn-light btn-sm sort-desc" title="Ordenar Z–A">Z–A</button>
+            </div>
+            <div class="cta-group">
+              <button type="button" class="btn btn-primary btn-sm apply">Aplicar</button>
+              <button type="button" class="btn btn-outline-secondary btn-sm clear">Limpar</button>
+            </div>
+          </div>
+          <div class="filter-foot text-muted">Pressione Esc para fechar</div>
+        </div>`;
+      const list = dd.querySelector('.filter-list');
       const valores = [...new Set(Array.from(tabela.tBodies[0].rows).map(r => (r.cells[idx]?.innerText || '').trim()))]
         .sort((a,b)=>a.localeCompare(b,'pt-BR'));
 
       valores.forEach(v => {
-        const id = `${col}-${btoa(unescape(encodeURIComponent(v))).replace(/=/g,'')}`;
-        menu.insertAdjacentHTML('beforeend',
-          `<div class="form-check"><input class="form-check-input" type="checkbox" id="${id}" value="${v}" checked>
-          <label class="form-check-label" for="${id}">${v || '&lt;vazio&gt;'}</label></div>`);
+        const safe = typeof escapeHTML === 'function' ? escapeHTML(v) : v;
+        list.insertAdjacentHTML('beforeend',
+          `<label class="filter-item"><input type="checkbox" value="${safe}" checked><span>${safe || '&lt;vazio&gt;'}</span></label>`);
       });
+
+      window.filterAttachHandlers && window.filterAttachHandlers(dd);
     });
 
     const resetBtn = document.querySelector('[data-reset-filtros]');
     if(resetBtn){
       resetBtn.addEventListener('click', () => {
         Object.keys(filtros).forEach(k => delete filtros[k]);
-        tabela.querySelectorAll('[data-role="filter-options"] input[type="checkbox"]').forEach(i=>i.checked = true);
+        document.querySelectorAll('.filter-dropdown input[type="checkbox"]').forEach(i=>i.checked = false);
         aplicarFiltros();
       });
     }

--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -638,3 +638,95 @@ document.addEventListener('change', (ev) => {
             .catch(() => showToast('Não foi possível salvar o link SGE.', 'danger'));
     }
 });
+
+// Utilitário: abrir/fechar dropdown ancorado ao botão
+function toggleFilter(btn, dropdown, open){
+  const isOpen = open ?? (btn.getAttribute('aria-expanded') !== 'true');
+  btn.setAttribute('aria-expanded', String(isOpen));
+  dropdown.hidden = !isOpen;
+
+  if(isOpen){
+    const rect = btn.getBoundingClientRect();
+    dropdown.style.left = rect.left + window.scrollX + 'px';
+    dropdown.style.top  = rect.bottom + window.scrollY + 'px';
+    const search = dropdown.querySelector('.filter-search');
+    if(search) setTimeout(()=>search.focus(), 0);
+  }
+}
+
+// Fechar com Esc / clique fora
+document.addEventListener('keydown', (e)=>{
+  if(e.key === 'Escape'){
+    document.querySelectorAll('.filter-btn[aria-expanded="true"]').forEach(btn=>{
+      const id = btn.dataset.filterFor;
+      const dd = document.getElementById('dd-'+id);
+      if(dd) toggleFilter(btn, dd, false);
+    });
+  }
+});
+document.addEventListener('click', (e)=>{
+  const openBtn = document.querySelector('.filter-btn[aria-expanded="true"]');
+  if(!openBtn) return;
+  const dd = document.getElementById('dd-'+openBtn.dataset.filterFor);
+  if(!dd) return;
+  if(!openBtn.contains(e.target) && !dd.contains(e.target)){
+    toggleFilter(openBtn, dd, false);
+  }
+});
+
+// Liga os botões
+document.querySelectorAll('.filter-btn').forEach(btn=>{
+  const dd = document.getElementById('dd-'+btn.dataset.filterFor);
+  if(!dd) return;
+  btn.addEventListener('click', ()=> toggleFilter(btn, dd));
+});
+
+// Busca/ordenação/aplicar/limpar – reutiliza funções existentes
+function filterAttachHandlers(dd){
+  const search = dd.querySelector('.filter-search');
+  const list   = dd.querySelector('.filter-list');
+  if(search && list){
+    search.addEventListener('input', ()=>{
+      const q = search.value.toLowerCase();
+      list.querySelectorAll('.filter-item').forEach(li=>{
+        const txt = li.textContent.toLowerCase();
+        li.style.display = txt.includes(q) ? '' : 'none';
+      });
+    });
+  }
+  const apply = dd.querySelector('.apply');
+  const clear = dd.querySelector('.clear');
+  const asc   = dd.querySelector('.sort-asc');
+  const desc  = dd.querySelector('.sort-desc');
+
+  if(asc||desc){
+    const sortFn = (rev=false)=>{
+      const items = Array.from(dd.querySelectorAll('.filter-item'));
+      items.sort((a,b)=>{
+        const ta = a.textContent.trim().toLowerCase();
+        const tb = b.textContent.trim().toLowerCase();
+        return rev ? tb.localeCompare(ta) : ta.localeCompare(tb);
+      });
+      const ul = dd.querySelector('.filter-list');
+      items.forEach(i=>ul.appendChild(i));
+    };
+    asc && asc.addEventListener('click', ()=> sortFn(false));
+    desc && desc.addEventListener('click', ()=> sortFn(true));
+  }
+
+  apply && apply.addEventListener('click', ()=>{
+    const btn = document.querySelector(`.filter-btn[data-filter-for="${dd.id.replace('dd-','')}"]`);
+    const col = btn ? btn.dataset.filterFor : null;
+    const selected = Array.from(dd.querySelectorAll('input[type="checkbox"]:checked')).map(cb=>cb.value);
+    window.aplicarFiltro && window.aplicarFiltro(col, selected);
+    toggleFilter(btn, dd, false);
+  });
+  clear && clear.addEventListener('click', ()=>{
+    dd.querySelectorAll('input[type="checkbox"]').forEach(cb=> cb.checked = false);
+    const btn = document.querySelector(`.filter-btn[data-filter-for="${dd.id.replace('dd-','')}"]`);
+    const col = btn ? btn.dataset.filterFor : null;
+    window.limparFiltro && window.limparFiltro(col);
+  });
+}
+
+window.filterAttachHandlers = filterAttachHandlers;

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
     <link rel="stylesheet" href="css/menu-suspenso.css">
-    <link rel="stylesheet" href="css/components/filter.css">
+    <link rel="stylesheet" href="css/planejamento-trimestral.css">
     <style>
         .table-responsive {
             max-height: 75vh;
@@ -99,397 +99,189 @@
                         <table id="tabela-trimestral" class="table table-striped table-hover mb-0">
                             <thead>
                                 <tr>
-                                    <th data-filterable="true">Data Inicial
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Data Inicial" data-col="data-inicial">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Data Inicial</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="data-inicial">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Data Inicial”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-data-inicial" role="menu" aria-label="Filtro Data Inicial" hidden></div>
                                     </th>
-                                    <th data-filterable="true">Data Final
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Data Final" data-col="data-final">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Data Final</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="data-final">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Data Final”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-data-final" role="menu" aria-label="Filtro Data Final" hidden></div>
                                     </th>
-                                    <th data-filterable="true">Semana
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Semana" data-col="semana">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Semana</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="semana">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Semana”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-semana" role="menu" aria-label="Filtro Semana" hidden></div>
                                     </th>
-                                    <th data-filterable="true">Horário
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Horário" data-col="horario">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Horário</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="horario">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Horário”</span>
+                                            </button>
                                         </div>
-                                      </span>
+        <div class="filter-dropdown" id="dd-horario" role="menu" aria-label="Filtro Horário" hidden></div>
                                     </th>
-                                    <th data-filterable="true">C.H.
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna C.H." data-col="carga-horaria">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">C.H.</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="carga-horaria">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “C.H.”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-carga-horaria" role="menu" aria-label="Filtro C.H." hidden></div>
                                     </th>
-                                    <th data-filterable="true">Modalidade
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Modalidade" data-col="modalidade">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Modalidade</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="modalidade">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Modalidade”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-modalidade" role="menu" aria-label="Filtro Modalidade" hidden></div>
                                     </th>
-                                    <th data-filterable="true">Treinamento
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Treinamento" data-col="treinamento">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Treinamento</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="treinamento">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Treinamento”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-treinamento" role="menu" aria-label="Filtro Treinamento" hidden></div>
                                     </th>
-                                    <th data-filterable="true">CMD
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna CMD" data-col="cmd">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">CMD</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="cmd">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “CMD”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-cmd" role="menu" aria-label="Filtro CMD" hidden></div>
                                     </th>
-                                    <th data-filterable="true">SJB
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna SJB" data-col="sjb">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">SJB</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="sjb">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “SJB”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-sjb" role="menu" aria-label="Filtro SJB" hidden></div>
                                     </th>
-                                    <th data-filterable="true">SAG/TOMBOS
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna SAG/TOMBOS" data-col="sag-tombos">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">SAG/TOMBOS</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="sag-tombos">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “SAG/TOMBOS”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-sag-tombos" role="menu" aria-label="Filtro SAG/TOMBOS" hidden></div>
                                     </th>
-                                    <th data-filterable="true">Instrutor
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Instrutor" data-col="instrutor">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Instrutor</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="instrutor">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Instrutor”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-instrutor" role="menu" aria-label="Filtro Instrutor" hidden></div>
                                     </th>
-                                    <th data-filterable="true">Local
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Local" data-col="local">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Local</span>
+                                            <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="local">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Local”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-local" role="menu" aria-label="Filtro Local" hidden></div>
                                     </th>
-                                    <th data-filterable="true">Obs.
-                                      <span class="filter-scope">
-                                        <div class="dropdown d-inline">
-                                          <button class="filter-btn" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Filtrar coluna Obs." data-col="observacao">
-                                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                                              <path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"></path>
-                                            </svg>
-                                          </button>
-
-                                          <div class="filter-menu dropdown-menu dropdown-menu-end shadow">
-                                            <div class="mb-2">
-                                              <input type="text" class="form-control form-control-sm" placeholder="Buscar..." data-role="filter-search">
-                                            </div>
-
-                                            <div class="mb-2" data-role="filter-options">
-                                              <!-- mantenha/repita aqui os checkboxes existentes da coluna (gerados como hoje) -->
-                                            </div>
-
-                                            <div class="divider"></div>
-
-                                            <div class="filter-actions">
-                                              <button class="btn btn-primary btn-sm"  data-action="apply">Aplicar</button>
-                                              <button class="btn btn-outline-secondary btn-sm" data-action="clear">Limpar</button>
-                                              <button class="btn btn-outline-primary btn-sm ms-auto" data-action="sort-asc">A–Z</button>
-                                              <button class="btn btn-outline-primary btn-sm" data-action="sort-desc">Z–A</button>
-                                            </div>
-                                          </div>
+                                    <th scope="col" data-filterable="true">
+                                        <div class="th-content">
+                                            <span class="th-label">Obs.</span>
+        <button class="filter-btn" type="button"
+                                                aria-haspopup="menu" aria-expanded="false"
+                                                data-filter-for="observacao">
+                                                <svg class="icon" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" fill="currentColor"/>
+                                                </svg>
+                                                <span class="sr-only">Filtrar “Obs.”</span>
+                                            </button>
                                         </div>
-                                      </span>
+                                        <div class="filter-dropdown" id="dd-observacao" role="menu" aria-label="Filtro Obs." hidden></div>
                                     </th>
-                                    <th data-no-filter="true" class="text-end">Ações</th>
+                                    <th scope="col" data-no-filter="true" class="text-end">Ações</th>
                                 </tr>
                             </thead>
                             <tbody id="planejamento-tbody"></tbody>
@@ -623,7 +415,6 @@
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>
     <script src="js/filtros-tabela.js"></script>
-    <script src="js/filters-ui.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         window.inicializarFiltrosTabela?.('#tabela-trimestral');


### PR DESCRIPTION
## Summary
- Moderniza cabeçalhos da tabela com botões de filtro acessíveis e dropdown dinâmico
- Adiciona folha de estilo `planejamento-trimestral.css` com tokens e ajustes tipográficos
- Atualiza scripts de filtros para novo layout e interação sem dependências externas

## Testing
- `pytest`
- `pre-commit run --files src/static/planejamento-trimestral.html src/static/css/planejamento-trimestral.css src/static/js/filtros-tabela.js src/static/js/planejamento-trimestral.js` *(fails: Installing environment for https://github.com/pre-commit/mirrors-eslint...)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6981ac88323b89023e5af4bd998