### PR TITLE
Improve filter dropdown accessibility and contrast

### DIFF
--- a/src/static/css/planejamento-trimestral.css
+++ b/src/static/css/planejamento-trimestral.css
@@ -24,7 +24,7 @@ html, body {
 .th-content{
   display: flex; align-items: center; justify-content: space-between; gap: .5rem;
 }
-.th-label{ font-weight: 600; }
+.th-title{ font-weight: 600; }
 
 /* Botão filtro clean */
 .filter-btn{
@@ -94,3 +94,78 @@ html, body {
 .actions .btn, .table .btn-icon{
   min-width: 32px; width: 32px; height: 32px; padding: 0; display:inline-flex; align-items:center; justify-content:center;
 }
+
+/* Contraste geral */
+:root{
+  --fg: #111827;          /* slate-900 */
+  --fg-muted: #374151;     /* slate-700 */
+  --bg: #F9FAFB;           /* slate-50 */
+  --border: #E5E7EB;       /* slate-200 */
+  --focus: #2563EB;        /* blue-600 */
+  --elev: 9999;            /* z-index p/ overlays */
+}
+
+html, body{
+  color: var(--fg);
+  background: var(--bg);
+}
+
+table{
+  color: var(--fg);
+}
+
+table thead th{
+  color: var(--fg);
+  background: white;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+table tbody td{
+  color: var(--fg-muted);
+  border-bottom: 1px solid var(--border);
+}
+
+a, button{
+  color: var(--fg);
+}
+
+::placeholder{
+  color: #6B7280; /* slate-500, visível sobre bg claro */
+}
+
+/* Acessibilidade visual dos hints */
+.sr-only, .visually-hidden{
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}
+
+/* Grupo do botão de filtros */
+.filter-group{
+  position: relative; /* âncora para o menu */
+  display: inline-block;
+}
+
+/* Dropdown ancorado (não fixo) */
+.dropdown-menu{
+  position: absolute;
+  inset: auto auto auto 0;   /* top/left definidos via JS */
+  min-width: 240px;
+  max-height: 60vh;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 20px rgba(0,0,0,.08);
+  z-index: var(--elev);
+  padding: .75rem;
+}
+
+/* Estado visível */
+.dropdown-menu[hidden]{ display: none !important; }
+
+/* Evitar textos avulsos sobre o TH */
+th .filter-hint{ display: none !important; }

--- a/src/static/js/filters.js
+++ b/src/static/js/filters.js
@@ -1,0 +1,81 @@
+(function(){
+  const btn = document.getElementById('btnFiltros');
+  const menu = document.getElementById('menuFiltros');
+
+  if(!btn || !menu) return;
+
+  const place = () => {
+    const bcr = btn.getBoundingClientRect();
+    const scrollX = window.scrollX || document.documentElement.scrollLeft;
+    const scrollY = window.scrollY || document.documentElement.scrollTop;
+
+    // posição preferida: abaixo e alinhado à esquerda
+    let top = bcr.bottom + scrollY + 8;  // 8px gap
+    let left = bcr.left + scrollX;
+
+    // manter dentro da janela
+    const menuWidth = menu.offsetWidth || 280;
+    const menuHeight = menu.offsetHeight || 200;
+    const vw = document.documentElement.clientWidth;
+    const vh = document.documentElement.clientHeight;
+
+    if (left + menuWidth > scrollX + vw - 8) {
+      left = Math.max(scrollX + 8, (bcr.right + scrollX) - menuWidth);
+    }
+    if (top + menuHeight > scrollY + vh - 8) {
+      // se faltar espaço abaixo, abre acima
+      const above = (bcr.top + scrollY) - menuHeight - 8;
+      if (above > scrollY + 8) top = above;
+    }
+
+    menu.style.left = `${left}px`;
+    menu.style.top  = `${top}px`;
+  };
+
+  const open = () => {
+    menu.hidden = false;
+    btn.setAttribute('aria-expanded', 'true');
+    place();
+    document.addEventListener('click', onDocClick, { capture: true });
+    window.addEventListener('resize', place);
+    window.addEventListener('scroll', place, { passive: true });
+  };
+
+  const close = () => {
+    menu.hidden = true;
+    btn.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', onDocClick, { capture: true });
+    window.removeEventListener('resize', place);
+    window.removeEventListener('scroll', place, { passive: true });
+  };
+
+  const onDocClick = (e) => {
+    if (menu.contains(e.target) || btn.contains(e.target)) return;
+    close();
+  };
+
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    (menu.hidden) ? open() : close();
+  });
+
+  // acessibilidade: fechar com Esc
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !menu.hidden) close();
+  });
+
+  // Sanitizar cabeçalhos: remover textos "Filtrar ..." se existirem
+  document.querySelectorAll('table thead th').forEach(th => {
+    const text = th.textContent.trim();
+    if (/^Filtrar\s+/.test(text)) {
+      // mantém apenas o título principal se houver span com .th-title; caso contrário,
+      // remove o prefixo "Filtrar ...".
+      const titleEl = th.querySelector('.th-title');
+      if (titleEl) {
+        th.childNodes.forEach(n => { if (n.nodeType === Node.TEXT_NODE) n.textContent = ''; });
+      } else {
+        th.textContent = text.replace(/^Filtrar\s+“?.+?”?\s*/i, '').trim();
+      }
+    }
+  });
+})();

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -92,6 +92,13 @@
             </button>
         </div>
 
+        <div class="filter-group">
+            <button id="btnFiltros" class="btn btn-filter" aria-expanded="false" aria-controls="menuFiltros">
+                Filtros
+            </button>
+            <div id="menuFiltros" class="dropdown-menu" role="menu" hidden></div>
+        </div>
+
         <div id="planejamento-container" class="mt-4">
             <div class="card mb-4">
                 <div class="card-body p-0">
@@ -101,7 +108,7 @@
                                 <tr>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Data Inicial</span>
+                                            <span class="th-title">Data Inicial</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="data-inicial">
@@ -115,7 +122,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Data Final</span>
+                                            <span class="th-title">Data Final</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="data-final">
@@ -129,7 +136,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Semana</span>
+                                            <span class="th-title">Semana</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="semana">
@@ -143,7 +150,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Horário</span>
+                                            <span class="th-title">Horário</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="horario">
@@ -157,7 +164,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">C.H.</span>
+                                            <span class="th-title">C.H.</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="carga-horaria">
@@ -171,7 +178,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Modalidade</span>
+                                            <span class="th-title">Modalidade</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="modalidade">
@@ -185,7 +192,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Treinamento</span>
+                                            <span class="th-title">Treinamento</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="treinamento">
@@ -199,7 +206,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">CMD</span>
+                                            <span class="th-title">CMD</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="cmd">
@@ -213,7 +220,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">SJB</span>
+                                            <span class="th-title">SJB</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="sjb">
@@ -227,7 +234,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">SAG/TOMBOS</span>
+                                            <span class="th-title">SAG/TOMBOS</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="sag-tombos">
@@ -241,7 +248,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Instrutor</span>
+                                            <span class="th-title">Instrutor</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="instrutor">
@@ -255,7 +262,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Local</span>
+                                            <span class="th-title">Local</span>
                                             <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="local">
@@ -269,7 +276,7 @@
                                     </th>
                                     <th scope="col" data-filterable="true">
                                         <div class="th-content">
-                                            <span class="th-label">Obs.</span>
+                                            <span class="th-title">Obs.</span>
         <button class="filter-btn" type="button"
                                                 aria-haspopup="menu" aria-expanded="false"
                                                 data-filter-for="observacao">
@@ -414,6 +421,7 @@
     <script src="js/menu-suspenso.js"></script>
     <script src="/js/utils/datas.js"></script>
     <script src="/js/planejamento-trimestral.js"></script>
+    <script src="js/filters.js"></script>
     <script src="js/filtros-tabela.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- enhance global color variables for accessible contrast and placeholders
- anchor filter dropdown to its trigger and clean up header filter hints
- add JS to reposition dropdown on scroll/resize and close on outside click or Esc

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbf7f0888832388d152b9bf12f413