### PR TITLE
Improve quarterly planning header and filter dropdown

### DIFF
--- a/src/static/css/planejamento-trimestral.css
+++ b/src/static/css/planejamento-trimestral.css
@@ -1,0 +1,59 @@
+:root{
+  --fiemg-blue:#164194;
+  --senai-orange:#F3B54E;
+}
+
+/* Cabeçalho */
+.pt-header{
+  display:flex; align-items:center; justify-content:space-between;
+  gap:12px; flex-wrap:nowrap; margin:12px 0 8px;
+}
+.pt-title{
+  margin:0; font-weight:600; color:#164194;
+  font-family: "Exo 2", Calibri, system-ui, sans-serif;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+}
+.pt-actions{ display:flex; align-items:center; gap:8px; flex:0 0 auto; }
+
+/* Visual do botão de filtro */
+.btn-filter{
+  display:inline-flex; align-items:center; gap:8px;
+  height:32px; padding:0 10px; border-radius:9999px;
+  background:var(--fiemg-blue); color:#fff; border:1px solid transparent;
+  font-weight:600; line-height:1; font-size:14px;
+  font-family:"Exo 2", Calibri, system-ui, sans-serif;
+}
+.btn-filter .icon{ font-size:14px; line-height:1; }
+.btn-filter:focus-visible{ outline:2px solid var(--senai-orange); outline-offset:2px; }
+.btn-filter:hover{ filter:brightness(0.95); }
+@media (max-width:420px){ .btn-filter .label{ display:none; } }
+
+/* Container do dropdown */
+.filter-dropdown{
+  position:absolute; z-index:1050; min-width:280px; width:360px; max-width:92vw;
+  background:#fff; border:1px solid #E6EAF0; border-radius:12px;
+  box-shadow:0 10px 24px rgba(0,0,0,.08);
+  font-family:"Exo 2", Calibri, system-ui, sans-serif;
+}
+
+/* Barra de busca sticky */
+.fd-search{ position:sticky; top:0; background:#fff; padding:10px 12px; border-bottom:1px solid #EEF2F6; border-top-left-radius:12px; border-top-right-radius:12px; }
+.fd-input{
+  width:100%; height:32px; padding:0 10px; border:1px solid #D9DEE7; border-radius:8px; font-size:14px;
+}
+
+/* Lista rolável */
+.fd-list{ max-height:320px; overflow:auto; padding:8px 12px; }
+
+/* Item com checkbox alinhado */
+.fd-item{ display:flex; align-items:flex-start; gap:8px; padding:6px 0; }
+.fd-check{ width:16px; height:16px; margin-top:2px; accent-color:var(--fiemg-blue); }
+.fd-label{ line-height:1.25; font-size:14px; color:#1f2937; }
+
+/* Rodapé */
+.fd-footer{ display:flex; justify-content:flex-end; gap:8px; padding:10px 12px; border-top:1px solid #EEF2F6; }
+.fd-apply, .fd-clear{
+  height:32px; padding:0 10px; border-radius:8px; border:1px solid #E6EAF0; background:#fff; font-weight:600; font-size:13px;
+}
+.fd-apply{ background:var(--fiemg-blue); color:#fff; border-color:var(--fiemg-blue); }
+.fd-apply:focus-visible{ outline:2px solid var(--senai-orange); outline-offset:2px; }

--- a/src/static/js/planejamento-trimestral.js
+++ b/src/static/js/planejamento-trimestral.js
@@ -638,3 +638,61 @@ document.addEventListener('change', (ev) => {
             .catch(() => showToast('Não foi possível salvar o link SGE.', 'danger'));
     }
 });
+
+// --- Dropdown de Filtros no cabeçalho ---
+document.addEventListener('DOMContentLoaded', () => {
+    const btnFiltros = document.getElementById('btn-filtros');
+    const dd = document.getElementById('dropdown-filtros');
+    if (!btnFiltros || !dd) return;
+    let ddOpen = false;
+
+    function openDropdown(){
+        dd.hidden = false;
+        ddOpen = true;
+        positionDropdown();
+        btnFiltros.setAttribute('aria-expanded','true');
+    }
+
+    function closeDropdown(){
+        dd.hidden = true;
+        ddOpen = false;
+        btnFiltros.setAttribute('aria-expanded','false');
+    }
+
+    function positionDropdown(){
+        const r = btnFiltros.getBoundingClientRect();
+        const ddRect = dd.getBoundingClientRect();
+        const viewportW = document.documentElement.clientWidth;
+        const scrollY = window.scrollY || document.documentElement.scrollTop;
+        const scrollX = window.scrollX || document.documentElement.scrollLeft;
+        const left = Math.min(
+            r.right - ddRect.width + scrollX,
+            viewportW - ddRect.width + scrollX - 8
+        );
+        const top = r.bottom + scrollY + 8;
+        dd.style.left = `${Math.max(8 + scrollX, left)}px`;
+        dd.style.top = `${top}px`;
+    }
+
+    btnFiltros.addEventListener('click', (e) => {
+        e.stopPropagation();
+        ddOpen ? closeDropdown() : openDropdown();
+    });
+
+    document.addEventListener('click', (e) => {
+        if (!ddOpen) return;
+        if (!dd.contains(e.target) && e.target !== btnFiltros) closeDropdown();
+    });
+
+    window.addEventListener('resize', () => { if (ddOpen) positionDropdown(); });
+    window.addEventListener('scroll', () => { if (ddOpen) positionDropdown(); }, { passive:true });
+
+    const q = document.getElementById('fd-q');
+    q?.addEventListener('input', () => {
+        const term = q.value.trim().toLowerCase();
+        dd.querySelectorAll('.fd-item').forEach(it => {
+            const txt = it.querySelector('.fd-label')?.textContent?.toLowerCase() || '';
+            it.style.display = txt.includes(term) ? '' : 'none';
+        });
+    });
+});

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -10,6 +10,7 @@
     <link href="/css/styles.css" rel="stylesheet">
     <link rel="stylesheet" href="css/menu-suspenso.css">
     <link rel="stylesheet" href="css/components/filter.css">
+    <link rel="stylesheet" href="css/planejamento-trimestral.css">
     <style>
         .table-responsive {
             max-height: 75vh;
@@ -85,12 +86,39 @@
     </aside>
 
     <main class="container-fluid py-4" id="aba-planejamento-trimestral">
-        <div class="page-header">
-            <h1 class="mb-0">Planejamento Trimestral</h1>
-            <button id="btn-adicionar-planejamento" class="btn btn-primary">
-                <i class="bi bi-plus-circle me-2"></i>Adicionar
-            </button>
-        </div>
+        <!-- Cabeçalho -->
+        <header class="pt-header">
+            <h1 class="pt-title">Planejamento Trimestral</h1>
+
+            <div class="pt-actions">
+                <!-- Botão Filtros (novo visual) -->
+                <button id="btn-filtros" class="btn btn-filter" type="button" aria-expanded="false" aria-controls="dropdown-filtros">
+                    <span class="icon" aria-hidden="true">🔎</span>
+                    <span class="label">Filtros</span>
+                </button>
+
+                <!-- Dropdown dos filtros -->
+                <div id="dropdown-filtros" class="filter-dropdown" role="dialog" aria-label="Filtros" hidden>
+                    <div class="fd-search">
+                        <input type="text" id="fd-q" class="fd-input" placeholder="Buscar..." aria-label="Buscar nos filtros">
+                    </div>
+
+                    <div class="fd-list" id="fd-list">
+                        <!-- Itens de filtro inseridos via JS -->
+                    </div>
+
+                    <div class="fd-footer">
+                        <button type="button" class="fd-apply">Aplicar</button>
+                        <button type="button" class="fd-clear">Limpar</button>
+                    </div>
+                </div>
+
+                <!-- Botão já existente (ex.: Adicionar) permanece ao lado -->
+                <button id="btn-adicionar-planejamento" class="btn btn-primary">
+                    <i class="bi bi-plus-circle me-2"></i>Adicionar
+                </button>
+            </div>
+        </header>
 
         <div id="planejamento-container" class="mt-4">
             <div class="card mb-4">


### PR DESCRIPTION
## Summary
- keep title and action buttons on one line using new flex header
- add compact brand-styled filter button with anchored dropdown
- implement positioning, search and toggling logic for filter menu

## Testing
- `pytest` *(interrupted after 67 tests; remaining tests not executed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad05d2cd988323b7c4ca0ec9160f01