### PR TITLE
refine header layout and filter styles for planning page

### DIFF
--- a/src/static/css/filtros-tabela.css
+++ b/src/static/css/filtros-tabela.css
@@ -15,3 +15,67 @@ th { position: relative; }
 .filter-menu .btn {
   border: 1px solid #ddd; background: #f7f7f7; padding: 4px 8px; border-radius: 4px; cursor: pointer;
 }
+
+/* DESCRIÇÃO: Este código aplica um estilo secundário e moderno ao botão, com fundo branco, borda e texto na cor principal da marca, além de cantos arredondados e preenchimento reduzido. */
+#filter-button {
+  background-color: #ffffff; /* Fundo branco para um visual limpo */
+  border: 1px solid #005a9e; /* Borda com a cor azul do SENAI */
+  color: #005a9e; /* Texto na cor azul do SENAI */
+  padding: 6px 16px; /* Reduz o preenchimento para um botão menor */
+  font-size: 14px;
+  font-weight: bold;
+  border-radius: 20px; /* Cantos arredondados */
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px; /* Adiciona um espaço entre o ícone e o texto "Filtros" */
+  transition: all 0.3s ease; /* Adiciona uma transição suave para o efeito hover */
+}
+
+/* DOCUMENTAÇÃO: O pseudo-seletor :hover inverte as cores do botão quando o usuário passa o mouse sobre ele, melhorando o feedback visual. */
+#filter-button:hover {
+  background-color: #005a9e;
+  color: #ffffff;
+}
+
+/* DESCRIÇÃO: Melhora a aparência geral do menu suspenso com espaçamento interno, sombra e bordas suaves. */
+.filter-dropdown {
+  padding: 16px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  border: 1px solid #e0e0e0;
+}
+
+/* DESCRIÇÃO: Organiza os grupos de filtros (Status, Ano, etc.) com margens adequadas. */
+.filter-dropdown .filter-group {
+  margin-bottom: 16px;
+}
+.filter-dropdown .filter-group:last-child {
+  margin-bottom: 0;
+}
+
+/* DESCRIÇÃO: Estiliza o título de cada grupo de filtros. */
+.filter-dropdown h4 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 1rem;
+  color: #333;
+}
+
+/* DESCRIÇÃO: Este é o ajuste principal. O Flexbox alinha verticalmente o checkbox e o texto dentro de cada opção do filtro. */
+.filter-dropdown label {
+  display: flex;
+  align-items: center; /* Alinha os itens verticalmente */
+  margin-bottom: 10px;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+/* DESCRIÇÃO: Padroniza o tamanho do checkbox e adiciona um espaçamento à direita para separá-lo do texto. */
+.filter-dropdown label input[type="checkbox"] {
+  margin: 0 10px 0 0; /* Zera margens e adiciona 10px à direita */
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0; /* Impede que o checkbox seja "espremido" em telas menores */
+}
+

--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -55,6 +55,14 @@ i.bi {
   flex: 1;
 }
 
+/* DESCRIÇÃO: Este código organiza o contêiner do cabeçalho para que seus itens (título e botão) fiquem em linha, com alinhamento vertical centralizado. */
+.header-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
 .page-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- align header items with flexbox container
- restyle filter button and dropdown for clearer layout

## Testing
- `pre-commit run --files src/static/css/styles.css src/static/css/filtros-tabela.css`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad05c12efc8323946fb4f7adf9a076