### PR TITLE
Refine filter controls on quarterly planning page

### DIFF
--- a/src/static/css/components/filter.css
+++ b/src/static/css/components/filter.css
@@ -13,14 +13,14 @@
 /* Tipografia do componente (fallback sem impactar o site todo) */
 .filter-scope{ font-family: "Exo 2", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif; }
 
-/* Botão de filtro “ghost” minimalista */
+/* Botão de filtro compacto e simples */
 .filter-btn{
-  --size: 28px;
+  --size: 24px;
   width: var(--size);
   height: var(--size);
   display: inline-grid;
   place-items: center;
-  border-radius: 8px;
+  border-radius: 4px;
   border: 1px solid var(--neutral-300);
   background: var(--white);
   padding: 0;
@@ -52,3 +52,29 @@
 .filter-menu .btn-outline-primary:hover{ background: var(--brand-blue-500); color: var(--white); }
 .filter-menu .btn-outline-secondary{ color: var(--neutral-700); }
 .filter-menu .divider{ height:1px; background: var(--neutral-300); margin:.5rem 0; }
+
+/* Ajustes para cabeçalhos com botão de filtro */
+th[data-filterable="true"]{
+  white-space: nowrap;
+}
+th[data-filterable="true"] .filter-scope{
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: .25rem;
+}
+
+/* Alinhamento do menu suspenso de filtros */
+.filter-menu .form-check{
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+  margin-bottom: .25rem;
+}
+.filter-menu .form-check-input{
+  margin-top: 0;
+  flex-shrink: 0;
+}
+.filter-menu .form-check-label{
+  margin-bottom: 0;
+  flex-grow: 1;
+}

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -22,6 +22,13 @@
         .hidden-col {
             display: none;
         }
+        .page-header {
+            flex-wrap: nowrap;
+            gap: .5rem;
+        }
+        #btn-adicionar-planejamento {
+            white-space: nowrap;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- prevent header button from wrapping on quarterly planning page
- simplify filter button and align dropdown options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad093c49bc8323ae6054b8d4a3a924