### PR TITLE
Reduce filter button size

### DIFF
--- a/src/static/css/components/filter.css
+++ b/src/static/css/components/filter.css
@@ -25,8 +25,8 @@
 .filter-toggle,
 .filtro-btn,
 .filter-btn {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   padding: 0;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- shrink filter button to 16px while keeping layout centered

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adaa2bced4832387a9cc9d90256996