### PR TITLE
fix: load filter stylesheet and normalize icon size

### DIFF
--- a/src/static/css/components/filter.css
+++ b/src/static/css/components/filter.css
@@ -50,12 +50,19 @@
 .filter-btn[aria-expanded="true"]{ background: var(--brand-blue-700); color: var(--white); }
 
 /* Ícone do funil centralizado e proporcional */
-.filtro-btn i,
 .filtro-btn svg,
-.filter-toggle i,
 .filter-toggle svg,
-.filter-btn i,
 .filter-btn svg {
+  display: block;
+  width: 12px;
+  height: 12px;
+  color: currentColor;
+  line-height: 1;
+}
+
+.filtro-btn i,
+.filter-toggle i,
+.filter-btn i {
   display: block;
   font-size: 12px;
   line-height: 1;

--- a/src/static/planejamento-trimestral.html
+++ b/src/static/planejamento-trimestral.html
@@ -9,7 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
     <link rel="stylesheet" href="css/menu-suspenso.css">
-    <link rel="stylesheet" href="css/components/filter.css">
+    <link rel="stylesheet" href="/css/components/filter.css">
     <style>
         .table-responsive {
             max-height: 75vh;


### PR DESCRIPTION
## Summary
- correct filter icon CSS so SVG inherits current color and fixed size
- use absolute path when loading filter.css on planning page

## Testing
- `pytest`
- `python3 -m http.server 8000 --directory src/static &` *(for Playwright test)*
- `node test_filter_icon.js` *(ensured filter SVG centered, width=0 height=12 offsets=0)*

------
https://chatgpt.com/codex/tasks/task_e_68adaea290148323b2fbe392213ef319