### PR TITLE
Refine filter button styling on planejamento trimestral

### DIFF
--- a/src/static/css/components/filter.css
+++ b/src/static/css/components/filter.css
@@ -25,8 +25,8 @@
 .filter-toggle,
 .filtro-btn,
 .filter-btn {
-  width: 8px;
-  height: 8px;
+  width: 16px;
+  height: 16px;
   padding: 0;
   display: inline-flex;
   align-items: center;

--- a/src/static/css/filtros-tabela.css
+++ b/src/static/css/filtros-tabela.css
@@ -1,16 +1,23 @@
 th { position: relative; }
 .filtro-btn {
     background-color: var(--white);
-    border: 1px solid var(--gray-200);
-    border-radius: 8px;
-    padding: 8px;
+    border: 1px solid var(--brand-gray-300);
+    border-radius: 4px;
+    padding: 0;
     cursor: pointer;
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
     display: flex;
     align-items: center;
     justify-content: center;
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    color: var(--brand-primary);
+}
+
+.filtro-btn svg {
+    width: 12px;
+    height: 12px;
+    display: block;
 }
 .filter-toggle {
   margin-left: .5rem; border: 1px solid #ddd; background: #fff; cursor: pointer;


### PR DESCRIPTION
## Summary
- shrink table filter buttons for a more compact layout
- ensure funnel icon is visible and centered in filter buttons

## Testing
- `pre-commit run --files src/static/css/filtros-tabela.css src/static/css/components/filter.css`


------
https://chatgpt.com/codex/tasks/task_e_68adb3c2e65c83239216280e8aa63395