### PR TITLE
refactor scheduler startup and safe start command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ ADMIN_USERNAME=<definir_em_producao>
 # Redis connection URL for rate limiting and token revocation
 REDIS_URL=redis://localhost:6379/0
 
+# Background scheduler configuration
+SCHEDULER_ENABLED=1
+NOTIFICACAO_INTERVALO_MINUTOS=60
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD curl -f http://localhos
 
 # Comando para iniciar a aplicação
 # Executa as migrações do banco de dados e inicia o servidor Gunicorn
-CMD sh -c "flask --app src.main db upgrade && gunicorn --factory -b 0.0.0.0:${PORT:-8080} src.main:create_app"
+CMD ["/bin/bash", "-lc", "SCHEDULER_ENABLED=0 flask --app src.main db upgrade && exec gunicorn 'src.main:create_app()' --bind 0.0.0.0:${PORT:-8080} --workers 1 --threads 1 --max-requests 200 --max-requests-jitter 50 --timeout 30 --graceful-timeout 30 --keep-alive 2 --log-level info"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Todas as variáveis disponíveis estão listadas em `.env.example`.
 
 7. Um scheduler baseado em APScheduler gera periodicamente lembretes de
    agendamentos. O intervalo em minutos pode ser ajustado pela variável de
-   ambiente `NOTIFICACAO_INTERVALO_MINUTOS` (padrão: `60`).
+   ambiente `NOTIFICACAO_INTERVALO_MINUTOS` (padrão: `60`). Defina
+   `SCHEDULER_ENABLED=0` para desativá-lo completamente.
 
 ## Segurança
 

--- a/src/services/scheduler.py
+++ b/src/services/scheduler.py
@@ -1,0 +1,53 @@
+import logging
+import os
+from typing import Optional
+
+from flask import Flask
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from src.services.notificacao_service import (
+    criar_notificacoes_agendamentos_proximos,
+)
+
+scheduler = BackgroundScheduler()
+_scheduler_started = False
+_app: Optional[Flask] = None
+
+
+def job_notificacoes_agendamentos() -> None:
+    """Job de criação periódica de notificações."""
+    global _app
+    if _app is None:
+        return
+    with _app.app_context():
+        criar_notificacoes_agendamentos_proximos()
+
+
+def iniciar_scheduler(app) -> None:
+    """Inicia o scheduler uma única vez por processo."""
+    global _scheduler_started, _app
+
+    if os.getenv("SCHEDULER_ENABLED", "1") in {"0", "false", "False"}:
+        logging.info("Scheduler desabilitado via SCHEDULER_ENABLED=0")
+        return
+
+    if _scheduler_started:
+        logging.debug("Scheduler já iniciado; ignorando nova chamada")
+        return
+
+    _app = app
+    intervalo = int(os.getenv("NOTIFICACAO_INTERVALO_MINUTOS", "60"))
+
+    scheduler.add_job(
+        job_notificacoes_agendamentos,
+        "interval",
+        minutes=intervalo,
+        id="notificacoes_agendamentos",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+
+    scheduler.start()
+    _scheduler_started = True
+    logging.info("Scheduler iniciado com intervalo de %s minutos", intervalo)

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 echo "[start] Running DB migrations..."
-flask --app src.main db upgrade
+SCHEDULER_ENABLED=0 flask --app src.main db upgrade
 echo "[start] Starting Gunicorn..."
-exec gunicorn -c gunicorn.conf.py "src.main:create_app()"
+exec gunicorn "src.main:create_app()" \
+  --bind 0.0.0.0:${PORT:-8080} \
+  --workers 1 \
+  --threads 1 \
+  --max-requests 200 \
+  --max-requests-jitter 50 \
+  --timeout 30 \
+  --graceful-timeout 30 \
+  --keep-alive 2 \
+  --log-level info


### PR DESCRIPTION
## Summary
- add dedicated scheduler service with single-start guard and env flag
- disable scheduler during migrations and standardize gunicorn options
- document scheduler controls in README and env example

## Testing
- `pre-commit run --files src/services/scheduler.py src/main.py start.sh Dockerfile README.md .env.example`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae35476eb08323a602428c65a62f45