### PR TITLE
chore: configure gunicorn workers and lock scheduler

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,11 +1,15 @@
-import multiprocessing
 import os
 
 # Bind to host/port pulled from PORT env var for flexibility
 bind = f"0.0.0.0:{os.getenv('PORT', '8080')}"
 
-# Allow customizing worker count via env while providing sane default
-workers = int(os.getenv("GUNICORN_WORKERS", multiprocessing.cpu_count() * 2 + 1))
+# Worker settings tuned to avoid OOM and excessive concurrency
+workers = int(os.getenv("WEB_CONCURRENCY", "1"))
+threads = int(os.getenv("GTHREADS", "1"))
+worker_class = os.getenv("WORKER_CLASS", "sync")
 
-# Set a reasonable default timeout; configurable through env var
-timeout = int(os.getenv("GUNICORN_TIMEOUT", "120"))
+timeout = 60
+keepalive = 2
+max_requests = 600
+max_requests_jitter = 60
+preload_app = False

--- a/src/main.py
+++ b/src/main.py
@@ -139,6 +139,7 @@ def create_default_recursos(app):
 
 def create_app():
     """Fábrica de aplicação usada pelo Flask."""
+    logging.info("Iniciando a criação da aplicação Flask...")
     app = Flask(__name__, static_url_path='', static_folder='static')
 
     env = os.getenv('FLASK_ENV', 'development').lower()
@@ -233,7 +234,9 @@ def create_app():
     app.register_blueprint(auth_bp)
 
     # Inicia scheduler para notificações
-    iniciar_scheduler(app)
+    with app.app_context():
+        if os.getenv("ENABLE_SCHEDULER", "1") == "1":
+            iniciar_scheduler(app)
 
 
     @app.route('/')
@@ -252,11 +255,10 @@ def create_app():
     # A inicializacao do banco (migracoes e dados padrao) deve ser executada
     # separadamente durante o processo de deploy.
 
+    logging.info("Aplicação Flask criada com sucesso.")
     return app
 try:
-    logging.info("Iniciando a criação da aplicação Flask...")
     app = create_app()
-    logging.info("Aplicação Flask criada com sucesso.")
 except Exception as e:
     logging.error("!!!!!! FALHA CRÍTICA AO INICIAR A APLICAÇÃO !!!!!!")
     logging.error(f"Erro: {e}")

--- a/src/services/scheduler.py
+++ b/src/services/scheduler.py
@@ -1,3 +1,4 @@
+import atexit
 import logging
 import os
 from typing import Optional
@@ -5,12 +6,17 @@ from typing import Optional
 from flask import Flask
 from apscheduler.schedulers.background import BackgroundScheduler
 
+try:  # pragma: no cover - fcntl may not be available on all platforms
+    import fcntl  # type: ignore
+except Exception:  # pragma: no cover - fallback when fcntl is absent
+    fcntl = None  # type: ignore
+
 from src.services.notificacao_service import (
     criar_notificacoes_agendamentos_proximos,
 )
 
-scheduler = BackgroundScheduler()
-_scheduler_started = False
+_scheduler: Optional[BackgroundScheduler] = None
+_lock_file = None
 _app: Optional[Flask] = None
 
 
@@ -23,31 +29,53 @@ def job_notificacoes_agendamentos() -> None:
         criar_notificacoes_agendamentos_proximos()
 
 
+def _shutdown_scheduler() -> None:
+    global _scheduler, _lock_file
+    if _scheduler:
+        _scheduler.shutdown()
+        _scheduler = None
+    if fcntl and _lock_file:
+        try:
+            fcntl.flock(_lock_file, fcntl.LOCK_UN)
+        finally:
+            _lock_file.close()
+            _lock_file = None
+
+
 def iniciar_scheduler(app) -> None:
     """Inicia o scheduler uma única vez por processo."""
-    global _scheduler_started, _app
+    global _scheduler, _app, _lock_file
 
-    if os.getenv("SCHEDULER_ENABLED", "1") in {"0", "false", "False"}:
-        logging.info("Scheduler desabilitado via SCHEDULER_ENABLED=0")
-        return
-
-    if _scheduler_started:
+    if _scheduler is not None:
         logging.debug("Scheduler já iniciado; ignorando nova chamada")
         return
+
+    if fcntl:
+        try:
+            _lock_file = open("/tmp/apscheduler.lock", "w")
+            fcntl.flock(_lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            logging.debug("Outra instância do scheduler já está em execução")
+            _lock_file = None
+            return
+    else:
+        logging.debug("fcntl não disponível; prosseguindo sem lock")
 
     _app = app
     intervalo = int(os.getenv("NOTIFICACAO_INTERVALO_MINUTOS", "60"))
 
-    scheduler.add_job(
+    _scheduler = BackgroundScheduler()
+    _scheduler.add_job(
         job_notificacoes_agendamentos,
         "interval",
         minutes=intervalo,
-        id="notificacoes_agendamentos",
+        id="iniciar_scheduler_job",
         replace_existing=True,
         max_instances=1,
         coalesce=True,
+        misfire_grace_time=300,
     )
 
-    scheduler.start()
-    _scheduler_started = True
+    _scheduler.start()
+    atexit.register(_shutdown_scheduler)
     logging.info("Scheduler iniciado com intervalo de %s minutos", intervalo)


### PR DESCRIPTION
## Summary
- limit gunicorn workers and threads to avoid OOM
- protect scheduler startup with file lock and single instance
- initialize scheduler conditionally inside app factory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae380585c48323bea81c15e1c3bb1f