### PR TITLE
Fix turno persistence in base data schedule management

### DIFF
--- a/src/routes/planejamento/basedados.py
+++ b/src/routes/planejamento/basedados.py
@@ -9,6 +9,7 @@ from src.models.planejamento import (
     CargaHoraria,
     PublicoAlvo,
     PlanejamentoTreinamento,
+    TurnoEnum,
 )
 
 basedados_bp = Blueprint(
@@ -91,7 +92,11 @@ def create_item_generico(tipo):
         turno = data.get("turno")
         if not turno:
             return jsonify({"erro": "O campo 'turno' é obrigatório"}), 400
-        item = model(nome=nome, turno=turno)
+        try:
+            turno_enum = TurnoEnum(turno)
+        except ValueError:
+            return jsonify({"erro": "Turno inválido"}), 400
+        item = model(nome=nome, turno=turno_enum)
     else:
         item = model(nome=nome)
     db.session.add(item)
@@ -119,8 +124,12 @@ def update_item_generico(tipo, item_id):
     if tipo == "treinamento":
         item.carga_horaria = data.get("carga_horaria")
     elif tipo == "horario":
-        if data.get("turno"):
-            item.turno = data.get("turno")
+        turno_valor = data.get("turno")
+        if turno_valor:
+            try:
+                item.turno = TurnoEnum(turno_valor)
+            except ValueError:
+                return jsonify({"erro": "Turno inválido"}), 400
     db.session.commit()
     return jsonify(item.to_dict())
 


### PR DESCRIPTION
## Summary
- validate and convert `turno` using `TurnoEnum` when creating or updating schedule records in base data routes

## Testing
- `pytest tests/test_horario_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_68aeffe57a2083238ed5655ad829f3a8