### PR TITLE
fix: rollback on missing column

### DIFF
--- a/src/routes/horario.py
+++ b/src/routes/horario.py
@@ -115,6 +115,7 @@ def atualizar_horario(horario_id: int):
                 {"id": horario_id},
             ).mappings().first()
         except (ProgrammingError, OperationalError):
+            db.session.rollback()
             result = db.session.execute(
                 text(
                     "SELECT id, nome FROM planejamento_horarios WHERE id=:id"


### PR DESCRIPTION
## Summary
- handle missing `turno` column in Horario update by rolling back failed transaction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af1d1ea12c83239d2744917f4d9307