### PR TITLE
Add turno field to horario schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     ,"flask-wtf (==1.2.1)"
     ,"apscheduler (==3.10.4)"
     ,"flasgger (==0.9.7.1)",
-    "flask-mail (==0.9.1)"
+    "flask-mail (==0.9.1)",
+    "marshmallow (==3.21.1)"
 ]
 
 [tool.poetry]
@@ -65,6 +66,7 @@ flask-wtf = "1.2.1"
 apscheduler = "3.10.4"
 flasgger = "0.9.7.1"
 flask-mail = "0.9.1"
+marshmallow = "3.21.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.4.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ itsdangerous==2.2.0
 requests==2.32.4
 APScheduler==3.10.4
 flasgger==0.9.7.1
+marshmallow==3.21.1

--- a/src/schemas/planejamento.py
+++ b/src/schemas/planejamento.py
@@ -1,7 +1,10 @@
 from datetime import date, datetime
 from typing import List, Optional
-from pydantic import BaseModel, Field, field_validator, ConfigDict, constr
 from enum import Enum
+
+from marshmallow import Schema, fields
+from pydantic import BaseModel, Field, field_validator, ConfigDict, constr
+from src.models.planejamento import Horario, TurnoEnum as ModelTurnoEnum
 
 
 class PolosSchema(BaseModel):
@@ -83,3 +86,15 @@ class HorarioUpdate(BaseModel):
 
 class HorarioOut(HorarioBase):
     id: int
+
+
+class HorarioSchema(Schema):
+    id = fields.Int(dump_only=True)
+    hora_inicio = fields.Time(required=True)
+    hora_fim = fields.Time(required=True)
+    turno = fields.Enum(ModelTurnoEnum, by_value=False, allow_none=True)
+
+    class Meta:
+        model = Horario
+        load_instance = True
+        include_fk = True


### PR DESCRIPTION
## Summary
- include missing turno field in HorarioSchema
- add marshmallow dependency for new schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4e2c2ce8832381f808ee5255ae84