### PR TITLE
Exibir corretamente o turno na base de dados de horários

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -418,6 +418,17 @@ function formatarHorario(horario) {
     return horario;
 }
 
+function formatarTurno(turno) {
+    const mapa = {
+        manha: 'Manhã',
+        tarde: 'Tarde',
+        noite: 'Noite',
+        manha_tarde: 'Manhã/Tarde',
+        tarde_noite: 'Tarde/Noite',
+    };
+    return mapa[turno] || '';
+}
+
 /**
  * Garante a existência de um container global para toasts
  * @returns {HTMLElement} - Elemento container

--- a/src/static/js/planejamento-basedados.js
+++ b/src/static/js/planejamento-basedados.js
@@ -100,7 +100,7 @@ function renderizarTabela(tipo, dados) {
         } else if (tipo === 'horario') {
             tr.innerHTML = `
                 <td>${escapeHTML(item.nome)}</td>
-                <td>${escapeHTML(item.turno ?? '')}</td>
+                <td>${escapeHTML(formatarTurno(item.turno))}</td>
                 <td class="text-end">
                     <button class="btn btn-sm btn-outline-primary" onclick="editarItem('${tipo}', ${item.id}, '${escapeHTML(item.nome)}', '', '${item.turno || ''}')">
                         <i class="bi bi-pencil"></i>


### PR DESCRIPTION
## Summary
- Adiciona utilitário `formatarTurno` para converter valores canônicos de turno em rótulos amigáveis
- Passa a renderizar os horários na base de dados usando esses rótulos formatados

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af55ad60dc8323a40614da46c0f219