### PR TITLE
feat: add turno field to horario

### DIFF
--- a/migrations/versions/74ef32d8754e_add_turno_column_to_planejamento_.py
+++ b/migrations/versions/74ef32d8754e_add_turno_column_to_planejamento_.py
@@ -1,0 +1,39 @@
+"""add turno column to planejamento_horarios
+
+Revision ID: 74ef32d8754e
+Revises: 63791341500f
+Create Date: 2025-08-27 20:44:02.883818
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '74ef32d8754e'
+down_revision: Union[str, Sequence[str], None] = '63791341500f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [col["name"] for col in inspector.get_columns("planejamento_horarios")]
+    if "turno" not in columns:
+        op.add_column(
+            "planejamento_horarios",
+            sa.Column("turno", sa.String(length=20), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [col["name"] for col in inspector.get_columns("planejamento_horarios")]
+    if "turno" in columns:
+        op.drop_column("planejamento_horarios", "turno")

--- a/src/models/planejamento.py
+++ b/src/models/planejamento.py
@@ -90,7 +90,7 @@ class TurnoEnum(str, PyEnum):
 class Horario(PlanejamentoBase):
     __tablename__ = "planejamento_horarios"
 
-    turno = db.Column(db.String(20), nullable=True, index=True)
+    turno = db.Column(db.String(20), nullable=True)
 
     def to_dict(self):
         dados = super().to_dict()

--- a/src/schemas/horario.py
+++ b/src/schemas/horario.py
@@ -1,24 +1,19 @@
+from pydantic import BaseModel
 from typing import Optional, Literal
-from pydantic import BaseModel, constr, ConfigDict
 
 TurnoLiteral = Literal["Manhã", "Tarde", "Noite", "Manhã/Tarde", "Tarde/Noite"]
 
 
-class HorarioBase(BaseModel):
-    nome: constr(min_length=1, strip_whitespace=True)
+class HorarioIn(BaseModel):
+    nome: str
     turno: Optional[TurnoLiteral] = None
-    model_config = ConfigDict(from_attributes=True)
 
 
-class HorarioCreate(HorarioBase):
-    pass
-
-
-class HorarioUpdate(BaseModel):
-    nome: Optional[constr(min_length=1, strip_whitespace=True)] = None
-    turno: Optional[TurnoLiteral] = None
-    model_config = ConfigDict(from_attributes=True)
-
-
-class HorarioOut(HorarioBase):
+class HorarioOut(BaseModel):
     id: int
+    nome: str
+    turno: Optional[TurnoLiteral] = None
+
+    class Config:
+        from_attributes = True
+

--- a/src/static/js/planejamento-basedados.js
+++ b/src/static/js/planejamento-basedados.js
@@ -140,21 +140,13 @@ window.abrirModal = (tipo, id = null, nome = '', carga = '', turno = '') => {
     document.getElementById('itemId').value = id || '';
     document.getElementById('itemName').value = nome || '';
     const turnoGroup = document.getElementById('turnoGroup');
+    const selectTurno = document.getElementById('turnoHorario');
     if (tipo === 'horario') {
         turnoGroup.classList.remove('d-none');
-        const select = form.turno;
-        select.value = '';
-        if (turno) {
-            for (const opt of select.options) {
-                if (opt.text === turno) {
-                    opt.selected = true;
-                    break;
-                }
-            }
-        }
+        selectTurno.value = turno || '';
     } else {
         turnoGroup.classList.add('d-none');
-        form.turno.value = '';
+        selectTurno.value = '';
     }
 
     const cargaGroup = document.getElementById('cargaHorariaGroup');
@@ -195,8 +187,7 @@ async function salvarItemGeral() {
     const id = document.getElementById('itemId').value;
     const nome = document.getElementById('itemName').value.trim();
     const cargaHoraria = document.getElementById('itemCargaHoraria').value;
-    const turnoSelect = form.turno;
-    const turno = turnoSelect.options[turnoSelect.selectedIndex]?.text || '';
+    const turno = document.querySelector('#turnoHorario')?.value || '';
 
     if (!nome) {
         showToast('O nome não pode estar vazio.', 'warning');
@@ -237,7 +228,12 @@ async function salvarHorario(id, nome, turno) {
     const endpoint = id ? `/horarios/${id}` : '/horarios';
     const method = id ? 'PUT' : 'POST';
     try {
-        await chamarAPI(endpoint, method, { nome, turno });
+        await executarAcaoComFeedback(
+            document.getElementById('btnSalvarGeral'),
+            async () => {
+                await chamarAPI(endpoint, method, { nome, turno });
+            }
+        );
         showToast(`${NOMES_TIPO['horario']} ${id ? 'atualizado' : 'adicionado'} com sucesso!`, 'success');
         geralModal.hide();
         carregarTodosOsDados();

--- a/src/static/planejamento-basedados.html
+++ b/src/static/planejamento-basedados.html
@@ -209,14 +209,14 @@
                             <input type="text" class="form-control" id="itemName" required>
                         </div>
                         <div class="mb-3 d-none" id="turnoGroup">
-                            <label for="turno" class="form-label">Turno</label>
-                            <select id="turno" name="turno" class="form-select" required>
+                            <label for="turnoHorario" class="form-label">Turno</label>
+                            <select id="turnoHorario" class="form-select" required>
                                 <option value="" disabled selected>Selecione o turno</option>
-                                <option value="manha">Manhã</option>
-                                <option value="tarde">Tarde</option>
-                                <option value="noite">Noite</option>
-                                <option value="manha_tarde">Manhã/Tarde</option>
-                                <option value="tarde_noite">Tarde/Noite</option>
+                                <option value="Manhã">Manhã</option>
+                                <option value="Tarde">Tarde</option>
+                                <option value="Noite">Noite</option>
+                                <option value="Manhã/Tarde">Manhã/Tarde</option>
+                                <option value="Tarde/Noite">Tarde/Noite</option>
                             </select>
                         </div>
                         <div class="mb-3 d-none" id="cargaHorariaGroup">


### PR DESCRIPTION
## Summary
- allow Horario to persist optional turno
- expose turno via API and frontend modal
- add migration to create turno column

## Testing
- `pytest`
- `alembic upgrade heads` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*


------
https://chatgpt.com/codex/tasks/task_e_68af6cacb58083238a48a3eaae955b66