### PR TITLE
fix: preserve turno when updating horario

### DIFF
--- a/src/routes/horario.py
+++ b/src/routes/horario.py
@@ -305,7 +305,8 @@ def atualizar_horario(horario_id: int):
         return jsonify({"erro": "Já existe um horário com este nome"}), 400
 
     horario.nome = payload.nome
-    horario.turno = _to_canonical(payload.turno) if payload.turno is not None else None
+    if payload.turno is not None:
+        horario.turno = _to_canonical(payload.turno)
 
     try:
         db.session.commit()

--- a/tests/test_horario_routes.py
+++ b/tests/test_horario_routes.py
@@ -26,6 +26,40 @@ def test_criar_horario_turno_invalido(client):
 
 
 @pytest.mark.usefixtures("app")
+def test_atualizar_horario_atualiza_turno(client):
+    resp = client.post(
+        "/api/horarios",
+        json={"nome": "Horario X", "turno": "Manhã"},
+    )
+    horario_id = resp.get_json()["id"]
+
+    resp = client.put(
+        f"/api/horarios/{horario_id}",
+        json={"nome": "Horario X", "turno": "Tarde"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["turno"] == "Tarde"
+
+
+@pytest.mark.usefixtures("app")
+def test_atualizar_horario_mantem_turno_quando_ausente(client):
+    resp = client.post(
+        "/api/horarios",
+        json={"nome": "Horario Y", "turno": "Manhã"},
+    )
+    horario_id = resp.get_json()["id"]
+
+    resp = client.put(
+        f"/api/horarios/{horario_id}",
+        json={"nome": "Horario Z"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["turno"] == "Manhã"
+
+
+@pytest.mark.usefixtures("app")
 def test_listar_horarios_retorna_turno(client):
     client.post(
         "/api/horarios",


### PR DESCRIPTION
## Summary
- ensure horario update persists the `turno` field instead of overwriting with `None`
- add tests to confirm updating and retaining `turno`

## Testing
- `pytest tests/test_horario_routes.py::test_atualizar_horario_atualiza_turno -q`
- `pytest tests/test_horario_routes.py::test_atualizar_horario_mantem_turno_quando_ausente -q`
- `pytest tests/test_horario_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7a7ac3b083238fa73bdf46733d38