### PR TITLE
fix: prevent filter dropdown clipping

### DIFF
--- a/src/static/js/filters-ui.js
+++ b/src/static/js/filters-ui.js
@@ -3,6 +3,13 @@
 (function(){
   const $doc = document;
 
+  // Prevê que os menus de filtro sejam anexados estaticamente, evitando
+  // que o Bootstrap restrinja sua posição dentro de contêineres com
+  // overflow e fazendo com que não sejam cortados ao reduzir a altura da tabela.
+  $doc.querySelectorAll('.filter-btn[data-bs-toggle="dropdown"]').forEach(btn => {
+    btn.setAttribute('data-bs-display', 'static');
+  });
+
   // Fechar dropdown ao apertar ESC
   $doc.addEventListener('keydown', (e) => {
     if(e.key === 'Escape'){


### PR DESCRIPTION
## Summary
- ensure filter dropdowns attach statically to avoid clipping inside responsive tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afae25d1448323a16496d2f8562a59