### PR TITLE
Add enrollment deadline countdown for trainings

### DIFF
--- a/src/static/js/treinamentos.js
+++ b/src/static/js/treinamentos.js
@@ -1,0 +1,62 @@
+function initDeadlineCounters() {
+  const CLOSE_AHEAD_MS = 36 * 60 * 60 * 1000; // 1 dia e 12 horas
+
+  document.querySelectorAll('.card, .curso-card, [data-card-curso]').forEach(card => {
+    const periodoEl = findByLabel(card, 'Período:') || card.querySelector('[data-periodo]');
+    const horarioEl = findByLabel(card, 'Horário:') || card.querySelector('[data-horario]');
+    const deadlineEl = card.querySelector('[data-deadline]') || findByLabel(card, 'Inscrições encerram');
+
+    if (!periodoEl || !horarioEl || !deadlineEl) return;
+
+    const brInicio = extrairPrimeiraDataBR(periodoEl.textContent);      // dd/mm/aaaa
+    const hmInicio  = extrairPrimeiroHorario(horarioEl.textContent) || {h:8,m:0}; // fallback 08:00
+    if (!brInicio) return;
+
+    const inicio = criarDataLocal(brInicio, hmInicio.h, hmInicio.m);
+    const deadline = new Date(inicio.getTime() - CLOSE_AHEAD_MS);
+
+    function tick() {
+      const agora = new Date();
+      const diff = deadline - agora;
+
+      if (diff <= 0) {
+        deadlineEl.textContent = 'Inscrições encerradas';
+        return;
+      }
+      const d = Math.floor(diff / 86400000);
+      const h = Math.floor((diff % 86400000) / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+
+      const restante = d >= 1 ? `${d}d e ${h}h` : `${h}h e ${m}min`;
+      deadlineEl.textContent = `Inscrições encerram em: ${restante}`;
+    }
+
+    tick();
+    setInterval(tick, 60000); // atualiza a cada 1 min
+  });
+
+  function extrairPrimeiraDataBR(txt) {
+    const m = txt.match(/(\d{2}\/\d{2}\/\d{4})/);
+    return m ? m[1] : null;
+  }
+
+  function extrairPrimeiroHorario(txt) {
+    const m = txt.match(/(\d{2})\s*[Hh:\.]\s*(\d{2})/);
+    if (!m) return null;
+    return { h: parseInt(m[1], 10), m: parseInt(m[2], 10) };
+  }
+
+  function criarDataLocal(br, h, m) {
+    const [d, mo, y] = br.split('/').map(Number);
+    return new Date(y, mo - 1, d, h, m, 0, 0);
+  }
+
+  function findByLabel(root, startText) {
+    const lower = startText.toLowerCase();
+    return Array.from(root.querySelectorAll('li,div,span,small,p'))
+      .find(el => el.textContent.trim().toLowerCase().startsWith(lower));
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initDeadlineCounters);
+window.initDeadlineCounters = initDeadlineCounters;

--- a/src/static/js/treinamentos/cursos.js
+++ b/src/static/js/treinamentos/cursos.js
@@ -3,7 +3,6 @@
 // Armazena os dados do usuário logado e suas inscrições
 let dadosUsuarioLogado = null;
 let minhasInscricoesIds = new Set();
-let contadoresIntervals = [];
 let cacheMeusCursos = []; // Cache para os dados dos cursos do usuário
 
 /**
@@ -185,70 +184,23 @@ async function carregarTreinamentos() {
                             <span><b>Local:</b> ${escapeHTML(t.local_realizacao || 'A definir')}</span>
                         </div>
                     </div>
-                    <div class="card-footer bg-light">
-                        <div class="d-flex justify-content-between align-items-center">
-                            ${botaoHtml}
-                            <div class="text-end">
-                                <small class="text-muted d-block">Inscrições encerram em:</small>
-                                <span class="countdown-timer" id="countdown-${t.turma_id}" data-fim="${t.data_inicio}"></span>
-                            </div>
-                        </div>
+                    <div class="card-footer bg-light d-flex justify-content-between align-items-center">
+                        ${botaoHtml}
+                        <small class="text-muted" data-deadline>Inscrições encerram em: --</small>
                     </div>
                 </div>
             </div>`;
             container.insertAdjacentHTML('beforeend', cardHtml);
         });
 
-        iniciarContadores();
+        if (typeof initDeadlineCounters === 'function') {
+            initDeadlineCounters();
+        }
 
     } catch (e) {
         showToast(e.message, 'danger');
         container.innerHTML = '<p class="text-center text-danger w-100">Falha ao carregar os cursos.</p>';
     }
-}
-
-function iniciarContadores() {
-    contadoresIntervals.forEach(clearInterval);
-    contadoresIntervals = [];
-
-    document.querySelectorAll('.countdown-timer').forEach(timerEl => {
-        const fim = timerEl.dataset.fim;
-        if (!fim) {
-            timerEl.textContent = 'Data inválida';
-            return;
-        }
-        let dataFim = new Date(fim);
-        if (isNaN(dataFim.getTime())) {
-            timerEl.textContent = 'Data inválida';
-            return;
-        }
-        dataFim.setHours(23, 59, 59, 999);
-
-        const intervalId = setInterval(() => {
-            const agora = new Date();
-            const diferenca = dataFim - agora;
-
-            if (diferenca <= 0) {
-                clearInterval(intervalId);
-                timerEl.textContent = 'Inscrições encerradas';
-                const cardFooter = timerEl.closest('.card-footer');
-                if (cardFooter) {
-                    const btn = cardFooter.querySelector('.btn');
-                    if (btn && !btn.textContent.includes('INSCRITO')) {
-                        btn.disabled = true;
-                        btn.innerHTML = 'ENCERRADO';
-                    }
-                }
-                return;
-            }
-
-            const dias = Math.floor(diferenca / (1000 * 60 * 60 * 24));
-            const horas = Math.floor((diferenca % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-
-            timerEl.textContent = `${dias}d e ${horas}h`;
-        }, 1000);
-        contadoresIntervals.push(intervalId);
-    });
 }
 
 /**

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -158,6 +158,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/treinamentos/cursos.js"></script>
+    <script src="/js/treinamentos.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const usuario = getUsuarioLogado();


### PR DESCRIPTION
## Summary
- show a deadline placeholder within each training card
- add script to display enrollment countdown and close 36h before start
- reference new countdown script on trainings page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b89743609c832389a165f518a090f6