### PR TITLE
Reorder training module sidebar

### DIFF
--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -62,14 +62,13 @@
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link active admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link active admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
@@ -174,6 +173,18 @@
                 document.getElementById('userName').textContent = usuario.nome;
             }
         });
+    </script>
+    <script>
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
     </script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/treinamentos/admin-historico-passado.html
+++ b/src/static/treinamentos/admin-historico-passado.html
@@ -62,14 +62,13 @@
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
@@ -221,6 +220,18 @@
                 document.getElementById('userName').textContent = usuario.nome;
             }
         });
+    </script>
+    <script>
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
     </script>
     <div class="modal fade" id="confirmacaoExcluirModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">

--- a/src/static/treinamentos/admin-historico-turmas.html
+++ b/src/static/treinamentos/admin-historico-turmas.html
@@ -62,14 +62,13 @@
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
@@ -221,6 +220,18 @@
                 document.getElementById('userName').textContent = usuario.nome;
             }
         });
+    </script>
+    <script>
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
     </script>
     <div class="modal fade" id="confirmacaoExcluirModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -62,14 +62,13 @@
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
@@ -245,18 +244,30 @@
             document.addEventListener('DOMContentLoaded', () => carregarInscricoes(turmaId));
         }
     </script>
+     <script>
+         document.addEventListener('DOMContentLoaded', () => {
+             const usuario = getUsuarioLogado();
+             if (usuario) {
+                 document.getElementById('userName').textContent = usuario.nome;
+             }
+         });
+     </script>
     <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const usuario = getUsuarioLogado();
-            if (usuario) {
-                document.getElementById('userName').textContent = usuario.nome;
-            }
-        });
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
     </script>
-<footer class="mt-5 py-3 bg-dark text-white text-center">
-    <div class="container">
-        <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
-    </div>
-</footer>
+ <footer class="mt-5 py-3 bg-dark text-white text-center">
+     <div class="container">
+         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>
+     </div>
+ </footer>
 </body>
 </html>

--- a/src/static/treinamentos/admin-logs.html
+++ b/src/static/treinamentos/admin-logs.html
@@ -60,16 +60,15 @@
     <div class="container-fluid py-4">
         <div class="row">
             <div class="col-lg-3 d-none d-lg-block">
-                <div class="sidebar rounded shadow-sm" id="sidebar-menu">
+                <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
@@ -106,6 +105,18 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/treinamentos/logs.js"></script>
+    <script>
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
+    </script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -62,14 +62,13 @@
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link active admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
@@ -229,6 +228,18 @@
                 document.getElementById('userName').textContent = usuario.nome;
             }
         });
+    </script>
+    <script>
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
     </script>
     <div class="modal fade" id="confirmacaoExcluirModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -62,14 +62,13 @@
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link active" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
@@ -165,6 +164,18 @@
                 document.getElementById('userName').textContent = usuario.nome;
             }
         });
+    </script>
+    <script>
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
     </script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -62,14 +62,13 @@
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link active" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                         </div>
                 </div>
@@ -155,6 +154,18 @@
                 document.getElementById('userName').textContent = usuario.nome;
             }
         });
+    </script>
+    <script>
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
     </script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">

--- a/src/static/treinamentos/perfil.html
+++ b/src/static/treinamentos/perfil.html
@@ -49,14 +49,13 @@
             <div class="col-lg-3 d-none d-lg-block">
                 <div class="sidebar rounded shadow-sm">
                     <h2 class="mb-3">Menu Principal</h2>
-                    <div class="nav flex-column">
+                    <div class="nav flex-column" id="sidebar">
                         <a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list"></i> Cursos Disponíveis</a>
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3"></i> Meus Cursos</a>
-                        <a class="nav-link" href="/treinamentos/perfil.html" id="sidebar-perfil-link"><i class="bi bi-person"></i> Meu Perfil</a>
-                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill"></i> Turmas Futuras</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill"></i> Turmas em Andamento</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill"></i> Turmas Encerradas</a>
+                        <a class="nav-link admin-only" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill"></i> Catálogo</a>
                         <a class="nav-link admin-only" href="/treinamentos/admin-logs.html"><i class="bi bi-journal-text"></i> Logs</a>
                     </div>
                 </div>
@@ -104,6 +103,18 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
     <script src="/js/perfil.js"></script>
+    <script>
+    (function () {
+      var path = location.pathname.replace(/\/$/, '');
+      document.querySelectorAll('#sidebar a').forEach(function(a){
+        var href = (a.getAttribute('href') || '').replace(/\/$/, '');
+        if (href && (path === href || path.endsWith(href))) {
+          a.classList.add('active');
+          var li = a.closest('li'); if (li) li.classList.add('active');
+        }
+      });
+    })();
+    </script>
 <footer class="mt-5 py-3 bg-dark text-white text-center">
     <div class="container">
         <p class="mb-0">Sistema FIEMG | O futuro se faz juntos.</p>


### PR DESCRIPTION
## Summary
- Reorder sidebar items and remove "Meu Perfil" from training pages
- Add script to highlight active sidebar link on each training page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2c5cda08323b052c77cbb29f16e