### PR TITLE
Add teorico_online flag for turmas

### DIFF
--- a/migrations/versions/b6e3f5a1c9d0_add_teorico_online_to_turmas.py
+++ b/migrations/versions/b6e3f5a1c9d0_add_teorico_online_to_turmas.py
@@ -1,0 +1,30 @@
+"""add teorico_online to turmas
+
+Revision ID: b6e3f5a1c9d0
+Revises: f1d2d74c8a7b
+Create Date: 2025-08-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b6e3f5a1c9d0'
+down_revision: Union[str, Sequence[str], None] = 'f1d2d74c8a7b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'turmas_treinamento',
+        sa.Column('teorico_online', sa.Boolean(), nullable=False, server_default=sa.text("0"))
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('turmas_treinamento', 'teorico_online')
+

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -66,6 +66,7 @@ class TurmaTreinamento(db.Model):
     local_realizacao = db.Column(db.String(100))
     horario = db.Column(db.String(50))
     instrutor_id = db.Column(db.Integer, db.ForeignKey('instrutores.id'), nullable=True)
+    teorico_online = db.Column(db.Boolean, nullable=False, default=False, server_default="0")
 
     # Relacionamentos
     treinamento = db.relationship(
@@ -86,6 +87,7 @@ class TurmaTreinamento(db.Model):
             "horario": self.horario,
             "instrutor_id": self.instrutor_id,
             "instrutor_nome": self.instrutor.nome if self.instrutor else None,
+            "teorico_online": self.teorico_online,
         }
 
     def __repr__(self):

--- a/src/routes/treinamentos/treinamento.py
+++ b/src/routes/treinamentos/treinamento.py
@@ -76,6 +76,7 @@ def listar_turmas_agendadas():
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
                 "instrutor_nome": turma.instrutor.nome if turma.instrutor else "A definir",
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(dados)
@@ -111,6 +112,7 @@ def listar_turmas_ativas():
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
                 "instrutor": turma.instrutor.to_dict() if turma.instrutor else None,
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(dados)
@@ -142,6 +144,7 @@ def listar_historico_turmas():
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
                 "instrutor": turma.instrutor.to_dict() if turma.instrutor else None,
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(dados)
@@ -166,6 +169,7 @@ def listar_todas_as_turmas():
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
                 "instrutor": turma.instrutor.to_dict() if turma.instrutor else None,
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(dados)
@@ -249,6 +253,7 @@ def listar_meus_cursos():
                 "horario": turma.horario,
                 "local_realizacao": turma.local_realizacao,
                 "instrutor_nome": turma.instrutor.nome if turma.instrutor else None,
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(result)
@@ -420,6 +425,7 @@ def criar_turma_treinamento():
         local_realizacao=payload.local_realizacao,
         horario=payload.horario,
         instrutor_id=payload.instrutor_id,
+        teorico_online=payload.teorico_online,
     )
     try:
         db.session.add(turma)
@@ -495,6 +501,8 @@ def atualizar_turma_treinamento(turma_id):
             if not db.session.get(Instrutor, payload.instrutor_id):
                 return jsonify({"erro": "Instrutor não encontrado"}), 404
         turma.instrutor_id = payload.instrutor_id
+    if payload.teorico_online is not None:
+        turma.teorico_online = payload.teorico_online
     try:
         db.session.commit()
         log_action(

--- a/src/schemas/treinamento.py
+++ b/src/schemas/treinamento.py
@@ -48,6 +48,7 @@ class TurmaTreinamentoCreateSchema(BaseModel):
     local_realizacao: Optional[str] = None
     horario: Optional[str] = None
     instrutor_id: Optional[int] = None
+    teorico_online: Optional[bool] = False
 
 
 class TurmaTreinamentoUpdateSchema(BaseModel):
@@ -59,3 +60,4 @@ class TurmaTreinamentoUpdateSchema(BaseModel):
     local_realizacao: Optional[str] = None
     horario: Optional[str] = None
     instrutor_id: Optional[int] = None
+    teorico_online: Optional[bool] = None

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -159,11 +159,18 @@
                                     <option value="13H30 ÀS 16H30">13H30 ÀS 16H30</option>
                                     <option value="08H00 ÀS 17H00">08H00 ÀS 17H00</option>
                                     <option value="08H00 ÀS 12H00">08H00 ÀS 12H00</option>
-                                    <option value="12H00 ÀS 17H00">12H00 ÀS 17H00</option>                                
+                                    <option value="12H00 ÀS 17H00">12H00 ÀS 17H00</option>
                                     <option value="09H30 ÀS 18H30">09H30 ÀS 18H30</option>
                                     <option value="09H30 ÀS 13H30">09H30 ÀS 13H30</option>
-                                    <option value="13H30 ÀS 18H30">13H30 ÀS 18H30</option> 
+                                    <option value="13H30 ÀS 18H30">13H30 ÀS 18H30</option>
                                 </select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label d-block" for="turma-teorico-online">Teórico será online?</label>
+                                <div class="form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" id="turma-teorico-online" name="teorico_online">
+                                    <span class="form-text">Marque para indicar que a parte teórica ocorrerá online (EAD/remoto).</span>
+                                </div>
                             </div>
                     </form>
                 </div>


### PR DESCRIPTION
## Summary
- add "Teórico será online?" toggle to turma modal
- send and receive `teorico_online` flag in admin turmas page
- persist `teorico_online` in database and API with migration

## Testing
- `SECRET_KEY=dev flask --app src.main db upgrade`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68ba06868aac8323a2afac3c3df250ea