### PR TITLE
Add teorico-online option to turma form

### DIFF
--- a/migrations/versions/b0c1d2e3f4a5_add_teorico_online_to_turmas.py
+++ b/migrations/versions/b0c1d2e3f4a5_add_teorico_online_to_turmas.py
@@ -1,0 +1,29 @@
+"""add teorico_online column to turmas_treinamento
+
+Revision ID: b0c1d2e3f4a5
+Revises: f1d2d74c8a7b
+Create Date: 2025-08-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b0c1d2e3f4a5'
+down_revision: Union[str, Sequence[str], None] = 'f1d2d74c8a7b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('turmas_treinamento', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('teorico_online', sa.Boolean(), nullable=False, server_default=sa.text('false'))
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('turmas_treinamento', schema=None) as batch_op:
+        batch_op.drop_column('teorico_online')

--- a/src/models/treinamento.py
+++ b/src/models/treinamento.py
@@ -66,6 +66,7 @@ class TurmaTreinamento(db.Model):
     local_realizacao = db.Column(db.String(100))
     horario = db.Column(db.String(50))
     instrutor_id = db.Column(db.Integer, db.ForeignKey('instrutores.id'), nullable=True)
+    teorico_online = db.Column(db.Boolean, default=False, nullable=False)
 
     # Relacionamentos
     treinamento = db.relationship(
@@ -86,6 +87,7 @@ class TurmaTreinamento(db.Model):
             "horario": self.horario,
             "instrutor_id": self.instrutor_id,
             "instrutor_nome": self.instrutor.nome if self.instrutor else None,
+            "teorico_online": self.teorico_online,
         }
 
     def __repr__(self):

--- a/src/routes/treinamentos/treinamento.py
+++ b/src/routes/treinamentos/treinamento.py
@@ -76,6 +76,7 @@ def listar_turmas_agendadas():
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
                 "instrutor_nome": turma.instrutor.nome if turma.instrutor else "A definir",
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(dados)
@@ -111,6 +112,7 @@ def listar_turmas_ativas():
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
                 "instrutor": turma.instrutor.to_dict() if turma.instrutor else None,
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(dados)
@@ -142,6 +144,7 @@ def listar_historico_turmas():
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
                 "instrutor": turma.instrutor.to_dict() if turma.instrutor else None,
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(dados)
@@ -166,6 +169,7 @@ def listar_todas_as_turmas():
                 "local_realizacao": turma.local_realizacao,
                 "horario": turma.horario,
                 "instrutor": turma.instrutor.to_dict() if turma.instrutor else None,
+                "teorico_online": turma.teorico_online,
             }
         )
     return jsonify(dados)
@@ -420,6 +424,7 @@ def criar_turma_treinamento():
         local_realizacao=payload.local_realizacao,
         horario=payload.horario,
         instrutor_id=payload.instrutor_id,
+        teorico_online=payload.teorico_online,
     )
     try:
         db.session.add(turma)
@@ -495,6 +500,8 @@ def atualizar_turma_treinamento(turma_id):
             if not db.session.get(Instrutor, payload.instrutor_id):
                 return jsonify({"erro": "Instrutor não encontrado"}), 404
         turma.instrutor_id = payload.instrutor_id
+    if payload.teorico_online is not None:
+        turma.teorico_online = payload.teorico_online
     try:
         db.session.commit()
         log_action(

--- a/src/schemas/treinamento.py
+++ b/src/schemas/treinamento.py
@@ -48,6 +48,7 @@ class TurmaTreinamentoCreateSchema(BaseModel):
     local_realizacao: Optional[str] = None
     horario: Optional[str] = None
     instrutor_id: Optional[int] = None
+    teorico_online: Optional[bool] = False
 
 
 class TurmaTreinamentoUpdateSchema(BaseModel):
@@ -59,3 +60,4 @@ class TurmaTreinamentoUpdateSchema(BaseModel):
     local_realizacao: Optional[str] = None
     horario: Optional[str] = None
     instrutor_id: Optional[int] = None
+    teorico_online: Optional[bool] = None

--- a/src/static/js/treinamentos/admin.js
+++ b/src/static/js/treinamentos/admin.js
@@ -228,6 +228,7 @@ async function abrirModalTurma(id = null) {
     const form = document.getElementById('turmaForm');
     form.reset();
     document.getElementById('turmaId').value = id || '';
+    document.getElementById('teoricoOnline').checked = false;
 
     // Popula o select de treinamentos
     const selectTrein = document.getElementById('turmaTreinamentoId');
@@ -263,6 +264,7 @@ async function abrirModalTurma(id = null) {
             document.getElementById('localRealizacao').value = t.local_realizacao || '';
             document.getElementById('instrutorId').value = t.instrutor_id || '';
             document.getElementById('horario').value = t.horario || '';
+            document.getElementById('teoricoOnline').checked = !!t.teorico_online;
 
         } catch(e) {
             showToast(`Não foi possível carregar dados da turma: ${e.message}`, 'danger');
@@ -296,7 +298,8 @@ async function salvarTurma() {
         data_fim: document.getElementById('dataFim').value,
         local_realizacao: document.getElementById('localRealizacao').value,
         horario: document.getElementById('horario').value,
-        instrutor_id: parseInt(document.getElementById('instrutorId').value) || null
+        instrutor_id: parseInt(document.getElementById('instrutorId').value) || null,
+        teorico_online: document.getElementById('teoricoOnline').checked
     };
 
     if (!body.treinamento_id || !body.data_inicio || !body.data_fim) {

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -143,6 +143,10 @@
                                 <option value="SENAI Conceição do Mato Dentro">SENAI Conceição do Mato Dentro</option>
                             </select>
                         </div>
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="teoricoOnline">
+                            <label class="form-check-label" for="teoricoOnline">Teórico será online?</label>
+                        </div>
                         <div class="mb-3">
                             <label class="form-label">Instrutor</label>
                             <select class="form-select" id="instrutorId">

--- a/tests/test_treinamento_routes.py
+++ b/tests/test_treinamento_routes.py
@@ -64,3 +64,23 @@ def test_atualizar_turma_ativa_permitido(client, app):
     )
     assert resp_up.status_code == 200
     assert resp_up.get_json()['local_realizacao'] == 'Nova'
+
+
+def test_criar_turma_com_teorico_online(client, app):
+    headers = admin_headers(app)
+    r = client.post('/api/treinamentos/catalogo', json={'nome': 'Trein2', 'codigo': 'T100'}, headers=headers)
+    treino_id = r.get_json()['id']
+
+    hoje = datetime.utcnow().date()
+    resp_turma = client.post(
+        '/api/treinamentos/turmas',
+        json={
+            'treinamento_id': treino_id,
+            'data_inicio': (hoje + timedelta(days=1)).isoformat(),
+            'data_fim': (hoje + timedelta(days=2)).isoformat(),
+            'teorico_online': True
+        },
+        headers=headers,
+    )
+    assert resp_turma.status_code == 201
+    assert resp_turma.get_json()['teorico_online'] is True


### PR DESCRIPTION
## Summary
- Add `teorico_online` column and API support for training classes
- Expose "Teórico será online?" switch in admin turma modal
- Test creation of turma with theoretical part online

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba069cf9b08323bc2d4febe7d1f35f