### PR TITLE
Oculta colunas de avaliação e atualiza inscrições

### DIFF
--- a/src/static/css/treinamentos.css
+++ b/src/static/css/treinamentos.css
@@ -1,0 +1,8 @@
+/* Ocultar somente na interface */
+th[data-col="presenca_teoria"], td[data-col="presenca_teoria"],
+th[data-col="presenca_pratica"], td[data-col="presenca_pratica"],
+th[data-col="nota_teoria"], td[data-col="nota_teoria"],
+th[data-col="nota_pratica"], td[data-col="nota_pratica"],
+th[data-col="status"], td[data-col="status"] {
+    display: none !important;
+}

--- a/src/static/js/treinamentos/admin.js
+++ b/src/static/js/treinamentos/admin.js
@@ -138,6 +138,9 @@ async function enviarInscricaoAdmin() {
             showToast('Participante inscrito com sucesso!', 'success');
             const modal = bootstrap.Modal.getInstance(document.getElementById('adminInscricaoModal'));
             modal.hide();
+            if (document.getElementById('inscricoesTableBody')) {
+                await carregarInscricoes(turmaId);
+            }
         } catch (e) {
             showToast(e.message, 'danger');
             throw e;
@@ -399,7 +402,7 @@ async function carregarInscricoes(turmaId) {
             const statusReprovado = i.status_aprovacao === 'Reprovado' ? 'selected' : '';
 
             const tdPraticaHtml = temPratica ? `
-                <td class="text-center">
+                <td class="text-center" data-col="presenca_pratica">
                     <input class="form-check-input presenca-pratica-check" type="checkbox" ${i.presenca_pratica ? 'checked' : ''}>
                 </td>` : '';
 
@@ -415,17 +418,17 @@ async function carregarInscricoes(turmaId) {
                 <td>${escapeHTML(i.nome)}</td>
                 <td>${i.cpf || ''}</td>
                 <td>${i.empresa || ''}</td>
-                <td class="text-center">
+                <td class="text-center" data-col="presenca_teoria">
                     <input class="form-check-input presenca-teoria-check" type="checkbox" ${i.presenca_teoria ? 'checked' : ''}>
                 </td>
                 ${tdPraticaHtml}
-                <td>
+                <td data-col="nota_teoria">
                     <input type="number" class="form-control form-control-sm nota-teoria-input" value="${i.nota_teoria !== null ? i.nota_teoria : ''}" min="0" max="100" step="0.1">
                 </td>
-                <td>
+                <td data-col="nota_pratica">
                     <input type="number" class="form-control form-control-sm nota-pratica-input" value="${i.nota_pratica !== null ? i.nota_pratica : ''}" min="0" max="100" step="0.1">
                 </td>
-                <td>
+                <td data-col="status">
                     <select class="form-select form-select-sm status-aprovacao-select">
                         <option value="">Selecione...</option>
                         <option value="Aprovado" ${statusAprovado}>Aprovado</option>

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/static/css/brand.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/styles.css" rel="stylesheet">
+    <link href="/css/treinamentos.css" rel="stylesheet">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary sticky-top">
@@ -149,11 +150,11 @@
                                         <th scope="col">Nome</th>
                                         <th scope="col">CPF</th>
                                         <th scope="col">Empresa</th>
-                                        <th scope="col" class="text-center" style="width: 100px;">Presença Teoria</th>
-                                        <th scope="col" id="thPresencaPratica" class="text-center" style="width: 100px; display: none;">Presença Prática</th>
-                                        <th scope="col" style="width: 120px;">Nota Teoria</th>
-                                        <th scope="col" style="width: 120px;">Nota Prática</th>
-                                        <th scope="col" style="width: 150px;">Status</th>
+                                        <th scope="col" class="text-center" style="width: 100px;" data-col="presenca_teoria">Presença Teoria</th>
+                                        <th scope="col" id="thPresencaPratica" class="text-center" style="width: 100px; display: none;" data-col="presenca_pratica">Presença Prática</th>
+                                        <th scope="col" style="width: 120px;" data-col="nota_teoria">Nota Teoria</th>
+                                        <th scope="col" style="width: 120px;" data-col="nota_pratica">Nota Prática</th>
+                                        <th scope="col" style="width: 150px;" data-col="status">Status</th>
                                         <th scope="col" style="width: 80px;">Ações</th>
                                     </tr>
                                 </thead>


### PR DESCRIPTION
## Summary
- esconde colunas de presença, notas e status com seletor data-col
- atualiza a tabela de inscrições ao inscrever novo participante

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb288c519c832398b7b5a46348d32e