### PR TITLE
fix: improve password recovery flow

### DIFF
--- a/src/services/email_service.py
+++ b/src/services/email_service.py
@@ -1,83 +1,97 @@
-from email.message import EmailMessage
+from flask import current_app, render_template
+from threading import Thread
 import smtplib
-import ssl
-import threading
-from flask import current_app
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+import logging
 
 
-def _build_reset_message(to_email: str, reset_url: str) -> EmailMessage:
-    cfg = current_app.config
-    msg = EmailMessage()
-    msg["Subject"] = "Conecta SENAI – Redefinição de senha"
-    msg["From"] = cfg.get("MAIL_DEFAULT_SENDER")
-    msg["To"] = to_email
+def _send_email_via_smtp(app, subject, recipient, body_html, body_text=None):
+    """Executa dentro de uma thread, mas com app_context válido."""
+    with app.app_context():
+        try:
+            cfg = app.config
+            host = cfg.get("MAIL_SERVER")
+            port = int(cfg.get("MAIL_PORT", 587))
+            username = cfg.get("MAIL_USERNAME")
+            password = cfg.get("MAIL_PASSWORD")
+            use_tls = bool(cfg.get("MAIL_USE_TLS", True))
+            use_ssl = bool(cfg.get("MAIL_USE_SSL", False))
+            sender = cfg.get("MAIL_DEFAULT_SENDER") or username
 
-    text = (
-        f"Olá,\n\nUse o link abaixo para redefinir sua senha:\n{reset_url}\n\n"
-        "Se você não solicitou, ignore esta mensagem."
-    )
-    html = f"""
-        <p>Olá,</p>
-        <p>Use o link abaixo para redefinir sua senha:</p>
-        <p><a href="{reset_url}">{reset_url}</a></p>
-        <p>Se você não solicitou, ignore esta mensagem.</p>
-    """
+            if not host or not sender:
+                logging.error(
+                    "Config de e-mail ausente: "
+                    "MAIL_SERVER/MAIL_DEFAULT_SENDER."
+                )
+                return
 
-    msg.set_content(text)
-    msg.add_alternative(html, subtype="html")
-    return msg
+            msg = MIMEMultipart("alternative")
+            msg["Subject"] = subject
+            msg["From"] = sender
+            msg["To"] = recipient
+
+            if body_text:
+                msg.attach(MIMEText(body_text, "plain", "utf-8"))
+            if body_html:
+                msg.attach(MIMEText(body_html, "html", "utf-8"))
+
+            server = None
+            try:
+                if use_ssl:
+                    server = smtplib.SMTP_SSL(host, port, timeout=30)
+                else:
+                    server = smtplib.SMTP(host, port, timeout=30)
+                    if use_tls:
+                        server.starttls()
+
+                if username and password:
+                    server.login(username, password)
+
+                server.sendmail(sender, [recipient], msg.as_string())
+                logging.info(f"E-mail de recuperação enviado para {recipient}")
+            finally:
+                if server:
+                    try:
+                        server.quit()
+                    except Exception:
+                        logging.debug("SMTP quit falhou (ignorado).")
+        except Exception:
+            logging.exception("Falha ao enviar e-mail (recuperação de senha).")
 
 
-def send_email_via_smtp(message: EmailMessage):
-    """Envio SMTP com timeout curto para não travar o worker."""
+def send_email_async(subject, recipient, body_html, body_text=None):
+    """Captura o app atual e dispara a thread sem bloquear a requisição."""
     app = current_app._get_current_object()
-    cfg = app.config
+    th = Thread(
+        target=_send_email_via_smtp,
+        args=(app, subject, recipient, body_html, body_text),
+        daemon=True,
+    )
+    th.start()
+    return th
 
-    server = cfg.get("MAIL_SERVER")
-    port = int(cfg.get("MAIL_PORT", 587))
-    username = cfg.get("MAIL_USERNAME")
-    password = cfg.get("MAIL_PASSWORD")
-    use_tls = cfg.get("MAIL_USE_TLS", True)
-    use_ssl = cfg.get("MAIL_USE_SSL", False)
-    timeout = int(cfg.get("MAIL_TIMEOUT", 12))
 
-    try:
-        if use_ssl:
-            context = ssl.create_default_context()
-            with smtplib.SMTP_SSL(
-                server, port, timeout=timeout, context=context
-            ) as smtp:
-                if username and password:
-                    smtp.login(username, password)
-                smtp.send_message(message)
-        else:
-            with smtplib.SMTP(server, port, timeout=timeout) as smtp:
-                smtp.ehlo()
-                if use_tls:
-                    context = ssl.create_default_context()
-                    smtp.starttls(context=context)
-                    smtp.ehlo()
-                if username and password:
-                    smtp.login(username, password)
-                smtp.send_message(message)
-
-        app.logger.info("E-mail enviado para %s", message["To"])
-    except Exception:
-        # Loga a stack completa mas NÃO levanta para não quebrar o fluxo do
-        # /forgot
-        app.logger.exception(
-            "Falha ao enviar e-mail para %s", message["To"]
-        )
-
+# Compatibilidade: antiga função para envio de reset que utiliza
+# templates existentes
 
 def queue_reset_email(to_email: str, token: str):
-    """Dispara em thread para não bloquear o request."""
+    """Mantida para compatibilidade. Monta e-mail de reset e envia de forma
+    assíncrona."""
     app = current_app._get_current_object()
     base_url = app.config.get(
         "APP_BASE_URL", "https://conecta-senai.up.railway.app"
     )
     reset_url = f"{base_url}/reset?token={token}"
-    msg = _build_reset_message(to_email, reset_url)
-
-    t = threading.Thread(target=send_email_via_smtp, args=(msg,), daemon=True)
-    t.start()
+    try:
+        body_html = render_template(
+            "emails/reset_password.html", reset_url=reset_url
+        )
+    except Exception:
+        body_html = (
+            f"<p>Olá!</p><p>Use o link abaixo para redefinir sua senha:</p>"
+            f"<p><a href='{reset_url}'>{reset_url}</a></p>"
+            "<p>Se você não solicitou, ignore este e-mail.</p>"
+        )
+    subject = "Conecta SENAI – Redefinição de senha"
+    send_email_async(subject, to_email, body_html)

--- a/src/static/js/auth/forgot.js
+++ b/src/static/js/auth/forgot.js
@@ -1,0 +1,38 @@
+// src/static/js/auth/forgot.js
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('forgotForm');
+  if (!form) return;
+
+  const emailEl = document.getElementById('email');
+  const btn = document.getElementById('btnForgot');
+  const msg = document.getElementById('forgotMsg');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = (emailEl.value || '').trim();
+
+    btn.disabled = true;
+    const originalText = btn.innerText;
+    btn.innerText = 'Enviando...';
+    msg.textContent = '';
+    msg.className = '';
+
+    try {
+      const r = await fetch('/forgot', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      const data = await r.json().catch(() => ({}));
+      const text = data.message || 'Se o e-mail existir, enviaremos as instruções.';
+      msg.textContent = text;
+      msg.className = r.ok ? 'alert alert-success' : 'alert alert-warning';
+    } catch (err) {
+      msg.textContent = 'Não foi possível enviar agora. Tente novamente em instantes.';
+      msg.className = 'alert alert-danger';
+    } finally {
+      btn.disabled = false;
+      btn.innerText = originalText;
+    }
+  });
+});

--- a/src/templates/admin/forgot_password.html
+++ b/src/templates/admin/forgot_password.html
@@ -27,31 +27,18 @@
                         <img src="/img/senai-logo.png" alt="SENAI Logo" style="width: 120px;">
                     </div>
 
-                    {% with messages = get_flashed_messages() %}
-                        {% if messages %}
-                            <div class="alert alert-info">
-                                {% for message in messages %}
-                                    <div>{{ message }}</div>
-                                {% endfor %}
-                            </div>
-                        {% elif request.args.get('sent') %}
-                            <div class="alert alert-info">
-                                Se o e-mail estiver cadastrado, enviaremos instruções de redefinição.
-                            </div>
-                        {% endif %}
-                    {% endwith %}
-
                     <h1 class="h3 mb-3 fw-normal">Recuperar Senha</h1>
                     <p class="text-muted mb-4">Insira seu e-mail para receber as instruções de redefinição.</p>
 
-                    <form method="post">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <div id="forgotMsg" class="mb-3"></div>
+
+                    <form id="forgotForm" method="post">
                         <div class="form-floating mb-3">
                             <input type="email" class="form-control" id="email" name="email" placeholder="seu@email.com" required>
                             <label for="email"><i class="bi bi-envelope me-2"></i>Email</label>
                         </div>
                         <div class="d-grid">
-                            <button type="submit" class="btn btn-primary btn-lg">Enviar Instruções</button>
+                            <button type="submit" id="btnForgot" class="btn btn-primary btn-lg">Enviar Instruções</button>
                         </div>
                     </form>
 
@@ -71,5 +58,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="/static/js/auth/forgot.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure email sending uses app context and runs asynchronously
- return generic response from `/forgot` and trigger email in background
- add frontend script for password recovery page

## Testing
- `pre-commit run --files src/services/email_service.py src/blueprints/auth_reset.py src/templates/admin/forgot_password.html src/static/js/auth/forgot.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb48289a9c8323af05f2bafdd95612