### PR TITLE
Handle SMTP network errors gracefully and refine app startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -257,15 +257,21 @@ def create_app():
 
     logging.info("Aplicação Flask criada com sucesso.")
     return app
-try:
-    app = create_app()
-except Exception as e:
-    logging.error("!!!!!! FALHA CRÍTICA AO INICIAR A APLICAÇÃO !!!!!!")
-    logging.error(f"Erro: {e}")
-    logging.error(f"Traceback: {traceback.format_exc()}")
-    raise e
 
-if __name__ == '__main__':
+
+def main():
+    try:
+        app = create_app()
+    except Exception as e:
+        logging.error("!!!!!! FALHA CRÍTICA AO INICIAR A APLICAÇÃO !!!!!!")
+        logging.error("Erro: %s", e)
+        logging.error("Traceback: %s", traceback.format_exc())
+        raise e
+
     debug = os.getenv('FLASK_DEBUG', '0').lower() in ('1', 'true', 't', 'yes')
     port = int(os.getenv('PORT', '5000'))
     app.run(debug=debug, host='127.0.0.1', port=port)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- avoid duplicate Flask app creation by moving initialization into `main()`
- log SMTP network failures without stack traces for clearer diagnostics

## Testing
- `pre-commit run --files src/services/email_service.py src/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb4e419b788323a682e27d71e8eb70