### PR TITLE
Improve mail configuration and Gmail SMTP fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,6 @@ MAIL_USERNAME=seu_usuario
 MAIL_PASSWORD=sua_senha_ou_app_password
 MAIL_DEFAULT_SENDER=no-reply@seu-dominio
 MAIL_TIMEOUT=12
+MAIL_SUPPRESS_SEND=false
 APP_BASE_URL=https://conecta-senai.up.railway.app
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,14 +1,12 @@
 import os
 
-# Bind to host/port pulled from PORT env var for flexibility
-bind = f"0.0.0.0:{os.getenv('PORT', '8080')}"
-
-# Worker settings tuned to avoid OOM and excessive concurrency
-workers = int(os.getenv("WEB_CONCURRENCY", "1"))
+wsgi_app = "src.main:create_app()"
+bind = "0.0.0.0:8080"
+workers = 1
 threads = int(os.getenv("GTHREADS", "1"))
 worker_class = os.getenv("WORKER_CLASS", "sync")
-
 timeout = 30
+loglevel = "debug"
 keepalive = 2
 max_requests = 600
 max_requests_jitter = 60

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,19 @@
 import logging
 import os
+from distutils.util import strtobool
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    """Read an environment variable as boolean.
+
+    Accepts many common string representations ("true", "0", "yes", ...).
+    Falls back to ``default`` if parsing fails.
+    """
+    v = os.getenv(name, str(default))
+    try:
+        return bool(strtobool(str(v)))
+    except Exception:
+        return bool(default)
 
 
 class BaseConfig:
@@ -11,8 +25,9 @@ class BaseConfig:
 
     MAIL_SERVER = os.getenv("MAIL_SERVER", "smtp.gmail.com")
     MAIL_PORT = int(os.getenv("MAIL_PORT", "587"))
-    MAIL_USE_TLS = os.getenv("MAIL_USE_TLS", "true").lower() == "true"
-    MAIL_USE_SSL = os.getenv("MAIL_USE_SSL", "false").lower() == "true"
+    MAIL_USE_TLS = env_bool("MAIL_USE_TLS", True)
+    MAIL_USE_SSL = env_bool("MAIL_USE_SSL", False)
+    MAIL_SUPPRESS_SEND = env_bool("MAIL_SUPPRESS_SEND", False)
     MAIL_USERNAME = os.getenv("MAIL_USERNAME", "")
     MAIL_PASSWORD = os.getenv("MAIL_PASSWORD", "")
     MAIL_DEFAULT_SENDER = os.getenv(


### PR DESCRIPTION
## Summary
- parse MAIL_* environment variables as booleans consistently
- add Gmail IPv4 connection helper with TLS/SSL fallback and suppression option
- define wsgi_app and other defaults in gunicorn config

## Testing
- `pre-commit run --files src/config.py src/services/email_service.py gunicorn.conf.py .env.example`
- `pytest tests/test_email_service.py`
- `python - <<'PY'...`
- `getent hosts smtp.gmail.com || nslookup smtp.gmail.com`


------
https://chatgpt.com/codex/tasks/task_e_68bb6fdef5f08323a994415da1cedff8