### PR TITLE
Log SMTP connection failures with extra error context

### DIFF
--- a/src/services/email_service.py
+++ b/src/services/email_service.py
@@ -131,5 +131,9 @@ class EmailClient:
             log.info("SMTP connection test succeeded")
             return True
         except Exception as e:
-            log.error("SMTP connection test failed", exc_info=e)
+            log.error(
+                "SMTP connection test failed",
+                extra={"error": str(e)},
+                exc_info=e,
+            )
             return False


### PR DESCRIPTION
## Summary
- log SMTP connection failures with extra error context in email_service
- confirm logging setup captures structured extras and exception info

## Testing
- `pytest` *(fails: redis.exceptions.ConnectionError: Error 111 connecting to localhost:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7b43d43483239778b38350c20687