### PR TITLE
fix: align rate limit redis uri and serve legacy static path

### DIFF
--- a/src/extensions.py
+++ b/src/extensions.py
@@ -11,10 +11,14 @@ import os
 db = SQLAlchemy()
 migrate = Migrate()
 jwt = JWTManager()
+
+
+DEFAULT_REDIS_URI = os.getenv(
+    "REDIS_URL",
+    f"redis://{os.getenv('REDIS_HOST', 'localhost')}:{os.getenv('REDIS_PORT', '6379')}",
+)
+
 limiter = Limiter(
     key_func=get_remote_address,
-    storage_uri=os.getenv(
-        "RATELIMIT_STORAGE_URI",
-        f"redis://{os.getenv('REDIS_HOST', 'localhost')}:{os.getenv('REDIS_PORT', '6379')}",
-    ),
+    storage_uri=os.getenv("RATELIMIT_STORAGE_URI", DEFAULT_REDIS_URI),
 )

--- a/src/main.py
+++ b/src/main.py
@@ -277,6 +277,10 @@ def create_app():
     def index():
         return redirect('/admin/login.html')
 
+    @app.route('/static/<path:filename>')
+    def static_files(filename):
+        return app.send_static_file(filename)
+
     @app.route('/<path:path>')
     def static_file(path):
         return app.send_static_file(path)


### PR DESCRIPTION
## Summary
- ensure Flask-Limiter uses `REDIS_URL` when `RATELIMIT_STORAGE_URI` is unset so Redis auth credentials are respected
- add `/static/<path:filename>` route so legacy static file paths resolve

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf8103929083239fd3547fc5d64c18