### PR TITLE
Add Gmail email provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,17 +35,22 @@ SCHEDULER_ENABLED=1
 NOTIFICACAO_INTERVALO_MINUTOS=60
 
 # E-mail configuration
-EMAIL_PROVIDER=OUTLOOK               # Provedor de e-mail (apenas OUTLOOK suportado)
-EMAIL_FROM=<definir_em_producao>     # Endereço do remetente
-EMAIL_FROM_NAME=Conecta SENAI        # Nome exibido do remetente
-SMTP_SERVER=smtp.office365.com       # Servidor SMTP
-SMTP_PORT=587                        # Porta SMTP
-SMTP_USERNAME=<definir_em_producao>  # Usuário para autenticação SMTP
-SMTP_PASSWORD=<definir_em_producao>  # Senha ou app password
-SMTP_USE_TLS=true                    # Habilita STARTTLS
-SMTP_USE_SSL=false                   # Usa SSL/TLS implícito
-SMTP_TIMEOUT=15                      # Timeout em segundos
-EMAIL_SMTP_VALIDATE_ON_STARTUP=0     # Valida conexão SMTP no startup
+# EMAIL_PROVIDER=OUTLOOK               # Provedor de e-mail (OUTLOOK ou GMAIL)
+EMAIL_PROVIDER=GMAIL
+
+# Configurações para GMAIL
+# Para usar uma conta pessoal, pode ser necessário gerar uma "App Password"
+# Acesse: https://myaccount.google.com/apppasswords
+EMAIL_FROM=<seu_email@gmail.com>
+EMAIL_FROM_NAME=Conecta SENAI
+SMTP_SERVER=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=<seu_email@gmail.com>
+SMTP_PASSWORD=<sua_app_password>
+SMTP_USE_TLS=true
+SMTP_USE_SSL=false
+SMTP_TIMEOUT=15
+EMAIL_SMTP_VALIDATE_ON_STARTUP=0
 # Variáveis MAIL_* antigas ainda são aceitas para compatibilidade
 APP_BASE_URL=https://conecta-senai.up.railway.app
 

--- a/src/config.py
+++ b/src/config.py
@@ -44,20 +44,41 @@ class BaseConfig:
     LOG_LEVEL = logging.INFO
 
     # E-mail settings (new names with fallback to legacy MAIL_* variables)
-    EMAIL_PROVIDER = os.getenv("EMAIL_PROVIDER", "OUTLOOK")
+    EMAIL_PROVIDER = os.getenv("EMAIL_PROVIDER", "GMAIL")
     EMAIL_FROM = os.getenv(
         "EMAIL_FROM", os.getenv("MAIL_DEFAULT_SENDER", "")
     )
     EMAIL_FROM_NAME = os.getenv("EMAIL_FROM_NAME", "Conecta SENAI")
-    SMTP_SERVER = os.getenv(
-        "SMTP_SERVER", os.getenv("MAIL_SERVER", "smtp.office365.com")
+
+    if EMAIL_PROVIDER == "GMAIL":
+        SMTP_SERVER = os.getenv(
+            "SMTP_SERVER", os.getenv("MAIL_SERVER", "smtp.gmail.com")
+        )
+        SMTP_PORT = int(
+            os.getenv("SMTP_PORT", os.getenv("MAIL_PORT", "587"))
+        )
+    else:  # OUTLOOK or any other provider defaults to Outlook settings
+        SMTP_SERVER = os.getenv(
+            "SMTP_SERVER", os.getenv("MAIL_SERVER", "smtp.office365.com")
+        )
+        SMTP_PORT = int(
+            os.getenv("SMTP_PORT", os.getenv("MAIL_PORT", "587"))
+        )
+    SMTP_USERNAME = os.getenv(
+        "SMTP_USERNAME", os.getenv("MAIL_USERNAME", "")
     )
-    SMTP_PORT = int(os.getenv("SMTP_PORT", os.getenv("MAIL_PORT", "587")))
-    SMTP_USERNAME = os.getenv("SMTP_USERNAME", os.getenv("MAIL_USERNAME", ""))
-    SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", os.getenv("MAIL_PASSWORD", ""))
-    SMTP_USE_TLS = env_bool("SMTP_USE_TLS", env_bool("MAIL_USE_TLS", True))
-    SMTP_USE_SSL = env_bool("SMTP_USE_SSL", env_bool("MAIL_USE_SSL", False))
-    SMTP_TIMEOUT = int(os.getenv("SMTP_TIMEOUT", os.getenv("MAIL_TIMEOUT", "15")))
+    SMTP_PASSWORD = os.getenv(
+        "SMTP_PASSWORD", os.getenv("MAIL_PASSWORD", "")
+    )
+    SMTP_USE_TLS = env_bool(
+        "SMTP_USE_TLS", env_bool("MAIL_USE_TLS", True)
+    )
+    SMTP_USE_SSL = env_bool(
+        "SMTP_USE_SSL", env_bool("MAIL_USE_SSL", False)
+    )
+    SMTP_TIMEOUT = int(
+        os.getenv("SMTP_TIMEOUT", os.getenv("MAIL_TIMEOUT", "15"))
+    )
     CLIENT_ID = os.getenv("CLIENT_ID", "")
     TENANT_ID = os.getenv("TENANT_ID", "")
     CLIENT_SECRET = os.getenv("CLIENT_SECRET", "")


### PR DESCRIPTION
## Summary
- allow selecting Outlook or Gmail email providers via environment
- support Gmail SMTP login alongside Outlook OAuth
- document Gmail configuration in `.env.example`

## Testing
- `pre-commit run --files src/config.py src/services/email_service.py .env.example`
- `pytest` *(fails: `FAILED tests/test_email_service.py::test_send_mail_auth_error - Failed: DID NOT RAISE <class 'smtplib.SMTPAuthenticationError'>`)*

------
https://chatgpt.com/codex/tasks/task_e_68bf84d9b9748323a3cced3963d44eef