### PR TITLE
Reduce email send timeout and retries to avoid worker timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,8 @@ SMTP_USERNAME=<seu_email@gmail.com>
 SMTP_PASSWORD=<sua_app_password>
 SMTP_USE_TLS=true
 SMTP_USE_SSL=false
-SMTP_TIMEOUT=15
+SMTP_TIMEOUT=5
+SMTP_MAX_RETRIES=1
 EMAIL_SMTP_VALIDATE_ON_STARTUP=0
 # Variáveis MAIL_* antigas ainda são aceitas para compatibilidade
 APP_BASE_URL=https://conecta-senai.up.railway.app

--- a/src/services/email_service.py
+++ b/src/services/email_service.py
@@ -44,8 +44,12 @@ class EmailClient:
         self.client_secret = os.getenv("CLIENT_SECRET", "")
         self.use_tls = _env_bool("SMTP_USE_TLS", True)
         self.use_ssl = _env_bool("SMTP_USE_SSL", False)
-        self.timeout = int(os.getenv("SMTP_TIMEOUT", os.getenv("MAIL_TIMEOUT", "15")))
-        self.max_retries = 3
+        self.timeout = int(
+            os.getenv("SMTP_TIMEOUT", os.getenv("MAIL_TIMEOUT", "5"))
+        )
+        self.max_retries = int(
+            os.getenv("SMTP_MAX_RETRIES", os.getenv("MAIL_MAX_RETRIES", "1"))
+        )
 
     def _get_oauth2_token(self) -> str:
         authority = f"https://login.microsoftonline.com/{self.tenant_id}"

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -19,9 +19,11 @@ def email_env(monkeypatch):
     monkeypatch.setenv("CLIENT_ID", "cid")
     monkeypatch.setenv("TENANT_ID", "tid")
     monkeypatch.setenv("CLIENT_SECRET", "sec")
+    monkeypatch.setenv("EMAIL_PROVIDER", "OUTLOOK")
     monkeypatch.setenv("SMTP_USE_TLS", "true")
     monkeypatch.setenv("SMTP_USE_SSL", "false")
     monkeypatch.setenv("SMTP_TIMEOUT", "15")
+    monkeypatch.setenv("SMTP_MAX_RETRIES", "3")
     monkeypatch.setattr(
         "src.services.email_service.EmailClient._get_oauth2_token",
         lambda self: "token",


### PR DESCRIPTION
## Summary
- make SMTP timeout and retry count configurable with short defaults
- document new email settings in `.env.example`
- adjust email tests for configurable retries and Outlook provider

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf8b7e9ab083238a117fe9b88df80c