### PR TITLE
feat: add login error feedback

### DIFF
--- a/src/blueprints/auth.py
+++ b/src/blueprints/auth.py
@@ -1,5 +1,15 @@
-from flask import Blueprint, render_template, make_response, current_app
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    make_response,
+    render_template,
+    request,
+)
 from flask_wtf.csrf import generate_csrf
+
+from src.models import db
+from src.models.user import User
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -11,5 +21,28 @@ def register_page():
     secure_cookie = current_app.config.get("COOKIE_SECURE", False)
     samesite = current_app.config.get("COOKIE_SAMESITE", "Lax")
     resp = make_response(render_template("admin/register.html", csrf_token=token))
+    resp.set_cookie("csrf_token", token, secure=secure_cookie, samesite=samesite)
+    return resp
+
+
+@auth_bp.route("/login", methods=["GET", "POST"])
+def login_page():
+    """Renderiza a página de login e exibe mensagem em caso de falha."""
+    token = generate_csrf()
+    secure_cookie = current_app.config.get("COOKIE_SECURE", False)
+    samesite = current_app.config.get("COOKIE_SAMESITE", "Lax")
+
+    if request.method == "POST":
+        email = request.form.get("email", "").strip()
+        senha = request.form.get("senha", "")
+
+        usuario = db.session.execute(
+            db.select(User).filter_by(email=email)
+        ).scalar_one_or_none()
+
+        if not usuario or not usuario.check_senha(senha):
+            flash("Usuário ou senha inválidos", "error")
+
+    resp = make_response(render_template("admin/login.html", csrf_token=token))
     resp.set_cookie("csrf_token", token, secure=secure_cookie, samesite=samesite)
     return resp

--- a/src/static/admin/login.html
+++ b/src/static/admin/login.html
@@ -27,9 +27,18 @@
                     </div>
                     <h1 class="h3 mb-3 fw-normal">Acesse sua conta</h1>
                     <p class="text-muted mb-4">Bem-vindo de volta! Por favor, insira as suas credenciais.</p>
-                    
-                    
-                    <form id="loginForm">
+
+                    {% with messages = get_flashed_messages(with_categories=true) %}
+                      {% if messages %}
+                        {% for category, message in messages %}
+                          <div class="alert alert-danger" role="alert">
+                            {{ message }}
+                          </div>
+                        {% endfor %}
+                      {% endif %}
+                    {% endwith %}
+
+                    <form id="loginForm" method="POST">
                         <div class="form-floating mb-3">
                             <input type="email" class="form-control" id="email" name="email" placeholder="seu@email.com" required aria-required="true" aria-describedby="email-help email-error">
                             <label for="email"><i class="bi bi-envelope me-2"></i>Email</label>


### PR DESCRIPTION
## Summary
- show error flash on failed login attempts
- display flash messages on login form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c208659a208323a0da2f0044ba05a8