### PR TITLE
Padroniza notificações de remanejamento de turma

### DIFF
--- a/src/templates/email/instrutor_removido.html.j2
+++ b/src/templates/email/instrutor_removido.html.j2
@@ -2,7 +2,21 @@
 <html>
   <body style="font-family:Arial,Helvetica,sans-serif;">
     <p>Olá {{ instrutor_nome }},</p>
-    <p>Você não ministrará mais a turma de <strong>{{ treinamento_nome }}</strong> agendada para {{ data_inicio }}.</p>
+    <p>Seu treinamento foi remanejado para outro instrutor.</p>
+    <p>Você não ministrará o treinamento abaixo:</p>
+    <ul>
+      <li><strong>Treinamento:</strong> {{ turma.treinamento.nome }}</li>
+      <li><strong>Matriz do treinamento:</strong> {{ turma.treinamento.codigo }}</li>
+      <li><strong>Data(s):</strong> {{ turma.data_inicio.strftime('%d/%m/%Y') }}{% if turma.data_termino and turma.data_termino != turma.data_inicio %} a {{ turma.data_termino.strftime('%d/%m/%Y') }}{% endif %}</li>
+      <li><strong>Horário:</strong> {{ turma.horario }}</li>
+      <li><strong>Carga horária:</strong> {{ turma.treinamento.carga_horaria }}</li>
+      <li><strong>Instrutor:</strong> {{ instrutor_nome }}</li>
+      <li><strong>Local de Realização:</strong> {{ turma.local }}</li>
+      <li><strong>Teoria Online?</strong> {% if turma.teoria_online %}Sim{% else %}Não{% endif %}</li>
+      {% if turma.treinamento.tem_pratica %}
+      <li><strong>Prática:</strong> {{ turma.local_pratica or turma.local }}</li>
+      {% endif %}
+    </ul>
     {% include 'email/_signature.html.j2' %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- padroniza aviso de remanejamento com detalhes completos da turma
- usa template padrão de nova turma ao designar novo instrutor

## Testing
- `pre-commit run --files src/services/email_service.py src/templates/email/instrutor_removido.html.j2`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4b393c3bc83238ae2de9c270034ff