### PR TITLE
Notify new instructor after class reassignment

### DIFF
--- a/src/routes/treinamentos/treinamento.py
+++ b/src/routes/treinamentos/treinamento.py
@@ -55,6 +55,7 @@ from src.services.email_service import (
     build_turma_context,
     listar_emails_secretaria,
     send_turma_alterada_email,
+    send_nova_turma_instrutor_email,
 )
 
 log = logging.getLogger(__name__)
@@ -577,6 +578,11 @@ def atualizar_turma_treinamento(turma_id):
     try:
         db.session.commit()
         db.session.refresh(turma)
+        if instrutor_antigo != turma.instrutor and turma.instrutor:
+            try:
+                send_nova_turma_instrutor_email(turma, turma.instrutor)
+            except Exception as exc:  # pragma: no cover - log apenas
+                log.error(f"Erro ao notificar novo instrutor: {exc}")
         periodo_novo = ""
         if turma.data_inicio and turma.data_fim:
             periodo_novo = (


### PR DESCRIPTION
## Summary
- add `send_nova_turma_instrutor_email` helper and use it in turma notifications
- trigger email notification to newly assigned instructor when updating a class

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c554ef4e308323bd35468d6708a6a6