### PR TITLE
Padroniza email de nova turma para secretaria

### DIFF
--- a/src/templates/email/nova_turma_secretaria.html.j2
+++ b/src/templates/email/nova_turma_secretaria.html.j2
@@ -1,44 +1,26 @@
 <!doctype html>
 <html>
-  <body style="font-family:Arial,Helvetica,sans-serif;">
-    <h3>Assunto: Novo Agendamento de Turma</h3>
-    <p>
-        Uma nova turma foi criada no sistema de Cursos e Treinamentos. Seguem os detalhes:
-    </p>
-    <table border="1" cellpadding="10" cellspacing="0" style="border-collapse: collapse; width: 100%;">
-        <tr>
-            <td style="background-color: #f2f2f2;"><strong>Treinamento:</strong></td>
-            <td>{{ turma.treinamento.nome }}</td>
-        </tr>
-        <tr>
-            <td style="background-color: #f2f2f2;"><strong>Turma:</strong></td>
-            <td>{{ turma.nome }}</td>
-        </tr>
-        <tr>
-            <td style="background-color: #f2f2f2;"><strong>Instrutor(a):</strong></td>
-            <td>{{ turma.instrutor.nome if turma.instrutor else 'A definir' }}</td>
-        </tr>
-        <tr>
-            <td style="background-color: #f2f2f2;"><strong>Período:</strong></td>
-            <td>De {{ turma.data_inicio.strftime('%d/%m/%Y') }} a {{ turma.data_termino.strftime('%d/%m/%Y') }}</td>
-        </tr>
-        <tr>
-            <td style="background-color: #f2f2f2;"><strong>Horário:</strong></td>
-            <td>Das {{ turma.horario_inicio.strftime('%H:%M') }} às {{ turma.horario_fim.strftime('%H:%M') }}</td>
-        </tr>
-        <tr>
-            <td style="background-color: #f2f2f2;"><strong>Local:</strong></td>
-            <td>{{ turma.local }}</td>
-        </tr>
-        <tr>
-            <td style="background-color: #f2f2f2;"><strong>Nº de Vagas:</strong></td>
-            <td>{{ turma.capacidade_maxima }}</td>
-        </tr>
-    </table>
-    <p>
-        Para mais detalhes, acesse o portal.
-    </p>
+  <body style="font-family:Arial,Helvetica,sans-serif;" data-email-subject="Nova turma cadastrada - {{ turma.treinamento.nome }}">
+    <p>Olá,</p>
+
+    <p>Uma nova turma de treinamento <strong>{{ turma.treinamento.nome }}</strong> foi criada, com data de {{ turma.data_inicio.strftime('%d/%m/%Y') }} a {{ turma.data_termino.strftime('%d/%m/%Y') }}.</p>
+
+    <p>Segue detalhes do treinamento:</p>
+
+    <ul>
+      <li><strong>Treinamento:</strong> {{ turma.treinamento.nome }}</li>
+      <li><strong>Matriz do treinamento:</strong> {{ turma.treinamento.codigo }}</li>
+      <li><strong>Data(s):</strong> De {{ turma.data_inicio.strftime('%d/%m/%Y') }} a {{ turma.data_termino.strftime('%d/%m/%Y') }}</li>
+      <li><strong>Horário:</strong> Das {{ turma.horario_inicio.strftime('%H:%M') }} às {{ turma.horario_fim.strftime('%H:%M') }}</li>
+      <li><strong>Carga horária:</strong> {{ turma.treinamento.carga_horaria }} horas</li>
+      <li><strong>Instrutor:</strong> {{ turma.instrutor.nome if turma.instrutor else 'A definir' }}</li>
+      <li><strong>Local de Realização:</strong> {{ turma.local }}</li>
+      <li><strong>Teoria Online?</strong> {% if turma.teoria_online %}Sim{% else %}Não{% endif %}</li>
+      {% if turma.treinamento.tem_pratica %}
+      <li><strong>Prática:</strong> {{ turma.local_pratica }}</li>
+      {% endif %}
+    </ul>
+
     {% include 'email/_signature.html.j2' %}
   </body>
 </html>
-


### PR DESCRIPTION
## Summary
- atualiza o template de nova turma para a secretaria com o novo texto e lista padronizada de informações
- inclui o assunto padronizado no atributo `data-email-subject`

## Testing
- not run (template change)


------
https://chatgpt.com/codex/tasks/task_e_68c8433bc7f083239162c010414a24c2