### PR TITLE
Reordena menu de treinamentos para administradores

### DIFF
--- a/src/static/treinamentos/admin-catalogo.html
+++ b/src/static/treinamentos/admin-catalogo.html
@@ -28,12 +28,6 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link active" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -41,6 +35,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link active" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/admin-historico-passado.html
+++ b/src/static/treinamentos/admin-historico-passado.html
@@ -28,12 +28,6 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -41,6 +35,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link active" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/admin-historico-turmas.html
+++ b/src/static/treinamentos/admin-historico-turmas.html
@@ -28,12 +28,6 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -41,6 +35,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/admin-inscricoes.html
+++ b/src/static/treinamentos/admin-inscricoes.html
@@ -29,9 +29,6 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link active" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -39,6 +36,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/admin-logs.html
+++ b/src/static/treinamentos/admin-logs.html
@@ -28,9 +28,6 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -38,6 +35,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -28,12 +28,6 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link active" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -41,6 +35,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/basedados.html
+++ b/src/static/treinamentos/basedados.html
@@ -28,12 +28,6 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link active" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -41,6 +35,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link active" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/index.html
+++ b/src/static/treinamentos/index.html
@@ -28,12 +28,6 @@
                         <a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -41,6 +35,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                 </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/meus-cursos.html
+++ b/src/static/treinamentos/meus-cursos.html
@@ -28,12 +28,6 @@
                         <a class="nav-link active" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a>
                     </li>
                     <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
-                    </li>
-                    <li class="nav-item admin-only">
-                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
-                    </li>
-                    <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a>
                     </li>
                     <li class="nav-item admin-only">
@@ -41,6 +35,12 @@
                     </li>
                     <li class="nav-item admin-only">
                         <a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a>
+                    </li>
+                    <li class="nav-item admin-only">
+                        <a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a>
                     </li>
                     </ul>
                 <ul class="navbar-nav">

--- a/src/static/treinamentos/perfil.html
+++ b/src/static/treinamentos/perfil.html
@@ -23,11 +23,11 @@
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item"><a class="nav-link" href="/treinamentos/index.html"><i class="bi bi-card-list me-1"></i> Cursos Disponíveis</a></li>
                     <li class="nav-item"><a class="nav-link" href="/treinamentos/meus-cursos.html"><i class="bi bi-person-video3 me-1"></i> Meus Cursos</a></li>
-                    <li class="nav-item admin-only"><a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a></li>
-                    <li class="nav-item admin-only"><a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a></li>
                     <li class="nav-item admin-only"><a class="nav-link" href="/treinamentos/admin-turmas.html"><i class="bi bi-people-fill me-1"></i> Turmas Futuras</a></li>
                     <li class="nav-item admin-only"><a class="nav-link" href="/treinamentos/admin-historico-turmas.html"><i class="bi bi-play-circle-fill me-1"></i> Turmas em Andamento</a></li>
                     <li class="nav-item admin-only"><a class="nav-link" href="/treinamentos/admin-historico-passado.html"><i class="bi bi-archive-fill me-1"></i> Turmas Encerradas</a></li>
+                    <li class="nav-item admin-only"><a class="nav-link" href="/treinamentos/admin-catalogo.html"><i class="bi bi-collection-fill me-1"></i> Catálogo</a></li>
+                    <li class="nav-item admin-only"><a class="nav-link" href="/treinamentos/basedados.html"><i class="bi bi-database me-1"></i> Base de Dados</a></li>
                 </ul>
                 <ul class="navbar-nav">
                     <li class="nav-item dropdown">


### PR DESCRIPTION
## Resumo
- reordena os itens do menu superior das páginas de treinamentos para atender à nova sequência solicitada
- mantém o item correto destacado como ativo em cada página, inclusive nas telas administrativas

## Testes
- sem testes automatizados executados (alterações somente em HTML estático)


------
https://chatgpt.com/codex/tasks/task_e_68c856be341483238898d30c82e84ce3