### PR TITLE
Carregar locais de realização dinamicamente no modal de turmas

### DIFF
--- a/src/static/js/treinamentos/admin.js
+++ b/src/static/js/treinamentos/admin.js
@@ -3,6 +3,7 @@
 // Armazena a lista de treinamentos e instrutores para não ter que recarregar
 let catalogoDeTreinamentos = [];
 let listaDeInstrutores = [];
+let listaDeLocaisRealizacao = [];
 let turmaParaExcluirId = null;
 let turmaParaConvocarId = null;
 let confirmacaoModal;
@@ -255,6 +256,17 @@ async function carregarInstrutores() {
     }
 }
 
+// Carrega locais de realização para o select
+async function carregarLocaisRealizacao() {
+    if (listaDeLocaisRealizacao.length > 0) return; // Evita recarregar
+    try {
+        listaDeLocaisRealizacao = await chamarAPI('/treinamentos/locais-realizacao');
+    } catch(e) {
+        console.error("Falha ao carregar locais de realização", e);
+        showToast('Não foi possível carregar os locais de realização.', 'danger');
+    }
+}
+
 /**
  * Função centralizada para abrir o modal de turma, seja para criar ou editar.
  * @param {number|null} id - O ID da turma para editar, ou null para criar uma nova.
@@ -283,6 +295,16 @@ async function abrirModalTurma(id = null) {
     }
     listaDeInstrutores.forEach(i => {
         selectInstrutor.innerHTML += `<option value="${i.id}">${escapeHTML(i.nome)}</option>`;
+    });
+
+    // Popula o select de locais de realização
+    const selectLocal = document.getElementById('localRealizacao');
+    selectLocal.innerHTML = '<option value="">Selecione...</option>';
+    if (listaDeLocaisRealizacao.length === 0) {
+        await carregarLocaisRealizacao();
+    }
+    listaDeLocaisRealizacao.forEach(local => {
+        selectLocal.innerHTML += `<option value="${escapeHTML(local.nome)}">${escapeHTML(local.nome)}</option>`;
     });
 
     // Se for edição, busca os dados da turma

--- a/src/static/treinamentos/admin-turmas.html
+++ b/src/static/treinamentos/admin-turmas.html
@@ -134,8 +134,6 @@
                             <label class="form-label">Local de Realização</label>
                             <select class="form-select" id="localRealizacao">
                                 <option value="">Selecione...</option>
-                                <option value="Centro de Treinamento Anglo American">Centro de Treinamento Anglo American</option>
-                                <option value="SENAI Conceição do Mato Dentro">SENAI Conceição do Mato Dentro</option>
                             </select>
                         </div>
                         <div class="mb-3">


### PR DESCRIPTION
## Summary
- adiciona cache local e função para buscar locais de realização via API
- popula o campo de seleção de locais no modal de turmas usando os dados carregados
- remove opções estáticas de locais do HTML para evitar duplicidade

## Testing
- not run (motivo: alterações em arquivos estáticos)

------
https://chatgpt.com/codex/tasks/task_e_68c96dc575b08323b295609766271400