### PR TITLE
Add reusable client-side validation and input masks

### DIFF
--- a/src/static/inscricao_treinamento.html
+++ b/src/static/inscricao_treinamento.html
@@ -28,54 +28,79 @@
 
   <main class="container my-4">
     <h1 class="h3 mb-3">Inscrição em Treinamento</h1>
-    <form id="formInscricao" class="row g-3 needs-validation" novalidate>
-      <div class="col-md-3">
-        <label class="form-label">Matrícula</label>
-        <input id="matricula" class="form-control" required>
-      </div>
-
-      <div class="col-md-6">
-        <label class="form-label">Nome do treinamento</label>
-        <input id="nomeTreinamento" class="form-control" disabled>
+    <form id="formInscricao" class="row g-3 needs-validation" novalidate data-js-validate>
+      <div class="col-12">
+        <div class="alert alert-danger d-none" role="alert" aria-live="assertive" tabindex="-1" data-error-summary></div>
       </div>
 
       <div class="col-md-3">
-        <label class="form-label">Tipo de Treinamento</label>
-        <input id="tipoTreinamento" class="form-control" required>
+        <label class="form-label" for="matricula">Matrícula</label>
+        <input id="matricula" name="matricula" class="form-control" required data-error-target="matricula-error" aria-describedby="matricula-error" data-required-message="Informe a matrícula.">
+        <div id="matricula-error" class="invalid-feedback">Informe a matrícula.</div>
       </div>
 
       <div class="col-md-6">
-        <label class="form-label">Nome Completo</label>
-        <input id="nomeCompleto" class="form-control" required>
-      </div>
-
-      <div class="col-md-6">
-        <label class="form-label">Naturalidade (Cidade de Nascimento)</label>
-        <input id="naturalidade" class="form-control" required>
-      </div>
-
-      <div class="col-md-6">
-        <label class="form-label">E-mail Individual</label>
-        <input id="email" type="email" class="form-control" required>
+        <label class="form-label" for="nomeTreinamento">Nome do treinamento</label>
+        <input id="nomeTreinamento" name="nomeTreinamento" class="form-control" disabled>
       </div>
 
       <div class="col-md-3">
-        <label class="form-label">Data de Nascimento</label>
-        <input id="dataNascimento" type="date" class="form-control" required>
-      </div>
-
-      <div class="col-md-3">
-        <label class="form-label">CPF</label>
-        <input id="cpf" class="form-control" maxlength="14" required>
+        <label class="form-label" for="tipoTreinamento">Tipo de Treinamento</label>
+        <input id="tipoTreinamento" name="tipoTreinamento" class="form-control" required data-error-target="tipoTreinamento-error" aria-describedby="tipoTreinamento-error" data-required-message="Informe o tipo do treinamento.">
+        <div id="tipoTreinamento-error" class="invalid-feedback">Informe o tipo do treinamento.</div>
       </div>
 
       <div class="col-md-6">
-        <label class="form-label">Empresa</label>
-        <input id="empresa" class="form-control" required>
+        <label class="form-label" for="nomeCompleto">Nome Completo</label>
+        <input id="nomeCompleto" name="nomeCompleto" class="form-control" required data-error-target="nomeCompleto-error" aria-describedby="nomeCompleto-error" data-required-message="Informe o nome completo.">
+        <div id="nomeCompleto-error" class="invalid-feedback">Informe o nome completo.</div>
+      </div>
+
+      <div class="col-md-6">
+        <label class="form-label" for="naturalidade">Naturalidade (Cidade de Nascimento)</label>
+        <input id="naturalidade" name="naturalidade" class="form-control" required data-error-target="naturalidade-error" aria-describedby="naturalidade-error" data-required-message="Informe a naturalidade.">
+        <div id="naturalidade-error" class="invalid-feedback">Informe a naturalidade.</div>
+      </div>
+
+      <div class="col-md-6">
+        <label class="form-label" for="email">E-mail Individual</label>
+        <input id="email" name="email" type="email" class="form-control" required data-error-target="email-error" aria-describedby="email-error" data-required-message="Informe um endereço de e-mail." data-validate="email">
+        <div id="email-error" class="invalid-feedback">Informe um endereço de e-mail.</div>
+      </div>
+
+      <div class="col-md-6">
+        <label class="form-label" for="telefone">Telefone (com DDD)</label>
+        <input id="telefone" name="telefone" type="text" class="form-control" inputmode="tel" required data-mask="telefone" data-validate="telefone" data-error-target="telefone-error" aria-describedby="telefone-help telefone-error" data-required-message="Informe um telefone para contato.">
+        <div id="telefone-help" class="form-text">Use 10 ou 11 dígitos para telefone fixo ou celular.</div>
+        <div id="telefone-error" class="invalid-feedback">Informe um telefone válido com DDD.</div>
+      </div>
+
+      <div class="col-md-3">
+        <label class="form-label" for="dataNascimento">Data de Nascimento</label>
+        <input id="dataNascimento" name="dataNascimento" type="text" class="form-control" inputmode="numeric" required data-mask="date" data-validate="date" data-error-target="dataNascimento-error" aria-describedby="dataNascimento-error" data-required-message="Informe a data de nascimento.">
+        <div id="dataNascimento-error" class="invalid-feedback">Informe uma data válida no formato DD/MM/AAAA.</div>
+      </div>
+
+      <div class="col-md-3">
+        <label class="form-label" for="cpf">CPF</label>
+        <input id="cpf" name="cpf" class="form-control" inputmode="numeric" required maxlength="14" data-mask="cpf" data-validate="cpf" data-error-target="cpf-error" aria-describedby="cpf-error" data-required-message="Informe o CPF.">
+        <div id="cpf-error" class="invalid-feedback">Informe um CPF válido.</div>
+      </div>
+
+      <div class="col-md-6">
+        <label class="form-label" for="cnpjEmpresa">CNPJ da Empresa</label>
+        <input id="cnpjEmpresa" name="cnpjEmpresa" class="form-control" inputmode="numeric" data-mask="cnpj" data-validate="cnpj" data-error-target="cnpjEmpresa-error" aria-describedby="cnpjEmpresa-error">
+        <div id="cnpjEmpresa-error" class="invalid-feedback">Informe um CNPJ válido.</div>
+      </div>
+
+      <div class="col-md-6">
+        <label class="form-label" for="empresa">Empresa</label>
+        <input id="empresa" name="empresa" class="form-control" required data-error-target="empresa-error" aria-describedby="empresa-error" data-required-message="Informe o nome da empresa.">
+        <div id="empresa-error" class="invalid-feedback">Informe o nome da empresa.</div>
       </div>
 
       <div class="col-12 d-flex gap-2">
-        <button id="btnEnviar" type="button" class="btn btn-primary">
+        <button id="btnEnviar" type="submit" class="btn btn-primary">
           <span class="spinner-border spinner-border-sm d-none" role="status"></span>
           <span class="btn-text">Enviar</span>
         </button>
@@ -86,6 +111,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/js/app.js"></script>
+  <script src="/js/forms/validation.js"></script>
   <script src="/js/inscricao_treinamento.js"></script>
 </body>
 </html>

--- a/src/static/js/forms/validation.js
+++ b/src/static/js/forms/validation.js
@@ -1,0 +1,468 @@
+(function () {
+  'use strict';
+
+  const digitsOnly = (value) => (value || '').replace(/\D+/g, '');
+
+  const maskers = {
+    cpf(value) {
+      const digits = digitsOnly(value).slice(0, 11);
+      const parts = [];
+      if (digits.length > 0) {
+        parts.push(digits.slice(0, 3));
+      }
+      if (digits.length >= 4) {
+        parts.push(digits.slice(3, 6));
+      }
+      if (digits.length >= 7) {
+        parts.push(digits.slice(6, 9));
+      }
+      let masked = parts.filter(Boolean).join('.');
+      if (digits.length >= 10) {
+        masked += `${masked ? '-' : ''}${digits.slice(9, 11)}`;
+      }
+      return masked;
+    },
+    cnpj(value) {
+      const digits = digitsOnly(value).slice(0, 14);
+      let masked = '';
+      if (digits.length > 0) {
+        masked = digits.slice(0, 2);
+      }
+      if (digits.length >= 3) {
+        masked += `.${digits.slice(2, 5)}`;
+      }
+      if (digits.length >= 6) {
+        masked += `.${digits.slice(5, 8)}`;
+      }
+      if (digits.length >= 9) {
+        masked += `/${digits.slice(8, 12)}`;
+      }
+      if (digits.length >= 13) {
+        masked += `-${digits.slice(12, 14)}`;
+      }
+      return masked;
+    },
+    telefone(value) {
+      const digits = digitsOnly(value).slice(0, 11);
+      if (digits.length === 0) {
+        return '';
+      }
+      if (digits.length <= 2) {
+        return `(${digits}`;
+      }
+      if (digits.length <= 6) {
+        return `(${digits.slice(0, 2)}) ${digits.slice(2)}`;
+      }
+      if (digits.length <= 10) {
+        const prefix = digits.slice(2, digits.length - 4);
+        const suffix = digits.slice(digits.length - 4);
+        return `(${digits.slice(0, 2)}) ${prefix}-${suffix}`;
+      }
+      return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7, 11)}`;
+    },
+    date(value) {
+      const digits = digitsOnly(value).slice(0, 8);
+      let result = '';
+      if (digits.length >= 1) {
+        result = digits.slice(0, Math.min(2, digits.length));
+      }
+      if (digits.length >= 3) {
+        result += `/${digits.slice(2, Math.min(4, digits.length))}`;
+      }
+      if (digits.length >= 5) {
+        result += `/${digits.slice(4, 8)}`;
+      }
+      return result;
+    },
+  };
+
+  const isRepeatedSequence = (value) => (/^(\d)\1{10,13}$/.test(value));
+
+  const validators = {
+    cpf(value) {
+      const digits = digitsOnly(value);
+      if (digits.length !== 11 || isRepeatedSequence(digits)) {
+        return false;
+      }
+      let sum = 0;
+      for (let i = 0; i < 9; i += 1) {
+        sum += parseInt(digits[i], 10) * (10 - i);
+      }
+      let check = (sum * 10) % 11;
+      if (check === 10) check = 0;
+      if (check !== parseInt(digits[9], 10)) {
+        return false;
+      }
+      sum = 0;
+      for (let i = 0; i < 10; i += 1) {
+        sum += parseInt(digits[i], 10) * (11 - i);
+      }
+      check = (sum * 10) % 11;
+      if (check === 10) check = 0;
+      return check === parseInt(digits[10], 10);
+    },
+    cnpj(value) {
+      const digits = digitsOnly(value);
+      if (digits.length !== 14 || isRepeatedSequence(digits)) {
+        return false;
+      }
+      const calcDigit = (length) => {
+        let sum = 0;
+        let pos = length - 7;
+        for (let i = 0; i < length - 1; i += 1) {
+          sum += parseInt(digits[i], 10) * pos;
+          pos -= 1;
+          if (pos < 2) {
+            pos = 9;
+          }
+        }
+        const result = sum % 11;
+        return result < 2 ? 0 : 11 - result;
+      };
+      const digit1 = calcDigit(13);
+      const digit2 = calcDigit(14);
+      return digit1 === parseInt(digits[12], 10) && digit2 === parseInt(digits[13], 10);
+    },
+    telefone(value) {
+      const digits = digitsOnly(value);
+      if (digits.length < 10 || digits.length > 11) {
+        return false;
+      }
+      if (digits[0] === '0') {
+        return false;
+      }
+      return true;
+    },
+    date(value) {
+      if (!value) {
+        return false;
+      }
+      const match = value.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+      if (!match) {
+        return false;
+      }
+      const day = parseInt(match[1], 10);
+      const month = parseInt(match[2], 10);
+      const year = parseInt(match[3], 10);
+      if (month < 1 || month > 12 || day < 1 || day > 31) {
+        return false;
+      }
+      const dateObj = new Date(year, month - 1, day);
+      return dateObj.getFullYear() === year && dateObj.getMonth() === month - 1 && dateObj.getDate() === day;
+    },
+    email(value) {
+      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      return emailPattern.test(value);
+    },
+  };
+
+  const sanitizers = {
+    cpf: (value) => digitsOnly(value),
+    cnpj: (value) => digitsOnly(value),
+    telefone: (value) => digitsOnly(value),
+    date(value) {
+      const match = (value || '').match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+      if (!match) {
+        return '';
+      }
+      return `${match[3]}-${match[2]}-${match[1]}`;
+    },
+  };
+
+  const defaultMessages = {
+    required: 'Preencha este campo.',
+    cpf: 'Informe um CPF válido.',
+    cnpj: 'Informe um CNPJ válido.',
+    telefone: 'Informe um telefone válido (DD) 99999-9999.',
+    date: 'Informe uma data válida no formato DD/MM/AAAA.',
+    email: 'Informe um email válido.',
+  };
+
+  class FormValidator {
+    constructor(form) {
+      this.form = form;
+      this.summary = this.setupSummary();
+      this.fields = this.collectFields();
+      this.prepareErrorMessages();
+      this.attachFieldEvents();
+    }
+
+    collectFields() {
+      return Array.from(
+        this.form.querySelectorAll('[data-validate], [data-required], [required]')
+      ).filter((field) => !field.disabled && field.type !== 'hidden');
+    }
+
+    prepareErrorMessages() {
+      this.fields.forEach((field) => {
+        const errorId = field.dataset.errorTarget;
+        if (!errorId) {
+          return;
+        }
+        const errorElement = document.getElementById(errorId);
+        if (errorElement && !errorElement.dataset.defaultMessage) {
+          errorElement.dataset.defaultMessage = errorElement.textContent.trim();
+        }
+      });
+    }
+
+    setupSummary() {
+      let summary = this.form.querySelector('[data-error-summary]');
+      if (!summary) {
+        summary = document.createElement('div');
+        summary.className = 'alert alert-danger d-none';
+        summary.setAttribute('data-error-summary', '');
+        summary.setAttribute('role', 'alert');
+        summary.setAttribute('tabindex', '-1');
+        summary.setAttribute('aria-live', 'assertive');
+        this.form.prepend(summary);
+      }
+      return summary;
+    }
+
+    attachFieldEvents() {
+      this.fields.forEach((field) => {
+        const maskType = field.dataset.mask;
+        if (maskType && typeof maskers[maskType] === 'function') {
+          field.addEventListener('input', () => {
+            const currentPos = field.selectionStart;
+            field.value = maskers[maskType](field.value);
+            if (typeof field.setSelectionRange === 'function' && currentPos != null) {
+              field.setSelectionRange(field.value.length, field.value.length);
+            }
+          });
+          field.addEventListener('blur', () => {
+            field.value = maskers[maskType](field.value);
+          });
+          field.value = maskers[maskType](field.value);
+        }
+        field.addEventListener('blur', () => {
+          this.validateField(field);
+        });
+        field.addEventListener('input', () => {
+          if (field.classList.contains('is-invalid')) {
+            this.validateField(field, { silentSummary: true });
+          }
+        });
+      });
+    }
+
+    validateField(field, options = {}) {
+      const value = (field.value || '').trim();
+      const type = field.dataset.validate;
+      const isRequired = field.hasAttribute('required') || field.dataset.required === 'true';
+      let valid = true;
+      let message = '';
+
+      if (isRequired && !value) {
+        valid = false;
+        message = field.dataset.requiredMessage || defaultMessages.required;
+      } else if (value && type && typeof validators[type] === 'function') {
+        valid = validators[type](value);
+        if (!valid) {
+          message = field.dataset.errorMessage || defaultMessages[type] || defaultMessages.required;
+        }
+      }
+
+      this.setFieldState(field, valid, message);
+
+      if (!options.silentSummary) {
+        this.showSummaryForFields(this.collectCurrentErrors());
+      }
+
+      return { field, valid, message };
+    }
+
+    validate() {
+      const errors = [];
+      this.fields.forEach((field) => {
+        const result = this.validateField(field, { silentSummary: true });
+        if (!result.valid) {
+          errors.push(result);
+        }
+      });
+
+      if (errors.length === 0) {
+        this.clearSummary();
+        return true;
+      }
+
+      this.showSummaryForFields(errors);
+      if (errors[0] && typeof errors[0].field.focus === 'function') {
+        errors[0].field.focus();
+      }
+      return false;
+    }
+
+    showSummaryForFields(errors) {
+      if (!this.summary) {
+        return;
+      }
+      const uniqueErrors = [];
+      const seen = new Set();
+      errors.forEach(({ field, message }) => {
+        if (!field || !message) {
+          return;
+        }
+        if (seen.has(field)) {
+          return;
+        }
+        seen.add(field);
+        uniqueErrors.push({ field, message });
+      });
+
+      if (uniqueErrors.length === 0) {
+        this.clearSummary();
+        return;
+      }
+
+      this.summary.innerHTML = '';
+      const title = document.createElement('p');
+      title.className = 'mb-2 fw-semibold';
+      title.textContent = `Verifique ${uniqueErrors.length === 1 ? 'o erro' : 'os erros'} abaixo:`;
+      this.summary.appendChild(title);
+
+      const list = document.createElement('ul');
+      list.className = 'mb-0';
+      uniqueErrors.forEach(({ field, message }) => {
+        const item = document.createElement('li');
+        const label = this.getFieldLabel(field);
+        const link = document.createElement('a');
+        link.href = `#${field.id}`;
+        link.textContent = label ? `${label}: ${message}` : message;
+        link.addEventListener('click', (event) => {
+          event.preventDefault();
+          field.focus();
+        });
+        item.appendChild(link);
+        list.appendChild(item);
+      });
+      this.summary.appendChild(list);
+      this.summary.classList.remove('d-none');
+      this.summary.focus();
+    }
+
+    clearSummary() {
+      if (!this.summary) {
+        return;
+      }
+      this.summary.classList.add('d-none');
+      this.summary.innerHTML = '';
+    }
+
+    setFieldState(field, isValid, message) {
+      const errorId = field.dataset.errorTarget;
+      const errorElement = errorId ? document.getElementById(errorId) : null;
+      if (isValid) {
+        field.classList.remove('is-invalid');
+        field.removeAttribute('aria-invalid');
+        delete field.dataset.errorMessageCurrent;
+        if (errorElement && errorElement.dataset.defaultMessage !== undefined) {
+          errorElement.textContent = errorElement.dataset.defaultMessage;
+        }
+        return;
+      }
+      field.classList.add('is-invalid');
+      field.setAttribute('aria-invalid', 'true');
+      field.dataset.errorMessageCurrent = message;
+      if (errorElement) {
+        errorElement.textContent = message;
+      }
+    }
+
+    getFieldLabel(field) {
+      if (!field.id) {
+        return '';
+      }
+      const label = this.form.querySelector(`label[for="${field.id}"]`);
+      return label ? label.textContent.trim() : field.name || field.id;
+    }
+  }
+
+  FormValidator.prototype.collectCurrentErrors = function collectCurrentErrors() {
+    const errors = [];
+    this.fields.forEach((field) => {
+      if (field.classList.contains('is-invalid')) {
+        const message = field.dataset.errorMessageCurrent || '';
+        if (message) {
+          errors.push({ field, message });
+        }
+      }
+    });
+    return errors;
+  };
+
+  const registry = new Map();
+
+  function ensureValidator(form) {
+    if (!registry.has(form)) {
+      registry.set(form, new FormValidator(form));
+    }
+    return registry.get(form);
+  }
+
+  function sanitizeField(field) {
+    if (!field) {
+      return '';
+    }
+    const type = field.dataset.validate;
+    const rawValue = (field.value || '').trim();
+    if (type && typeof sanitizers[type] === 'function') {
+      return sanitizers[type](rawValue);
+    }
+    if (field.type === 'checkbox') {
+      return field.checked;
+    }
+    if (field.type === 'radio') {
+      if (field.checked) {
+        return rawValue;
+      }
+      return '';
+    }
+    return rawValue;
+  }
+
+  function sanitizeForm(form) {
+    const values = {};
+    Array.from(form.elements).forEach((field) => {
+      if (!field.name) {
+        return;
+      }
+      if (field.type === 'radio') {
+        if (!field.checked) {
+          return;
+        }
+        values[field.name] = sanitizeField(field);
+        return;
+      }
+      if (field.type === 'checkbox') {
+        values[field.name] = sanitizeField(field);
+        return;
+      }
+      values[field.name] = sanitizeField(field);
+    });
+    return values;
+  }
+
+  function init() {
+    const forms = document.querySelectorAll('[data-js-validate]');
+    forms.forEach((form) => {
+      ensureValidator(form);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  window.FormValidation = {
+    get(form) {
+      return ensureValidator(form);
+    },
+    validate(form) {
+      const validator = ensureValidator(form);
+      return validator.validate();
+    },
+    sanitizeField,
+    sanitizeForm,
+    maskers,
+  };
+})();

--- a/src/static/js/inscricao_treinamento.js
+++ b/src/static/js/inscricao_treinamento.js
@@ -3,37 +3,42 @@
   const treinamentoId = params.get('treinamentoId');
   const nomeQS = params.get('nome');
 
-  const $nomeTreinamento = document.getElementById('nomeTreinamento');
-  if (nomeQS) $nomeTreinamento.value = decodeURIComponent(nomeQS);
+  const form = document.getElementById('formInscricao');
+  const submitButton = document.getElementById('btnEnviar');
+  const nomeTreinamentoInput = document.getElementById('nomeTreinamento');
 
-  const $cpf = document.getElementById('cpf');
-  $cpf.addEventListener('input', (e) => {
-    let v = e.target.value.replace(/\D/g, '').slice(0, 11);
-    if (v.length > 3) v = v.slice(0,3) + '.' + v.slice(3);
-    if (v.length > 7) v = v.slice(0,7) + '.' + v.slice(7);
-    if (v.length > 11) v = v.slice(0,11) + '-' + v.slice(11);
-    e.target.value = v;
-  });
+  if (nomeQS) {
+    nomeTreinamentoInput.value = decodeURIComponent(nomeQS);
+  }
 
-  document.getElementById('btnEnviar').addEventListener('click', async () => {
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const validator = window.FormValidation?.get(form);
+    if (validator && !validator.validate()) {
+      return;
+    }
+
+    const dataNascimentoIso = window.FormValidation
+      ? window.FormValidation.sanitizeField(document.getElementById('dataNascimento'))
+      : document.getElementById('dataNascimento').value;
+
     const payload = {
       matricula: document.getElementById('matricula').value?.trim(),
       treinamento_id: treinamentoId,
-      nome_treinamento: $nomeTreinamento.value,
+      nome_treinamento: nomeTreinamentoInput.value,
       tipo_treinamento: document.getElementById('tipoTreinamento').value?.trim(),
       nome_completo: document.getElementById('nomeCompleto').value?.trim(),
       naturalidade: document.getElementById('naturalidade').value?.trim(),
       email: document.getElementById('email').value?.trim(),
-      data_nascimento: document.getElementById('dataNascimento').value,
-      cpf: document.getElementById('cpf').value?.trim(),
+      data_nascimento: dataNascimentoIso,
+      cpf: window.FormValidation
+        ? window.FormValidation.sanitizeField(document.getElementById('cpf'))
+        : document.getElementById('cpf').value?.trim(),
       empresa: document.getElementById('empresa').value?.trim(),
     };
 
-    for (const [k, v] of Object.entries(payload)) {
-      if (!v && k !== 'treinamento_id') { alert('Preencha todos os campos.'); return; }
-    }
-
-    await executarAcaoComFeedback(document.getElementById('btnEnviar'), async () => {
+    await executarAcaoComFeedback(submitButton, async () => {
       await chamarAPI('/api/inscricoes-treinamento', 'POST', payload);
       alert('Inscrição enviada com sucesso!');
       window.location.href = '/planejamento-treinamentos.html';

--- a/src/templates/admin/register.html
+++ b/src/templates/admin/register.html
@@ -31,30 +31,57 @@
                     <h1 class="h3 mb-3 fw-normal">Crie sua Conta</h1>
                     <p class="text-muted mb-4">Preencha os dados para se registrar no sistema.</p>
 
-                    <form id="form-registro" method="POST" action="/api/registrar">
+                    <form id="form-registro" method="POST" action="/api/registrar" novalidate data-js-validate>
+                        <div class="alert alert-danger d-none mb-4" role="alert" aria-live="assertive" tabindex="-1" data-error-summary></div>
+
                         <div class="form-floating mb-3">
-                            <input type="text" class="form-control" id="nome" name="nome" placeholder="Nome Completo" required aria-required="true" aria-describedby="nome-help nome-error">
+                            <input type="text" class="form-control" id="nome" name="nome" placeholder="Nome Completo" required aria-required="true" aria-describedby="nome-help nome-error" data-error-target="nome-error" data-required-message="Informe seu nome completo.">
                             <label for="nome"><i class="bi bi-person me-2"></i>Nome Completo</label>
                             <div id="nome-error" class="invalid-feedback">Por favor, informe seu nome completo.</div>
                         </div>
                         <div id="nome-help" class="form-text">Informe seu nome completo.</div>
 
                         <div class="form-floating mb-3">
-                            <input type="email" class="form-control" id="email" name="email" placeholder="seu@email.com" required aria-required="true" aria-describedby="email-help email-error">
+                            <input type="email" class="form-control" id="email" name="email" placeholder="seu@email.com" required aria-required="true" aria-describedby="email-help email-error" data-error-target="email-error" data-required-message="Informe um email válido." data-validate="email">
                             <label for="email"><i class="bi bi-envelope me-2"></i>Email</label>
                             <div id="email-error" class="invalid-feedback">Por favor, informe um email válido.</div>
                         </div>
                         <div id="email-help" class="form-text">Informe um endereço de email válido.</div>
 
                         <div class="form-floating mb-3">
-                            <input type="password" class="form-control" id="senha" name="senha" placeholder="Senha" required aria-required="true" aria-describedby="senha-help senha-error">
+                            <input type="text" class="form-control" id="telefone" name="telefone" placeholder="(31) 99999-9999" inputmode="tel" data-mask="telefone" data-validate="telefone" data-error-target="telefone-error" aria-describedby="telefone-help telefone-error">
+                            <label for="telefone"><i class="bi bi-telephone me-2"></i>Telefone (com DDD)</label>
+                            <div id="telefone-error" class="invalid-feedback">Informe um telefone válido com DDD.</div>
+                        </div>
+                        <div id="telefone-help" class="form-text">Opcional, mas facilita o contato da equipe.</div>
+
+                        <div class="form-floating mb-3">
+                            <input type="text" class="form-control" id="cpf" name="cpf" placeholder="000.000.000-00" inputmode="numeric" data-mask="cpf" data-validate="cpf" data-error-target="cpf-error" aria-describedby="cpf-error">
+                            <label for="cpf"><i class="bi bi-card-text me-2"></i>CPF</label>
+                            <div id="cpf-error" class="invalid-feedback">Informe um CPF válido.</div>
+                        </div>
+
+                        <div class="form-floating mb-3">
+                            <input type="text" class="form-control" id="dataNascimento" name="dataNascimento" placeholder="DD/MM/AAAA" inputmode="numeric" data-mask="date" data-validate="date" data-error-target="dataNascimento-error" aria-describedby="dataNascimento-error">
+                            <label for="dataNascimento"><i class="bi bi-calendar-date me-2"></i>Data de Nascimento</label>
+                            <div id="dataNascimento-error" class="invalid-feedback">Informe uma data válida no formato DD/MM/AAAA.</div>
+                        </div>
+
+                        <div class="form-floating mb-3">
+                            <input type="text" class="form-control" id="cnpj" name="cnpj" placeholder="00.000.000/0000-00" inputmode="numeric" data-mask="cnpj" data-validate="cnpj" data-error-target="cnpj-error" aria-describedby="cnpj-error">
+                            <label for="cnpj"><i class="bi bi-building me-2"></i>CNPJ da Empresa</label>
+                            <div id="cnpj-error" class="invalid-feedback">Informe um CNPJ válido.</div>
+                        </div>
+
+                        <div class="form-floating mb-3">
+                            <input type="password" class="form-control" id="senha" name="senha" placeholder="Senha" required aria-required="true" aria-describedby="senha-help senha-error" data-error-target="senha-error" data-required-message="Informe uma senha válida.">
                             <label for="senha"><i class="bi bi-lock me-2"></i>Senha</label>
                             <div id="senha-error" class="invalid-feedback">A senha não atende aos requisitos.</div>
                         </div>
                         <div id="senha-help" class="form-text text-danger">A senha deve ter pelo menos 8 caracteres, incluindo letra maiúscula, letra minúscula, número e caractere especial.</div>
 
                         <div class="form-floating mb-3">
-                            <input type="password" class="form-control" id="confirmarSenha" name="confirmarSenha" placeholder="Confirmar Senha" required aria-required="true" aria-describedby="confirmarSenha-help confirmarSenha-error">
+                            <input type="password" class="form-control" id="confirmarSenha" name="confirmarSenha" placeholder="Confirmar Senha" required aria-required="true" aria-describedby="confirmarSenha-help confirmarSenha-error" data-error-target="confirmarSenha-error" data-required-message="Confirme a senha informada.">
                             <label for="confirmarSenha"><i class="bi bi-lock-fill me-2"></i>Confirmar Senha</label>
                             <div id="confirmarSenha-error" class="invalid-feedback">As senhas não coincidem.</div>
                         </div>
@@ -85,6 +112,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/app.js"></script>
+    <script src="/js/forms/validation.js"></script>
 
     <script>
       document.addEventListener('DOMContentLoaded', function () {
@@ -93,6 +121,11 @@
 
         form.addEventListener('submit', function (event) {
           event.preventDefault();
+
+          const validator = window.FormValidation?.get(form);
+          if (validator && !validator.validate()) {
+            return;
+          }
 
           const dadosForm = {
             nome: document.getElementById('nome').value,


### PR DESCRIPTION
## Summary
- add a reusable validation helper that applies masks and inline error handling through data attributes
- enhance the treinamento registration form with masked CPF/CNPJ/telefone/data inputs and an accessible error summary
- update the admin registration form to consume the helper and surface optional masked contact fields

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sentry_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_68cd9fea5ee48323b341e1a67aaa9855